### PR TITLE
Add implementation of depthwise convolution.

### DIFF
--- a/doc/functions.rst
+++ b/doc/functions.rst
@@ -130,6 +130,73 @@ References:
      - :math:`(B + 1 + N)`-D array (:math:`M_1 \times ... \times M_B \times C' \times L'_1 \times ... \times L'_N`).
      - 
 
+DepthwiseConvolution
+^^^^^^^^^^^^^^^^^^^^
+
+N-D Depthwise Convolution with bias.
+
+References:
+
+    * `F. Chollet: Chollet, Francois. "Xception: Deep Learning with Depthwise Separable Convolutions.
+      <https://arxiv.org/abs/1610.02357>`_
+
+* Input(s)
+
+.. list-table::
+
+   * - Name
+     - Description
+     - Options
+   * - x
+     - :math:`(B + 1 + N)`-D array (:math:`M_1 \times ... \times M_B \times C \times L_1 \times ... \times L_N`).
+     -
+   * - weight
+     - :math:`(1 + N)`-D array (:math:`C \times K_1 \times ... \times K_N`).
+     - Parameter
+   * - bias
+     - Bias vector (:math:`C`).
+     - Optional Parameter
+
+* Argument(s)
+
+.. list-table::
+
+   * - Name
+     - Type
+     - Default
+     - Description
+   * - base_axis
+     - int64
+     - 1
+     - base axis :math:`B`.
+   * - pad
+     - Shape
+     - (0,) * (len(x.shape) - (base_axis+1))
+     - Padding sizes for dimensions.
+   * - stride
+     - Shape
+     - (1,) * (len(x.shape) - (base_axis+1))
+     - Stride sizes for dimensions.
+   * - dilation
+     - Shape
+     - (1,) * (len(x.shape) - (base_axis+1))
+     - Dilation sizes for dimensions.
+   * - multiplier
+     - int64
+     - 1
+     - Number of output feature maps per input feature map.
+
+* Output(s)
+
+.. list-table::
+
+   * - Name
+     - Description
+     - Options
+   * - y
+     - :math:`(B + 1 + N)`-D array (:math:`M_1 \times ... \times M_B \times C \times L'_1 \times ... \times L'_N`).
+     -
+
 Deconvolution
 ^^^^^^^^^^^^^
 

