### PR TITLE
Communicator with Half Precision

### DIFF
--- a/python/test/communicator/conftest.py
+++ b/python/test/communicator/conftest.py
@@ -20,6 +20,8 @@ def pytest_addoption(parser):
                      default=False, help='Enable NCCL communicator test.')
     parser.addoption('--communicator-gpus', type=str, default=None,
                      help='Comma separated device IDs. e.g --communicator-gpus=0,2.')
+    parser.addoption('--type-config', type=str, default='float', action='store',
+                     help='Type of computation. e.g. "float", "half"., --type-config=float')
 
 
 @pytest.fixture(scope='session')
@@ -55,7 +57,8 @@ def comm_nccl_opts(request):
                 "GPU IDs must be comma sperated integers of available GPUs. Given {}. Avaiable GPUs are {}.".format(gpus, n_devices))
 
     extension_module = "cuda"
-    ctx = get_extension_context(extension_module)
+    type_config = request.config.getoption('--type-config')
+    ctx = get_extension_context(extension_module, type_config=type_config)
     try:
         comm = C.MultiProcessDataParalellCommunicator(ctx)
     except Exception as e:

--- a/python/test/communicator/conftest.py
+++ b/python/test/communicator/conftest.py
@@ -43,7 +43,7 @@ def comm_nccl_opts(request):
     if gpus is None:
         devices = list(map(str, range(n_devices)))
     else:
-        devices = gpu.split(',')
+        devices = gpus.split(',')
         # Check numbers
         try:
             for d in devices:

--- a/python/test/communicator/test_all_gather.py
+++ b/python/test/communicator/test_all_gather.py
@@ -32,6 +32,10 @@ def test_all_gather(seed, comm_nccl_opts):
     if comm_nccl_opts is None:
         pytest.skip(
             "Communicator test is disabled. You can turn it on by an option `--test-communicator`.")
+    if len(comm_nccl_opts.devices) < 2:
+        pytest.skip(
+            "Communicator test is disabled. Use more than 1 gpus.")
+
     comm = comm_nccl_opts.comm
     device_id = int(comm_nccl_opts.device_id)
     n_devices = len(comm_nccl_opts.devices)
@@ -54,4 +58,4 @@ def test_all_gather(seed, comm_nccl_opts):
 
     # Check
     for y, ref in zip(y_list, refs):
-        assert np.allclose(y.d, ref)
+        assert np.allclose(y.d, ref, rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_all_reduce.py
+++ b/python/test/communicator/test_all_reduce.py
@@ -53,7 +53,7 @@ def test_all_reduce(seed, inplace, division, comm_nccl_opts):
     num_layers = 20
     rng = np.random.RandomState(seed)
     for l in range(num_layers):
-        x_data = np.clip(rng.rand(3, 4), -1e-5, 2.*1e3)
+        x_data = rng.rand(3, 4)
         x_data_list.append(x_data)
         x = nn.Variable(x_data.shape)
         x.d = x_data * (device_id + 1)

--- a/python/test/communicator/test_bcast.py
+++ b/python/test/communicator/test_bcast.py
@@ -34,6 +34,10 @@ def test_bcast(seed, src, inplace, comm_nccl_opts):
     if comm_nccl_opts is None:
         pytest.skip(
             "Communicator test is disabled. You can turn it on by an option `--test-communicator`.")
+    if len(comm_nccl_opts.devices) < 2:
+        pytest.skip(
+            "Communicator test is disabled. Use more than 1 gpus.")
+
     comm = comm_nccl_opts.comm
     device_id = int(comm_nccl_opts.device_id)
     n_devices = len(comm_nccl_opts.devices)
@@ -58,4 +62,4 @@ def test_bcast(seed, src, inplace, comm_nccl_opts):
 
     # Check
     for x, ref in zip(x_list, refs):
-        assert np.allclose(x.d, ref)
+        assert np.allclose(x.d, ref, rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_comm_reduce.py
+++ b/python/test/communicator/test_comm_reduce.py
@@ -42,6 +42,10 @@ def test_reduce(seed, dst, inplace, division, comm_nccl_opts):
     if comm_nccl_opts is None:
         pytest.skip(
             "Communicator test is disabled. You can turn it on by an option `--test-communicator`.")
+    if len(comm_nccl_opts.devices) < 2:
+        pytest.skip(
+            "Communicator test is disabled. Use more than 1 gpus.")
+
     comm = comm_nccl_opts.comm
     device_id = int(comm_nccl_opts.device_id)
     n_devices = len(comm_nccl_opts.devices)
@@ -69,4 +73,4 @@ def test_reduce(seed, dst, inplace, division, comm_nccl_opts):
 
         # Check
         for x, ref in zip(x_list, refs):
-            assert np.allclose(x.d, ref)
+            assert np.allclose(x.d, ref, rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_reduce_scatter.py
+++ b/python/test/communicator/test_reduce_scatter.py
@@ -39,6 +39,9 @@ def test_reduce_scatter(seed, division, comm_nccl_opts):
     if comm_nccl_opts is None:
         pytest.skip(
             "Communicator test is disabled. You can turn it on by an option `--test-communicator`.")
+    if len(comm_nccl_opts.devices) < 2:
+        pytest.skip(
+            "Communicator test is disabled. Use more than 1 gpus.")
     comm = comm_nccl_opts.comm
     device_id = int(comm_nccl_opts.device_id)
     devices = comm_nccl_opts.devices
@@ -64,4 +67,4 @@ def test_reduce_scatter(seed, division, comm_nccl_opts):
     refs = ref_reduce_scatter(x_data_list, n_devices, division)
 
     # Check
-    assert np.allclose(x.d, refs[device_id])
+    assert np.allclose(x.d, refs[device_id], rtol=1e-3, atol=1e-6)

--- a/src/nbla/communicator/data_parallel_communicator.cpp
+++ b/src/nbla/communicator/data_parallel_communicator.cpp
@@ -132,4 +132,6 @@ vector<string> DataParallelCommunicator<T>::allowed_array_classes() {
 }
 
 template class DataParallelCommunicator<float>;
+
+template class DataParallelCommunicator<Half>;
 }

--- a/src/nbla/communicator/multi_process_data_parallel_communicator.cpp
+++ b/src/nbla/communicator/multi_process_data_parallel_communicator.cpp
@@ -177,4 +177,6 @@ MultiProcessDataParallelCommunicator<T>::allowed_array_classes() {
 }
 
 template class MultiProcessDataParallelCommunicator<float>;
+
+template class MultiProcessDataParallelCommunicator<Half>;
 }


### PR DESCRIPTION
Now, the communicator can take data with the half precision in the same way to do a single GPU training with the half precision like

```python
ctx = get_extension_context("cudnn", type_config="half")
```

See the [multi_device_multi_process_classification.py](https://github.com/sony/nnabla-examples/blob/master/distributed/cifar10-100/multi_device_multi_process_classification.py) for more details.


