### PR TITLE
[python] Fix exec issue in parametric_function_api in Python2.7.6

### DIFF
--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from six import exec_
 import numpy as np
 
 import nnabla as nn
@@ -83,7 +84,7 @@ def {name}{signature}:
         """.format(**locals())
         execdict = dict(
             func=func, parameter_scope=nn.parameter_scope, scope_name=scope_name)
-        exec(code, execdict)
+        exec_(code, execdict)
         newfunc = execdict[name]
         newfunc.__doc__ = doc
         newfunc.__parametric_function_api_base__ = func


### PR DESCRIPTION
Use `six.exec_` which is Python2/3 compatible.