--- a/include/nbla/function/depthwise_convolution.hpp
+++ b/include/nbla/function/depthwise_convolution.hpp
@@ -1,0 +1,123 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** DepthwiseConvolution
+ */
+#ifndef __NBLA_FUNCTION_DEPTHWISECONVOLUTION_HPP__
+#define __NBLA_FUNCTION_DEPTHWISECONVOLUTION_HPP__
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+#include <memory>
+#include <string>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(DepthwiseConvolution, int, const vector<int> &,
+                              const vector<int> &, const vector<int> &, int);
+
+/** N-D Depthwise Convolution with bias.
+
+Inputs (\f$B\f$ is base_axis):
+- Input \f$(B + 1 + N)\f$-D array
+  (\f$M_1 \times ... \times M_B \times C \times L_1 \times ... \times L_N\f$).
+- Weight \f$(1 + N)\f$-D array
+  (\f$C \times K_1 \times ... \times K_N\f$).
+- (optional) Bias vector (\f$C\f$).
+
+Outputs:
+- \f$(B + 1 + N)\f$-D array
+  (\f$ M_1 \times ... \times M_B \times C \times L'_1 \times ... \times L'_N
+\f$).
+
+@tparam T Data type for computation.
+@param base_axis Base axis of Convolution operation. Dimensions up to base_axis
+is treated as sample dimension.
+@param pad Padding sizes for dimensions.
+@param stride Stride sizes for dimensions.
+@param dilation Dilation sizes for dimensions.
+@param multiplier Number of output feature maps per input feature map.
+
+@sa Reference:
+- F. Chollet: Chollet, Francois. "Xception: Deep Learning with Depthwise
+Separable Convolutions.
+<https://arxiv.org/abs/1610.02357>
+
+ */
+template <typename T>
+class DepthwiseConvolution
+    : public BaseFunction<int, const vector<int> &, const vector<int> &,
+                          const vector<int> &, int> {
+protected:
+  int base_axis_;
+  const vector<int> pad_;
+  const vector<int> stride_;
+  const vector<int> dilation_;
+  vector<int> kernel_;
+  int multiplier_;
+  int channels_i_;
+  vector<int> spatial_shape_i_;
+  vector<int> spatial_shape_o_;
+  int spatial_dims_;
+  int outer_size_;
+  int inner_size_i_;
+  int inner_size_o_;
+  int inner_size_k_;
+  Variable col_;
+
+  // Variables for convolution by matrix multiplication
+  int col_w_;
+  int row_col_;
+  int col_col_;
+  int col_y_;
+
+public:
+  DepthwiseConvolution(const Context &ctx, int base_axis,
+                       const vector<int> &pad, const vector<int> &stride,
+                       const vector<int> &dilation, int multiplier)
+      : BaseFunction<int, const vector<int> &, const vector<int> &,
+                     const vector<int> &, int>(ctx, base_axis, pad, stride,
+                                               dilation, multiplier),
+        base_axis_(base_axis), pad_(pad), stride_(stride), dilation_(dilation),
+        multiplier_(multiplier) {}
+  virtual ~DepthwiseConvolution() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_DepthwiseConvolution(ctx_, base_axis_, pad_, stride_,
+                                       dilation_, multiplier_);
+  }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual int min_inputs() { return 2; }
+  virtual int min_outputs() { return 1; }
+  virtual string name() { return "DepthwiseConvolution"; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -653,6 +653,52 @@ def inq_convolution(inp, outmaps, kernel,
     return F.inq_convolution(inp, w, i, b, base_axis, pad, stride, dilation, group, num_bits, inq_iterations, selection_algorithm, seed)
 
 
+@parametric_function_api("depthwise_conv")
+def depthwise_convolution(inp, kernel,
+                          pad=None, stride=None, dilation=None, multiplier=1,
+                          w_init=None, b_init=None,
+                          base_axis=1, fix_parameters=False, rng=None, with_bias=True):
+    """
+    N-D Deptwise Convolution with a bias term.
+
+    Reference:
+
+    - F. Chollet: Chollet, Francois. "Xception: Deep Learning with Depthwise Separable Convolutions. https://arxiv.org/abs/1610.02357
+
+    Args:
+        inp (~nnabla.Variable): N-D array.
+        kernel (:obj:`tuple` of :obj:`int`): Convolution kernel size. For example, to apply convolution on an image with a 3 (height) by 5 (width) two-dimensional kernel, specify (3,5).
+        pad (:obj:`tuple` of :obj:`int`): Padding sizes for dimensions.
+        stride (:obj:`tuple` of :obj:`int`): Stride sizes for dimensions.
+        dilation (:obj:`tuple` of :obj:`int`): Dilation sizes for dimensions.
+        multiplier (:obj:`int`): Number of output feature maps per input feature map.
+        w_init (~nnabla.initializer.BaseInitializer): Initializer for weight.
+        b_init (~nnabla.initializer.BaseInitializer): Initializer for bias.
+        base_axis (int): Dimensions up to `base_axis` are treated as the sample dimensions.
+        fix_parameters (bool): When set to `True`, the weights and biases will not be updated.
+        rng (numpy.random.RandomState): Random generator for Initializer.
+        with_bias (bool): Specify whether to include the bias term.
+
+    Returns:
+        :class:`~nnabla.Variable`: N-D array.
+
+    """
+    if w_init is None:
+        w_init = UniformInitializer(
+            calc_uniform_lim_glorot(inp.shape[base_axis], inp.shape[base_axis], tuple(kernel)), rng=rng)
+    if with_bias and b_init is None:
+        b_init = ConstantInitializer()
+    w = get_parameter_or_create(
+        "W", (inp.shape[base_axis],) + tuple(kernel),
+        w_init, not fix_parameters)
+    b = None
+    if with_bias:
+        b = get_parameter_or_create(
+            "b", (inp.shape[base_axis],), b_init, not fix_parameters)
+    return F.depthwise_convolution(inp, w, b, base_axis, pad, stride, dilation,
+                                   multiplier)
+
+
 @parametric_function_api("deconv")
 def deconvolution(inp, outmaps, kernel,
                   pad=None, stride=None, dilation=None, group=1,
@@ -705,9 +751,14 @@ def batch_normalization(inp, axes=[1], decay_rate=0.9, eps=1e-5,
         \\begin{array}{lcl}
         \\mu &=& \\frac{1}{M} \\sum x_i\\\\
         \\sigma^2 &=& \\frac{1}{M} \\left(\\sum x_i - \\mu\\right)^2\\\\
-        \\hat{x}_i &=& \\frac{x_i - \\mu}{\\sqrt{\\sigma^2 + \\epsilon}} \\\\
-        y_i &=& \\hat{x}_i \\gamma + \\beta.
-        \\end{array}
+        \\hat{
+          x
+        } _i &= & \\frac{x_i - \\mu} {
+          \\sqrt {\\sigma ^ 2 + \\epsilon }
+        }
+        \\\ y_i &= & \\hat { x }
+        _i \\gamma + \\beta.
+        \\end { array }
 
     where :math:`x_i, y_i` are the inputs.
     In testing, the mean and variance computed by moving average calculated during training are used.

--- a/python/test/function/refs.py
+++ b/python/test/function/refs.py
@@ -35,6 +35,27 @@ def get_pool_ignore_border_in_out_size(w, k, p, s):
     return i, o
 
 
+def convolution_1d(x, w, b, pad, stride, dilation, group, dtype=np.float32):
+    """
+    """
+    C, H = x.shape
+    K, Cg, M = w.shape
+
+    Ho = get_conv_out_size(H, M, pad[0], stride[0], dilation[0])
+    x_pad = np.zeros((C, H + pad[0] * 2), dtype=dtype)
+    x_pad[:, pad[0]:pad[0] + H] = x
+    y = np.zeros((K, Ho), dtype=dtype)
+    for k in range(K):
+        g = int(k // (K // group))
+        for ho in range(Ho):
+                hi = ho * stride[0] + np.arange(0, M) * dilation[0]
+                ci = np.arange(g * Cg, (g + 1) * Cg)
+                y[k, ho] = (w[k] * x_pad[np.ix_(ci, hi)]).sum()
+    if b is not None:
+        y += b[..., np.newaxis]
+    return y
+
+
 def convolution_2d(x, w, b, pad, stride, dilation, group, dtype=np.float32):
     """
     """

--- a/python/test/function/test_depthwise_convolution.py
+++ b/python/test/function/test_depthwise_convolution.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import division
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+import refs
+from nbla_test_utils import list_context
+
+ctxs = list_context('DepthwiseConvolution')
+
+
+def ref_depthwise_convolution(x, w, b, base_axis, pad, stride, dilation):
+    """ implement depthwise convolution by using normal convolution
+    with group = inmaps """
+    # insert second dimension to weights
+    w = np.expand_dims(w, axis=1)
+
+    y = []
+    for xx in x.reshape((-1,) + x.shape[base_axis:]):
+        if w.ndim == 3:
+            y += [refs.convolution_1d(xx, w, b, pad, stride,
+                                      dilation, xx.shape[0])[np.newaxis]]
+        elif w.ndim == 4:
+            y += [refs.convolution_2d(xx, w, b, pad, stride,
+                                      dilation, xx.shape[0])[np.newaxis]]
+    y = np.vstack(y)
+    return y.reshape(x.shape[:base_axis] + y.shape[1:])
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, kernel, pad, stride, dilation", [
+    ((2, 2, 10, 10), (3, 2), (3, 0), (1, 2), (2, 1)),
+    ((2, 4, 10, 10), (3, 2), (0, 0), (1, 1), (1, 1)),
+    ((2, 2, 10, 10), (3, 3), (3, 0), (1, 2), (2, 1)),
+])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_depthwise_convolution_2d_forward_backward(inshape, kernel, pad,
+                                                   stride, dilation, with_bias,
+                                                   seed, ctx, func_name):
+    from nbla_test_utils import function_tester
+    rng = np.random.RandomState(seed)
+    i = rng.randn(*inshape).astype(np.float32)
+    inmaps = inshape[1]
+    kshape = (inmaps,) + kernel
+    k = rng.randn(*kshape).astype(np.float32)
+    base_axis = len(inshape) - 3
+    b = None
+    if with_bias:
+        b = rng.randn(inmaps).astype(np.float32)
+    inputs = [i, k, b]
+    function_tester(rng, F.depthwise_convolution, ref_depthwise_convolution, inputs,
+                    func_args=[base_axis, pad, stride, dilation],
+                    atol_f=1e-4, atol_b=3e-3, dstep=1e-2,
+                    ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, kernel, pad, stride, dilation", [
+    ((2, 2, 10), (3,), (3,), (1,), (2,)),
+    ((2, 4, 10), (3,), (0,), (2,), (1,)),
+    ((2, 2, 10), (4,), (3,), (1,), (2,)),
+])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_depthwise_convolution_1d_forward_backward(inshape, kernel, pad,
+                                                   stride, dilation, with_bias,
+                                                   seed, ctx, func_name):
+    if ctx.backend == 'cpu|cuda':
+        from nbla_test_utils import function_tester
+        rng = np.random.RandomState(seed)
+        i = rng.randn(*inshape).astype(np.float32)
+        inmaps = inshape[1]
+        kshape = (inmaps,) + kernel
+        k = rng.randn(*kshape).astype(np.float32)
+        base_axis = len(inshape) - 2
+        b = None
+        if with_bias:
+            b = rng.randn(inmaps).astype(np.float32)
+        inputs = [i, k, b]
+        function_tester(rng, F.depthwise_convolution, ref_depthwise_convolution, inputs,
+                        func_args=[base_axis, pad, stride, dilation],
+                        atol_f=1e-4, atol_b=3e-3, dstep=1e-2,
+                        ctx=ctx, func_name=func_name)
+    else:
+        pytest.xfail("1D depthwise convolution currently only supported for CUDA.")

--- a/src/nbla/function/depthwise_convolution.cpp
+++ b/src/nbla/function/depthwise_convolution.cpp
@@ -1,0 +1,253 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/** DepthwiseConvolution
+ */
+
+#include <nbla/array.hpp>
+#include <nbla/function/depthwise_convolution.hpp>
+#include <nbla/utils/eigen.hpp>
+#include <nbla/utils/im2col.hpp>
+#include <nbla/variable.hpp>
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(DepthwiseConvolution,
+                              int,                 // base_axis
+                              const vector<int> &, // pad
+                              const vector<int> &, // stride
+                              const vector<int> &, // dilation
+                              int);                // multiplier
+
+template <typename T>
+void DepthwiseConvolution<T>::setup_impl(const Variables &inputs,
+                                         const Variables &outputs) {
+  Variable *const input = inputs[0];
+  Variable *const weights = inputs[1];
+  Variable *const bias = (inputs.size() == 3) ? inputs[2] : nullptr;
+  Variable *const output = outputs[0];
+
+  NBLA_CHECK(multiplier_ == 1, error_code::value,
+             "multiplier > 1 is yet to be implemented.");
+
+  // Shape check
+  NBLA_CHECK(base_axis_ < input->shape().size() - 1, error_code::unclassified,
+             "base_axis must be less than ndim - 1 of inputs[0]. "
+             "base_axis: %d >= ndim of inputs[0] - 1: %d.",
+             base_axis_, input->shape().size() - 1);
+
+  spatial_dims_ = input->shape().size() - base_axis_ - 1;
+  NBLA_CHECK(weights->shape().size() == 1 + spatial_dims_, error_code::value,
+             "Weights must be at least a 2D tensor.");
+
+  // Storing shape variables
+  channels_i_ = input->shape()[base_axis_];
+  inner_size_k_ = 1;
+
+  for (int i = 0; i < spatial_dims_; ++i) {
+    kernel_.push_back(weights->shape()[1 + i]);
+    inner_size_k_ *= kernel_[i];
+    spatial_shape_i_.push_back(input->shape()[base_axis_ + 1 + i]);
+    const int k = dilation_[i] * (kernel_[i] - 1) + 1;
+    const int o = (spatial_shape_i_[i] + 2 * pad_[i] - k) / stride_[i] + 1;
+    NBLA_CHECK(
+        o > 0, error_code::value,
+        "Invalid configuration of convolution at %d-th spatial dimension.  "
+        "{input:%d, kernel:%d, pad:%d, stride:%d, dilation:%d}.",
+        i, spatial_shape_i_[i], kernel_[i], pad_[i], stride_[i], dilation_[i]);
+    spatial_shape_o_.push_back(o);
+  }
+
+  // Reshaping output
+  Shape_t output_shape;
+  outer_size_ = 1;
+  for (int i = 0; i < base_axis_; ++i) { // Fill shapes up to base axis
+    output_shape.push_back(input->shape()[i]);
+    outer_size_ *= input->shape()[i];
+  }
+  output_shape.push_back(channels_i_); // #output channels = #input channels
+  inner_size_i_ = channels_i_;
+  inner_size_o_ = channels_i_;
+  for (int i = 0; i < spatial_dims_; ++i) {
+    output_shape.push_back(spatial_shape_o_[i]);
+    inner_size_i_ *= spatial_shape_i_[i];
+    inner_size_o_ *= spatial_shape_o_[i];
+  }
+  output->reshape(output_shape, true);
+
+  // Reshaping col buffer
+  // Actual memory is not allocated until it is used.
+  col_.reshape(
+      Shape_t{inner_size_k_ * channels_i_, inner_size_o_ / channels_i_}, true);
+
+  // Check for with bias
+  if (bias != nullptr) {
+    NBLA_CHECK(bias->shape().size() == 1, error_code::value,
+               "Bias(inputs[2]) must be a 1d tensor.");
+    NBLA_CHECK(bias->shape()[0] == channels_i_, error_code::value,
+               "Shape of bias(inputs[2]) and weights(inputs[1]) mismatch. "
+               "bias shape[0]: %d != weights shape[0]: %d.",
+               bias->shape()[0], channels_i_);
+  }
+
+  // Set variables for convolution by matrix multiplication
+  // In 2D case:
+  // K: in maps, H: in height, W: in width
+  // K': out maps, H': out height, W': out height
+  // M: kernel height, N: kernel width
+  col_w_ = inner_size_k_;                 // KMN
+  row_col_ = col_w_;                      // KMN
+  col_col_ = inner_size_o_ / channels_i_; // H'W'
+  col_y_ = col_col_;                      // H'W'
+}
+
+template <typename T>
+void DepthwiseConvolution<T>::forward_impl(const Variables &inputs,
+                                           const Variables &outputs) {
+  using namespace ::nbla::eigen;
+  // Getting variable pointers
+  const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
+  const T *w = inputs[1]->get_data_pointer<T>(this->ctx_);
+  T *col = col_.cast_data_and_get_pointer<T>(this->ctx_);
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_);
+  const T *b;
+  if (inputs.size() == 3) {
+    b = inputs[2]->get_data_pointer<T>(this->ctx_);
+  }
+  // Sample loop
+  for (int n = 0; n < outer_size_; ++n) {
+    // Im2col
+    if (spatial_dims_ == 2) {
+      im2col<T>(x + n * inner_size_i_, channels_i_, spatial_shape_i_.data(),
+                kernel_.data(), pad_.data(), stride_.data(), dilation_.data(),
+                col);
+    } else {
+      im2col_nd<T>(x + n * inner_size_i_, channels_i_, spatial_dims_,
+                   spatial_shape_i_.data(), kernel_.data(), pad_.data(),
+                   stride_.data(), dilation_.data(), col);
+    }
+    // Convolution by matrix multiplication
+    T *y_n = y + n * inner_size_o_;
+    for (int g = 0; g < channels_i_; ++g) {
+      MatrixMap<T> mcol(col + g * row_col_ * col_col_, row_col_, col_col_);
+      ConstRowVectorMap<T> mk(w + g * col_w_, col_w_);
+      RowVectorMap<T> my(y_n + g * col_y_, col_y_);
+      my = mk * mcol;
+    }
+    // Adding bias
+    if (inputs.size() == 3) {
+      MatrixMap<T> my(y_n, channels_i_, col_y_);
+      my.colwise() += ConstColVectorMap<T>(b, channels_i_);
+    }
+  }
+}
+
+template <typename T>
+void DepthwiseConvolution<T>::backward_impl(const Variables &inputs,
+                                            const Variables &outputs,
+                                            const vector<bool> &propagate_down,
+                                            const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1] ||
+        (inputs.size() == 3 && propagate_down[2]))) {
+    return;
+  }
+  using namespace ::nbla::eigen;
+  const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
+  const T *x;
+  const T *w;
+  T *dx, *dw, *db, *col;
+  std::unique_ptr<ColVectorMap<T>> mdb;
+  if (propagate_down[0] || propagate_down[1]) {
+    col = col_.cast_data_and_get_pointer<T>(this->ctx_);
+  }
+  if (propagate_down[0]) {
+    w = inputs[1]->get_data_pointer<T>(this->ctx_);
+    dx = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_);
+  }
+  if (propagate_down[1]) {
+    x = inputs[0]->get_data_pointer<T>(this->ctx_);
+    dw = inputs[1]->cast_grad_and_get_pointer<T>(this->ctx_);
+    if (!accum[1])
+      memset(dw, 0, sizeof(*dw) * inputs[1]->size());
+  }
+  if (inputs.size() == 3 && propagate_down[2]) {
+    db = inputs[2]->cast_grad_and_get_pointer<T>(this->ctx_);
+    mdb.reset(new ColVectorMap<T>(db, channels_i_));
+    if (!accum[2])
+      // mdb = 0; // Results in segfault
+      memset(db, 0, sizeof(*db) * inputs[2]->size());
+  }
+  // Sample loop
+  for (int n = 0; n < outer_size_; ++n) {
+    const T *dy_n = dy + n * inner_size_o_;
+    if (propagate_down[0]) {
+      // Backprop to image
+      T *dx_n = dx + n * inner_size_i_;
+      for (int g = 0; g < channels_i_; ++g) {
+        ConstRowVectorMap<T> mdy(dy_n + g * col_y_, col_y_);
+        ConstRowVectorMap<T> mw(w + g * col_w_, col_w_);
+        MatrixMap<T> mdx(col + g * row_col_ * col_col_, row_col_, col_col_);
+        mdx = mw.transpose() * mdy;
+      }
+      // col2im
+      if (spatial_dims_ == 2) {
+        if (!accum[0])
+          // Remove this by substituting at n=0
+          memset(dx_n, 0, sizeof(*dx_n) * inner_size_i_);
+        col2im(col, channels_i_, spatial_shape_i_.data(), kernel_.data(),
+               pad_.data(), stride_.data(), dilation_.data(), dx_n);
+      } else {
+        if (!accum[0])
+          memset(dx_n, 0, sizeof(*dx_n) * inner_size_i_);
+        col2im_nd(col, channels_i_, spatial_dims_, spatial_shape_i_.data(),
+                  kernel_.data(), pad_.data(), stride_.data(), dilation_.data(),
+                  dx_n);
+      }
+    }
+    if (propagate_down[1]) {
+      // Backprop to weights
+      // im2col
+      if (spatial_dims_ == 2) {
+        im2col<T>(x + n * inner_size_i_, channels_i_, spatial_shape_i_.data(),
+                  kernel_.data(), pad_.data(), stride_.data(), dilation_.data(),
+                  col);
+      } else {
+        im2col_nd<T>(x + n * inner_size_i_, channels_i_, spatial_dims_,
+                     spatial_shape_i_.data(), kernel_.data(), pad_.data(),
+                     stride_.data(), dilation_.data(), col);
+      }
+      // Weight convolution by matrix multiplication
+      for (int g = 0; g < channels_i_; ++g) {
+        ConstRowVectorMap<T> mdy(dy_n + g * col_y_, col_y_);
+        ConstMatrixMap<T> mcol(col + g * row_col_ * col_col_, row_col_,
+                               col_col_);
+        RowVectorMap<T> mdw(dw + g * col_w_, col_w_);
+        mdw += mdy * mcol.transpose();
+      }
+    }
+    if (inputs.size() == 3 && propagate_down[2]) {
+      // Backprop to bias
+      ConstMatrixMap<T> mdy(dy_n, channels_i_, col_y_);
+      *mdb += mdy.rowwise().sum();
+    }
+  }
+}
+
+// Template instanciation
+template class DepthwiseConvolution<float>;
+} // namespace nbla


### PR DESCRIPTION
This adds an implementation of the depthwise convolution. Note that it is currently restricted to the same number of output feature maps as there are input feature maps (the multiplier parameter must be 1). A future update will lift this restriction.