### PR TITLE
[c++][function] Support broadcasting scalar

### DIFF
--- a/python/test/function/test_broadcast.py
+++ b/python/test/function/test_broadcast.py
@@ -51,6 +51,13 @@ def test_broadcast_forward_backward(ndim, broadcast_dim, seed, fname, ctx, func_
     shape = rng.randint(2, 5, size=(ndim,))
     inshape = shape.copy()
     inshape[broadcast_dim] = 1
+    if np.prod(inshape) == 1:
+        # Performing 0-dim array test too.
+        inputs = [np.array(rng.randn())]
+        function_tester(rng, func, ref_func, inputs, [shape],
+                        ctx=ctx, backward=[True], func_name=func_name,
+                        atol_b=4e-3)
+
     inputs = [np.array(rng.randn(*inshape))]
     function_tester(rng, func, ref_func, inputs, [shape],
                     ctx=ctx, backward=[True], func_name=func_name,

--- a/src/nbla/function/broadcast.cpp
+++ b/src/nbla/function/broadcast.cpp
@@ -31,9 +31,11 @@ void Broadcast<T>::setup_impl(const Variables &inputs,
                               const Variables &outputs) {
   auto inshape = inputs[0]->shape();
   int ndim = inputs[0]->ndim();
-  NBLA_CHECK(shape_.size() == ndim, error_code::value,
-             "Number of dimension must match. Shape: %d != input: %d.",
-             shape_.size(), ndim);
+  if (ndim > 0) {
+    NBLA_CHECK(shape_.size() == ndim, error_code::value,
+               "Number of dimension must match. Shape: %d != input: %d.",
+               shape_.size(), ndim);
+  }
   // X Stride and Y shape.
   stride_x_.reshape({ndim}, true);
   shape_y_.reshape({ndim}, true);


### PR DESCRIPTION
F.broadcast didn't support 0-dim (scalar) `Variable`/`NdArray` input. This PR enables it.