### PR TITLE
docs: Change 'loose' to 'lose' in tutorial

### DIFF
--- a/doc/python/tutorial/dynamic_and_static_nn.rst
+++ b/doc/python/tutorial/dynamic_and_static_nn.rst
@@ -251,5 +251,5 @@ First, we setup the solver and the data iterator for the training:
 
 Comparing the two processing times, we can observe that both schemes
 ("static" and "dynamic") takes the same executation time, i.e., although
-we created the computation graph dynamically, we did not loose
+we created the computation graph dynamically, we did not lose
 performance.


### PR DESCRIPTION
'loose' is often confused with 'lose' (but 'lose' is the correct word).

This is a minor fix to the documentation.