### PR TITLE
[python] Fix slash delimiter problem in paramter_scope arg

### DIFF
--- a/python/test/test_parameter.py
+++ b/python/test/test_parameter.py
@@ -40,6 +40,24 @@ def test_get_parameter_or_create_need_grad():
     nn.clear_parameters()
 
 
+def test_parameter_scope_slash():
+    """Testing if parameter_scope('aaa/bbb') works.
+    """
+    import nnabla as nn
+    from nnabla.parameter import get_parameter_or_create
+    nn.clear_parameters()
+    with nn.parameter_scope('aaa/bbb'):
+        param = get_parameter_or_create('ccc', (2, 3, 4, 5))
+    ref = np.random.randn(*param.shape).astype(np.float32)
+    param.d = ref
+
+    with nn.parameter_scope('aaa'):
+        with nn.parameter_scope('bbb'):
+            param = get_parameter_or_create('ccc', (2, 3, 4, 5))
+    assert np.all(param.d == ref)
+    nn.clear_parameters()
+
+
 # Dummy parametric function for test_parameteric_function
 @PF.parametric_function_api("dummy")
 def dummy_parametric_function(shape, f=10, i=1, s="dummy"):


### PR DESCRIPTION
This PR fixes a bug occurred when the argument of parameter_scope contains
'/'. Now
```python
    with parameter_scope('aaa/bbb'):
        SOME CODE
```
is now interpreted as
```python
    with parameter_scope('aaa'):
        with parameter_scope('bbb'):
	    SOME CODE
```