### PR TITLE
Add missing function (depth-wise conv/deconv) in document

### DIFF
--- a/doc/python/api/function.rst
+++ b/doc/python/api/function.rst
@@ -36,7 +36,9 @@ Neural Network Layers
 
 .. autofunction:: affine
 .. autofunction:: convolution
+.. autofunction:: depthwise_convolution
 .. autofunction:: deconvolution
+.. autofunction:: depthwise_deconvolution
 .. autofunction:: max_pooling
 .. autofunction:: average_pooling
 .. autofunction:: sum_pooling

--- a/doc/python/api/parametric_function.rst
+++ b/doc/python/api/parametric_function.rst
@@ -52,7 +52,9 @@ Here is the list of parametric functions.
 
 .. autofunction:: affine
 .. autofunction:: convolution
+.. autofunction:: depthwise_convolution
 .. autofunction:: deconvolution
+.. autofunction:: depthwise_deconvolution
 .. autofunction:: batch_normalization
 
 .. autofunction:: embed


### PR DESCRIPTION
List the depth-wise convolution/deconvolution in the document.