### PR TITLE
Add cross compile support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ include(${CMAKE_SOURCE_DIR}/build-tools/cmake/Utils.cmake)
 option(BUILD_CPP_LIB "Build C++ Library" ON)
 option(BUILD_CPP_TEST "Build testing" OFF)
 option(BUILD_CPP_UTILS "Build C++ API and utilities" OFF)
+option(BUILD_CPP_UTILS_LIB_ONLY "Build C++ utilitiy lib only" OFF)
 
 option(BUILD_PYTHON_PACKAGE "Build python package" ON)
 
@@ -143,7 +144,7 @@ if(BUILD_CPP_LIB)
       ${CMAKE_SOURCE_DIR}/third_party/cmdline-master)
   endif()
   
-  include_directories(${NBLA_INCLUDE_DIRS};${PROJECT_BINARY_DIR})
+  include_directories(${NBLA_CROSS_INCLUDE_DIRS};${NBLA_INCLUDE_DIRS};${PROJECT_BINARY_DIR})
   add_subdirectory(src/nbla)
   
   ###############################################################################
@@ -151,8 +152,10 @@ if(BUILD_CPP_LIB)
   ###############################################################################
   if(BUILD_CPP_UTILS)
     add_subdirectory(src/nbla_utils)
-    add_subdirectory(src/nbla_cli)
-    add_subdirectory(examples/cpp)
+    if(NOT (BUILD_CPP_UTILS_LIB_ONLY))
+      add_subdirectory(src/nbla_cli)
+      add_subdirectory(examples/cpp)
+    endif()
   endif()
     
   ###############################################################################

--- a/doc/cpp/installation_cross_compile.rst
+++ b/doc/cpp/installation_cross_compile.rst
@@ -1,0 +1,26 @@
+.. _cpp-lib-installation-cross-compile:
+
+Cross Compile
+=============
+
+.. contents::
+   :local:
+   :depth: 1
+
+Requirements
+------------
+
+Additional requirements to :ref:`cpp-lib-installation`
+
+* Cross compiler C/C++ toolchain
+* Cross compiled Protobuf, libArchive and zlib
+
+Build
+-----
+
+.. code-block:: shell
+
+    git clone https://github.com/sony/nnabla
+    mkdir -p nnabla/build && cd nnabla/build
+    cmake -DBUILD_PYTHON_PACKAGE=OFF -DBUILD_CPP_UTILS=ON -DBUILD_CPP_UTILS_LIB_ONLY=ON -DCMAKE_CXX_COMPILER=<path_to_g++> -DCMAKE_C_COMPILER=<path_to_gcc> -DLibArchive_LIBRARY=<path_to_libArchive> -DZLIB_LIBRARY=<path_to_zlib> -DPROTOBUF_LIBRARY=<path_to_libProtobuf> -DNBLA_CROSS_INCLUDE_DIRS=<path_to_libProtobuf_inc>;<path_to_libArchive_inc>;<path_to_zlib_inc> ..
+    make


### PR DESCRIPTION
- Add cross compile instructions
- Add BUILD_CPP_UTILS_LIB_ONLY to build libnnabla_utils.so without
  the need to build examples
- Add NBLA_CROSS_INCLUDE_DIRS to add custom include directories