### PR TITLE
Release GIL when casting NdArray

### DIFF
--- a/python/src/nnabla/_nd_array.pxd
+++ b/python/src/nnabla/_nd_array.pxd
@@ -52,7 +52,7 @@ cdef extern from "nbla/nd_array.hpp" namespace "nbla":
         void zero() except+
         void fill(double v) except+
         const CArray * get(dtypes dtype, const CContext & ctx) except+
-        CArray * cast(dtypes dtype, const CContext & ctx)except +
+        CArray * cast(dtypes dtype, const CContext & ctx) nogil except +
 
     ctypedef shared_ptr[CNdArray] NdArrayPtr
 


### PR DESCRIPTION
This improves the performance of data iterator with pre-fetch thread. A pre-fetch thread is going to be active when a cast occurs, i.e CPU-GPU synchronization occurs.