### PR TITLE
Add all_reduce interface

### DIFF
--- a/include/nbla/communicator.hpp
+++ b/include/nbla/communicator.hpp
@@ -102,13 +102,32 @@ public:
   virtual void reduce(bool division = false);
 
   /** allreduce over parameters added.
-   This method is \b sync before and after iallreduce w.r.t. a host thread.
    Currently, \e iallreduce is applied to gradient regions.
 
   @param division Divide the reduced value.
   @param inplace Pack the arrays into one large array if flase.
    */
   virtual void allreduce(bool division = false, bool inplace = false);
+
+  /** all_reduce over parameters added.
+   Currently, \e iallreduce is applied to gradient regions.
+
+        @param ndarray_list Vector of NdArrayPtr
+  @param division Divide the reduced value.
+  @param inplace Pack the arrays into one large array if flase.
+   */
+  virtual void all_reduce(vector<NdArrayPtr> ndarray_list,
+                          bool division = false, bool inplace = false);
+
+  /** all_reduce over parameters added.
+Currently, \e iallreduce is applied to gradient regions.
+
+  @param data NdArrayPtr
+@param division Divide the reduced value.
+@param inplace Pack the arrays into one large array if flase.
+*/
+  virtual void all_reduce(NdArrayPtr ndarray, bool division = false,
+                          bool inplace = false);
 
   /** reducescatter.
    @param division Divide the reduced value.

--- a/include/nbla/communicator/data_parallel_communicator.hpp
+++ b/include/nbla/communicator/data_parallel_communicator.hpp
@@ -66,6 +66,10 @@ public:
 
   virtual void reduce(bool division = false);
   virtual void allreduce(bool division = false, bool inplace = false);
+  virtual void all_reduce(vector<NdArrayPtr> ndarray_list,
+                          bool division = false, bool inplace = false);
+  virtual void all_reduce(NdArrayPtr ndarray, bool division = false,
+                          bool inplace = false);
   virtual void reducescatter(bool division = false);
   virtual void bcast();
   virtual void allgather();

--- a/include/nbla/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/communicator/multi_process_data_parallel_communicator.hpp
@@ -67,6 +67,10 @@ public:
 
   virtual void reduce(bool division = false);
   virtual void allreduce(bool division = false, bool inplace = false);
+  virtual void all_reduce(vector<NdArrayPtr> ndarray_list,
+                          bool division = false, bool inplace = false);
+  virtual void all_reduce(NdArrayPtr ndarray, bool division = false,
+                          bool inplace = false);
   virtual void reducescatter(bool division = false);
   virtual void bcast();
   virtual void allgather();

--- a/python/src/nnabla/communicator.pxd
+++ b/python/src/nnabla/communicator.pxd
@@ -20,6 +20,7 @@ from libcpp.memory cimport shared_ptr
 from libcpp cimport bool as cpp_bool
 cimport _variable
 from _variable cimport CVariable, CContext, dtypes
+from _nd_array cimport CNdArray
 
 
 cdef extern from "nbla/communicator.hpp" namespace "nbla":
@@ -39,6 +40,8 @@ cdef extern from "nbla/communicator.hpp" namespace "nbla":
 
         void reduce(cpp_bool division) except +
         void allreduce(cpp_bool division, cpp_bool inplace) nogil except +
+        void all_reduce(vector[shared_ptr[CNdArray]] ndarray_list, cpp_bool division, cpp_bool inplace) nogil except +
+        void all_reduce(shared_ptr[CNdArray] data, cpp_bool division, cpp_bool inplace) nogil except +
         void reducescatter(cpp_bool division) nogil except +
         void bcast() nogil except +
         void allgather() nogil except +

--- a/python/test/communicator/test_all_reduce.py
+++ b/python/test/communicator/test_all_reduce.py
@@ -25,12 +25,11 @@ from nnabla.contrib.context import extension_context
 # otherwise, mpirun fails.
 ############################################
 
-# Contex
-extension_module = "cuda"
-ctx = extension_context(extension_module)
-
 # Communicator
-try: 
+comm = None
+try:
+    extension_module = "cuda"
+    ctx = extension_context(extension_module)
     comm = C.MultiProcessDataParalellCommunicator(ctx)
     comm.init()
     n_devices = comm.size
@@ -55,6 +54,7 @@ def ref_all_reduce(x_data_list, size, division):
     return results
 
 
+@pytest.mark.skipif(comm == None, reason="Communicator does not exist.")
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("division", [False])

--- a/python/test/communicator/test_all_reduce.py
+++ b/python/test/communicator/test_all_reduce.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import nnabla as nn
+import nnabla.parametric_functions as PF
+import nnabla.communicators as C
+import numpy as np
+from nbla_test_utils import list_context
+from nnabla.contrib.context import extension_context
+
+############################################
+# Communicator has to be instantiated here,
+# otherwise, mpirun fails.
+############################################
+
+# Contex
+extension_module = "cuda"
+ctx = extension_context(extension_module)
+
+# Communicator
+try: 
+    comm = C.MultiProcessDataParalellCommunicator(ctx)
+    comm.init()
+    n_devices = comm.size
+    mpi_rank = comm.rank
+    mpi_local_rank = comm.local_rank
+    device_id = mpi_local_rank
+    ctx.device_id = str(device_id)
+except: 
+    pass
+
+############################################
+
+
+def ref_all_reduce(x_data_list, size, division):
+    f = reduce(lambda x, y: x + y, np.arange(size)) + size
+    results = []
+    for x_data in x_data_list:
+        result = x_data * f
+        if division:
+            result /= size
+        results.append(result)
+    return results
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("division", [False])
+def test_all_reduce(seed, inplace, division):
+    try:
+        import nnabla_ext
+        import nnabla_ext.cuda
+    except:
+        pytest.skip("{} is supported in CUDA device".format(
+            sys._getframe().f_code.co_name))
+
+    n_devices = nnabla_ext.cuda.init.get_device_count()
+    if n_devices < 2:
+        pytest.skip("Number of cuda devices in this machine is less than 2.")
+
+    if n_devices != comm.size:
+        pytest.skip("Number of cuda devices is not same as that of processes.")
+
+    # Variables
+    x_list = []
+    x_data_list = []
+    num_layers = 20
+    rng = np.random.RandomState(seed)
+    for l in range(num_layers):
+        x_data = rng.rand(3, 4)
+        x_data_list.append(x_data)
+        x = nn.Variable(x_data.shape)
+        x.d = x_data * (device_id + 1)
+        x_list.append(x)
+
+    # AllReduce
+    comm.all_reduce([x.data for x in x_list],
+                    division=division, inplace=inplace)
+
+    # Ref AllReduce
+    refs = ref_all_reduce(x_data_list, n_devices, division)
+
+    # Check
+    for x, ref in zip(x_list, refs):
+        assert np.allclose(x.d, ref)

--- a/src/nbla/communicator.cpp
+++ b/src/nbla/communicator.cpp
@@ -96,6 +96,14 @@ void Communicator::allreduce(bool division, bool inplace) {
   NBLA_ERROR(error_code::not_implemented, "CPU allreduce is not implemented.")
 }
 
+void Communicator::all_reduce(vector<NdArrayPtr> ndarray_list, bool division, bool inplace) {
+  NBLA_ERROR(error_code::not_implemented, "CPU all_reduce is not implemented.")
+}
+
+void Communicator::all_reduce(NdArrayPtr ndarray, bool division, bool inplace) {
+  NBLA_ERROR(error_code::not_implemented, "CPU all_reduce is not implemented.")
+}
+
 void Communicator::reducescatter(bool division) {
   NBLA_ERROR(error_code::not_implemented,
              "CPU reducescatter is not implemented.")

--- a/src/nbla/communicator/data_parallel_communicator.cpp
+++ b/src/nbla/communicator/data_parallel_communicator.cpp
@@ -46,6 +46,18 @@ void DataParallelCommunicator<T>::allreduce(bool division, bool inplace) {
 }
 
 template <typename T>
+void DataParallelCommunicator<T>::all_reduce(vector<NdArrayPtr> ndarray_list,
+                                             bool division, bool inplace) {
+  NBLA_ERROR(error_code::not_implemented, "CPU all_reduce is not implemented.")
+}
+
+template <typename T>
+void DataParallelCommunicator<T>::all_reduce(NdArrayPtr ndarray, bool division,
+                                             bool inplace) {
+  NBLA_ERROR(error_code::not_implemented, "CPU all_reduce is not implemented.")
+}
+
+template <typename T>
 void DataParallelCommunicator<T>::reducescatter(bool division) {
   NBLA_ERROR(error_code::not_implemented,
              "CPU reducescatter is not implemented.")

--- a/src/nbla/communicator/multi_process_data_parallel_communicator.cpp
+++ b/src/nbla/communicator/multi_process_data_parallel_communicator.cpp
@@ -50,6 +50,19 @@ void MultiProcessDataParallelCommunicator<T>::allreduce(bool division,
 }
 
 template <typename T>
+void MultiProcessDataParallelCommunicator<T>::all_reduce(
+    vector<NdArrayPtr> ndarray_list, bool division, bool inplace) {
+  NBLA_ERROR(error_code::not_implemented, "CPU all_reduce is not implemented.")
+}
+
+template <typename T>
+void MultiProcessDataParallelCommunicator<T>::all_reduce(NdArrayPtr ndarray,
+                                                         bool division,
+                                                         bool inplace) {
+  NBLA_ERROR(error_code::not_implemented, "CPU all_reduce is not implemented.")
+}
+
+template <typename T>
 void MultiProcessDataParallelCommunicator<T>::reducescatter(bool division) {
   NBLA_ERROR(error_code::not_implemented,
              "CPU reducescatter is not implemented.")


### PR DESCRIPTION
We add `all_reduce(ndarray, ...)` interface. With this feature, one can do
- the distributed validation over multiple nodes
- the data parallel distributed training with dynamic neural network

For details, see [CIFAR-10 example](https://github.com/sony/nnabla-examples/blob/master/distributed/cifar10-100/multi_device_multi_process_classification.py)