### PR TITLE
Remove duplicate documentation of dropout function.

### DIFF
--- a/doc/python/api/function.rst
+++ b/doc/python/api/function.rst
@@ -152,7 +152,6 @@ Array Manipulation
 Stochasticity
 -------------
 
-.. autofunction:: dropout
 .. autofunction:: rand
 .. autofunction:: randint
 .. autofunction:: randn


### PR DESCRIPTION
The dropout function was documented twice via inclusion from function.rst - this removes one occurrence.