### PR TITLE
[python] Fix unintended copy at backward()

### DIFF
--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -442,7 +442,7 @@ cdef class Variable:
             pass
         elif np.isscalar(grad):
             arr = NdArray(self.shape)
-            arr.data.fill(grad)
+            arr.fill(grad)
             p = ( < NdArray > arr).arr
         elif isinstance(grad, NdArray):
             p = ( < NdArray > grad).arr


### PR DESCRIPTION
Originally I intended that the fill operation invoked in SyncedArray if a scalar gradient was set at backward(). However, it called the fill operation as a Numpy array, which invoked CPU copy.