### PR TITLE
Changed `NULL` used as a null pointer to `nullptr`.

### DIFF
--- a/include/nbla/function/utils/base_pooling.hpp
+++ b/include/nbla/function/utils/base_pooling.hpp
@@ -70,7 +70,7 @@ public:
   }
 
   virtual ~BasePooling() {}
-  virtual shared_ptr<Function> copy() const { return NULL; }
+  virtual shared_ptr<Function> copy() const { return nullptr; }
   virtual vector<dtypes> in_types() { return vector<dtypes>{get_dtype<T>()}; }
   virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
   virtual int min_inputs() { return 1; }

--- a/src/nbla/logger.cpp
+++ b/src/nbla/logger.cpp
@@ -38,7 +38,7 @@ std::shared_ptr<spdlog::logger> get_logger(void) {
 #ifdef _WIN32
     TCHAR szPath[MAX_PATH];
 
-    if (SUCCEEDED(SHGetFolderPath(NULL, CSIDL_APPDATA | CSIDL_FLAG_CREATE, NULL,
+    if (SUCCEEDED(SHGetFolderPath(nullptr, CSIDL_APPDATA | CSIDL_FLAG_CREATE, nullptr,
                                   0, szPath))) {
       logpath = szPath;
       logpath += "\\NNabla";
@@ -49,13 +49,13 @@ std::shared_ptr<spdlog::logger> get_logger(void) {
     }
 #else
     const char *homedir = getenv("HOME");
-    if (homedir == NULL) {
+    if (homedir == nullptr) {
       struct passwd *pw = getpwuid(getuid());
-      if (pw != NULL) {
+      if (pw != nullptr) {
         homedir = pw->pw_dir;
       }
     }
-    if (homedir == NULL) {
+    if (homedir == nullptr) {
       logpath = "/tmp_";
       logpath += getuid();
     } else {


### PR DESCRIPTION
Almost all codes use `nullptr`, but these two codes don't.
If you don't have any special reasons to use `NULL`, I think it should be unified.


By the way, do you have any CIs to test codes for multiple platforms?  I don't have WindowsPC to build and test. I confirmed all tests(excepted for the tests reported #1) have passed only on MacOSX.