### PR TITLE
Fix sink clearing buffers

### DIFF
--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -3364,6 +3364,11 @@ Unsupported, Special Use:
       and creates a single 0-shape outputs.
       The forward pass does nothing. The backward pass set ones
       to the input grads if one_input_grad is set as true.
+
+      Note:
+          ``sink`` can only be called at the very end of the graph, and
+          ``grad`` of input variables are cleared
+           when ``y.backward(clear_buffer=True)`` is called.
     inputs:
       x:
         doc: Any number of inputs with any shape.

--- a/include/nbla/function.hpp
+++ b/include/nbla/function.hpp
@@ -243,6 +243,11 @@ public:
         "This must be implemented for in-place support of this function.");
   }
 
+  /** A flag for preventing that the graph engine clears buffers of
+      input variables even if clear_buffer is true and condition mets.
+   */
+  virtual bool prohibit_clear_input_buffers() const { return false; }
+
   /** Copy another instance of Function with the same context.
   */
   virtual shared_ptr<Function> copy() const = 0;

--- a/include/nbla/function/function_impl.hpp.tmpl
+++ b/include/nbla/function/function_impl.hpp.tmpl
@@ -93,6 +93,10 @@ public:
   // }
   // virtual int inplace_grad_with(int i) const {
   // }
+  // TODO: If you want to avoid clearing input buffers in any case, define this function returning true.
+  // virtual bool prohibit_clear_input_buffers() const {
+  //   return true;
+  // }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs, const Variables &outputs);

--- a/include/nbla/function/sink.hpp
+++ b/include/nbla/function/sink.hpp
@@ -48,6 +48,9 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  // NOTE: This avoid clearing input buffers by the graph engine during
+  // execution.
+  virtual bool prohibit_clear_input_buffers() const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/python/test/function/test_sink.py
+++ b/python/test/function/test_sink.py
@@ -48,3 +48,19 @@ def test_sink(seed):
     assert np.all(h0d == h0.d)
     assert np.all(h1d == h1.d)
     assert np.all(vg == v.g)
+
+    # Check if clear_buffer still keeps h0 an h1 even though they are not
+    # leaf variables.
+    # It's done by defining prohibit_clear_input_buffers function in sink.hpp.
+    dummy = F.sink(h0, h1, one_input_grad=True)
+    dummy.forward(clear_buffer=True)
+    assert np.all(h0d == h0.d)
+    assert np.all(h1d == h1.d)
+    # Also checking backward when clear buffers.
+    v.grad.zero()
+    dummy = F.sink(h0, h1, one_input_grad=True)
+    dummy.forward(clear_no_need_grad=True)
+    dummy.backward(clear_buffer=True)
+    assert np.all(h0d == h0.d)
+    assert np.all(h1d == h1.d)
+    assert np.all(vg == v.g)


### PR DESCRIPTION
The problem was when we use sink function with y.forward(clear_buffer=True). It clears the buffers in input variables of the Sink function. It was not desired behavior when we want to get inputs of the Sink as outputs of the entire graph (we usually do!).

I solved this issue by adding a function Function::prohibit_clear_input_buffer(), and modifying the graph engine to avoid clearing buffers if it returns true.