### PR TITLE
Reshape with not inplace option

### DIFF
--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -2168,6 +2168,10 @@ Array Manipulation:
       shape:
         doc: Dimensions for each axis. ``-1`` can be specified only in one shape dimension. The value is calculated from the size of the array and remaining dimensions.
         type: Shape
+      inplace:
+        doc: The output array is shared with the input array if True. 
+        type: bool
+        default: 'True'         
     outputs:
       y:
         doc: Reshaped N-D array

--- a/python/test/function/test_reshape.py
+++ b/python/test/function/test_reshape.py
@@ -21,7 +21,7 @@ from nbla_test_utils import list_context
 ctxs = list_context('Reshape')
 
 
-def ref_reshape(x, shape):
+def ref_reshape(x, shape, inplace):
     return x.reshape(shape).copy()
 
 
@@ -33,5 +33,19 @@ def test_reshape_forward_backward(seed, inshape, outshape, ctx, func_name):
     rng = np.random.RandomState(seed)
     # Input
     inputs = [rng.randn(*inshape).astype(np.float32)]
+    inplace = False
     function_tester(rng, F.reshape, ref_reshape, inputs, func_args=[
-                    outshape], ctx=ctx, func_name=func_name)
+                    outshape, inplace], ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, outshape", [((1, 1, 6), (1, 2, 3)), ((2, 3), (1, 6)), ((2, 4), (-1, 2, 2))])
+def test_reshpae_inplace(seed, ctx, func_name, inshape, outshape):
+    from nbla_test_utils import inplace_function_test_helper
+    rng = np.random.RandomState(seed)
+    inputs = [nn.Variable.from_numpy_array(
+        rng.randn(*inshape).astype(np.float32))]
+    inplace_function_test_helper(
+        inputs, F.reshape, func_args=[
+            outshape], ctx=ctx, rng=np.random.RandomState(seed))


### PR DESCRIPTION
Now you do not need to do the following for branching the variable after reshaping.

```python
h = F.Identity(F.reshape(x))
h0 = F.<func>(h, maps)
h1 = F.<func>(h, maps)
```

Instead

```python
h = F.reshape(x, inplace=False)
h0 = F.<func>(h, maps)
h1 = F.<func>(h, maps)
```