### PR TITLE
Re-design graph engine for rewiring

### DIFF
--- a/examples/cpp/cpp_graph/main.cpp
+++ b/examples/cpp/cpp_graph/main.cpp
@@ -38,7 +38,7 @@ int main() {
   auto affine3 = make_shared<CgFunction>(create_Affine(ctx, 1));
 
   // Variables
-  auto x = make_shared<CgVariable>(shape_x, false);
+  auto x = make_shared<CgVariable>(shape_x);
 
   Shape_t shape_affine_w;
   Shape_t shape_affine_b;

--- a/include/nbla/common.hpp
+++ b/include/nbla/common.hpp
@@ -22,6 +22,7 @@ maybe because they are uncategorized.
 
 #include <algorithm>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -85,6 +86,17 @@ inline string string_join(const vector<T> &vec, const string &delim) {
   oss << vec[vec.size() - 1];
   return oss.str();
 }
+
+/** Scoped callback
+*/
+class DestructorCallback {
+  std::function<void(void)> callback_;
+
+public:
+  inline DestructorCallback(std::function<void(void)> callback)
+      : callback_(callback) {}
+  inline ~DestructorCallback() { callback_(); }
+};
 
 /** Hash combining function.
 

--- a/include/nbla/computation_graph/computation_graph.hpp
+++ b/include/nbla/computation_graph/computation_graph.hpp
@@ -40,16 +40,6 @@ NBLA_API vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
                                        vector<NdArrayPtr> inplace_outputs = {},
                                        bool execute = false);
 
-/** Connect function to network.
-
-    Use allocated outputs vector.
- */
-NBLA_API vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
-                                       const vector<CgVariablePtr> &inputs,
-                                       const vector<CgVariablePtr> &outputs,
-                                       vector<NdArrayPtr> inplace_outputs = {},
-                                       bool execute = false);
-
 /** Steal some variable properties from `from` CgVariable to `to` in order to
    rewire previously constructed graphs.
 

--- a/include/nbla/computation_graph/computation_graph.hpp
+++ b/include/nbla/computation_graph/computation_graph.hpp
@@ -49,5 +49,15 @@ NBLA_API vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
                                        const vector<CgVariablePtr> &outputs,
                                        vector<NdArrayPtr> inplace_outputs = {},
                                        bool execute = false);
+
+/** Steal some variable properties from `from` CgVariable to `to` in order to
+   rewire previously constructed graphs.
+
+    It takes parent, need_grad flags, inplace flags, and the variable contents.
+
+    @param[in] from Its parent function is stolen by 'to'.
+    @param[in,out] to A variable 'from''s parent stolen to.
+*/
+NBLA_API void steal_variable_from_to(CgVariablePtr from, CgVariablePtr to);
 }
 #endif

--- a/include/nbla/computation_graph/function.hpp
+++ b/include/nbla/computation_graph/function.hpp
@@ -109,6 +109,11 @@ public:
   /**
    */
   NBLA_API string info() const { return info_; }
+
+  void check_data_inplace(int i, CgVariablePtr input,
+                          const vector<CgVariablePtr> &outputs);
+  void check_grad_inplace(int i, CgVariablePtr input);
+  void verify_during_forward();
 };
 
 /**

--- a/include/nbla/computation_graph/function.hpp
+++ b/include/nbla/computation_graph/function.hpp
@@ -43,10 +43,6 @@ class CgFunction {
   bool need_grad_{false};
   string info_;
 
-  /**
-   */
-  inline void set_rank(int rank) { rank_ = rank; }
-
 public:
   typedef shared_ptr<CgFunction> Ptr;
 
@@ -54,13 +50,24 @@ public:
       @param[in] func shared_ptr of Function.
   */
   NBLA_API CgFunction(FunctionPtr func);
-  /** Set inputs.
-      Check if any of inputs requires gradient computation and store the flag in
-      self. Also, rank will be set according to inputs' ranks.
+
+  /** Set inputs. Note user shouldn't call this directly.
 
       @param[in] inputs Function inputs as CgVariables.
   */
-  NBLA_API void set_inputs(const vector<CgVariablePtr> &inputs);
+  inline void set_inputs_(const vector<CgVariablePtr> &inputs) {
+    inputs_ = inputs;
+  }
+
+  /** Calling setup function of an Function object internally held.
+   */
+  void setup();
+
+  /** Get a weak reference output as a shared reference by index or raise.
+
+      @param[in] i Output index.
+  */
+  inline CgVariablePtr output(int i);
 
   /**
    */
@@ -77,6 +84,10 @@ public:
   /**
    */
   inline int rank() const { return rank_; }
+
+  /**
+   */
+  inline void set_rank_(int rank) { rank_ = rank; }
 
   /** Store outputs as weak references (weak_ptr).
 

--- a/include/nbla/computation_graph/function.hpp
+++ b/include/nbla/computation_graph/function.hpp
@@ -17,7 +17,11 @@
 
 #include <nbla/function.hpp>
 
+#include <utility>
+
 namespace nbla {
+
+using std::pair;
 
 // Forward declaration
 class CgVariable;
@@ -31,12 +35,17 @@ A Function object is held in this object, and pointers to inputs and outputs
 also kept.
  */
 class CgFunction {
+  friend class CgVariable;
   int rank_{0};
   vector<CgVariablePtr> inputs_;
   FunctionPtr func_;
   vector<std::weak_ptr<CgVariable>> outputs_;
   bool need_grad_{false};
   string info_;
+
+  /**
+   */
+  inline void set_rank(int rank) { rank_ = rank; }
 
 public:
   typedef shared_ptr<CgFunction> Ptr;
@@ -60,6 +69,10 @@ public:
   /**
    */
   inline bool need_grad() const { return need_grad_; }
+
+  /**
+   */
+  inline void set_need_grad(bool b) { need_grad_ = b; }
 
   /**
    */
@@ -87,12 +100,8 @@ public:
    */
   inline size_t num_outputs() const { return outputs_.size(); }
 
-  /** Update need_grad flag by seeing output variables.
-   */
-  NBLA_API bool update_need_grad();
-
   NBLA_API vector<Variable *> function_inputs();
-  NBLA_API vector<VariablePtr> function_outputs_shared();
+  NBLA_API pair<vector<CgVariablePtr>, vector<Variable *>> function_outputs();
 
   /**
    */

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -57,10 +57,8 @@ class CgVariable {
   CgFunctionPtr parent_{nullptr};   ///< Function created this variable.
   int rank_{0};                     ///< Longest path from root variable.
   int function_reference_count_{0}; ///< Reference count by child functions.
-  bool allow_inplace_data_{true};   ///< Whether the data can be in-placed.
-  bool grad_inplaced_{false}; ///< Gradient is in-placed with any of parent
-                              /// function's inputs grad.
-  bool persistent_{false};    ///<Persistency flag against clearing.
+  bool allow_modify_data_{true};    ///< Whether the data can be in-placed.
+  bool persistent_{false};          ///<Persistency flag against clearing.
 
   /** set rank.
 
@@ -235,25 +233,20 @@ public:
     function_reference_count_++;
   }
 
-  /** @copydoc allow_inplace_data_
+  /** @copydoc allow_modify_data_
    */
-  inline bool allow_inplace_data() const { return allow_inplace_data_; }
+  inline bool allow_modify_data() const { return allow_modify_data_; }
 
   /**
       @note User shouldn't call this directly.
    */
-  inline void set_allow_inplace_data(bool allow) {
-    allow_inplace_data_ = allow;
-  }
+  inline void set_allow_modify_data(bool allow) { allow_modify_data_ = allow; }
 
-  /** @copydoc grad_inplaced_
-   */
-  inline bool grad_inplaced() const { return grad_inplaced_; }
+  /** Take an parent function from a given CgVariable and rewire the graph
+      connection from the parent function to this variable.
 
-  /**
-      @note User shouldn't call this directly.
+      @param[in] var Its parent function is stolen by this variable.
    */
-  inline void set_grad_inplaced(bool inplaced) { grad_inplaced_ = inplaced; }
 
   /** Set persistent flag.
 

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -173,6 +173,10 @@ public:
    */
   inline VariablePtr variable() { return var_; }
 
+  /** Set variable reference.
+   */
+  inline void set_variable(VariablePtr var) { var_ = var; }
+
   /** @copydoc rank_
    */
   inline int rank() const { return rank_; }
@@ -241,12 +245,6 @@ public:
       @note User shouldn't call this directly.
    */
   inline void set_allow_modify_data(bool allow) { allow_modify_data_ = allow; }
-
-  /** Take an parent function from a given CgVariable and rewire the graph
-      connection from the parent function to this variable.
-
-      @param[in] var Its parent function is stolen by this variable.
-   */
 
   /** Set persistent flag.
 

--- a/include/nbla/function.hpp
+++ b/include/nbla/function.hpp
@@ -122,7 +122,7 @@ public:
   @sa setup() arguments.
   */
   void backward(const Variables &inputs, const Variables &outputs,
-                const vector<bool> &acccum);
+                const vector<bool> &propagate_down, const vector<bool> &acccum);
 
   /** Get Context used in this function.
   */

--- a/include/nbla/function/reshape.hpp
+++ b/include/nbla/function/reshape.hpp
@@ -69,11 +69,11 @@ public:
   }
   virtual bool grad_depends_output_data(int i, int o) const { return inplace_; }
   virtual int inplace_data(int i) const {
-    return inplace_ ? Function::INPLACE : Function::INPLACE_NOT_MODIFY;
+    return inplace_ ? Function::INPLACE_NOT_MODIFY : Function::NOT_INPLACE;
   }
   virtual int inplace_data_with(int i) const { return 0; }
   virtual int inplace_grad(int i) const {
-    return inplace_ ? Function::INPLACE : Function::INPLACE_NOT_MODIFY;
+    return inplace_ ? Function::INPLACE_NOT_MODIFY : Function::NOT_INPLACE;
   }
   virtual int inplace_grad_with(int i) const { return 0; }
 

--- a/include/nbla/function/utils/base_transform_binary.hpp
+++ b/include/nbla/function/utils/base_transform_binary.hpp
@@ -68,13 +68,13 @@ protected:
     }
     outputs[0]->reshape(oshape, true);
     if (bc0) {
-      o_bc0_ = make_shared<Variable>(Shape_t{}, inputs[0]->need_grad());
+      o_bc0_ = make_shared<Variable>(Shape_t{});
       f_bc0_ = create_Broadcast(this->ctx_,
                                 vector<int>(oshape.cbegin(), oshape.cend()));
       f_bc0_->setup(Variables{inputs[0]}, Variables{o_bc0_.get()});
     }
     if (bc1) {
-      o_bc1_ = make_shared<Variable>(Shape_t{}, inputs[1]->need_grad());
+      o_bc1_ = make_shared<Variable>(Shape_t{});
       f_bc1_ = create_Broadcast(this->ctx_,
                                 vector<int>(oshape.cbegin(), oshape.cend()));
       f_bc1_->setup(Variables{inputs[1]}, Variables{o_bc1_.get()});
@@ -196,9 +196,8 @@ void TransformBinary<T, BinaryOp, Args...>::backward_impl(
       transform_binary_grad0<T, BinaryOp, false>(size, dy, x0, x1, y, dx0,
                                                  binary_op_);
     if (this->f_bc0_) {
-      this->o_bc0_->set_need_grad(true);
       this->f_bc0_->backward(Variables{inputs[0]},
-                             Variables{this->o_bc0_.get()}, {accum[0]});
+                             Variables{this->o_bc0_.get()}, {true}, {accum[0]});
     }
   }
   if (propagate_down[1]) {
@@ -211,9 +210,8 @@ void TransformBinary<T, BinaryOp, Args...>::backward_impl(
       transform_binary_grad1<T, BinaryOp, false>(size, dy, x0, x1, y, dx1,
                                                  binary_op_);
     if (this->f_bc1_) {
-      this->o_bc1_->set_need_grad(true);
       this->f_bc1_->backward(Variables{inputs[1]},
-                             Variables{this->o_bc1_.get()}, {accum[1]});
+                             Variables{this->o_bc1_.get()}, {true}, {accum[1]});
     }
   }
 }

--- a/include/nbla/variable.hpp
+++ b/include/nbla/variable.hpp
@@ -38,7 +38,6 @@ class Variable {
   Shape_t strides_; ///< C-contiguous strides.
   Size_t size_;     ///< Size.
   Size_t ndim_;     ///< Number of dimensions.
-  bool need_grad_;  ///< Flag whether this variable needs backprop
   NdArrayPtr data_; ///< Storing forwardprop results.
   NdArrayPtr grad_; ///< Storing backprop results.
 
@@ -53,29 +52,15 @@ public:
   Constructor.
 
   @param shape Shape.
-  @param need_grad Flag whether backprop to this variable is required.
   */
-  NBLA_API Variable(const Shape_t &shape = {}, bool need_grad = false);
+  NBLA_API Variable(const Shape_t &shape = {});
 
   /**
   Constructor given NdArray.
 
   @param data A reference of NdArray created by another can be passed.
-  @param need_grad Flag whether backprop to this variable is required.
   */
-  NBLA_API Variable(NdArrayPtr data, bool need_grad = false);
-
-  /**
-  Setter of #need_grad_.
-
-  @param need_grad Flag.
-  */
-  NBLA_API void set_need_grad(bool need_grad);
-
-  /**
-  Getter of #need_grad_.
-  */
-  inline bool need_grad() const { return need_grad_; }
+  NBLA_API Variable(NdArrayPtr data);
 
   /** Reshape.
    */

--- a/python/src/nnabla/_computation_graph.pxd
+++ b/python/src/nnabla/_computation_graph.pxd
@@ -26,3 +26,4 @@ cdef extern from "nbla/computation_graph/computation_graph.hpp" namespace "nbla"
         int,
         vector[NdArrayPtr],
         cpp_bool) except+
+    void steal_variable_from_to(CgVariablePtr f, CgVariablePtr t) except+

--- a/python/src/nnabla/_variable.pxd
+++ b/python/src/nnabla/_variable.pxd
@@ -25,10 +25,8 @@ from _nd_array cimport *
 
 cdef extern from "nbla/variable.hpp" namespace "nbla":
     cdef cppclass CVariable "nbla::Variable":
-        CVariable(Shape_t, cpp_bool) except +
-        CVariable(NdArrayPtr, cpp_bool) except +
-        cpp_bool need_grad()
-        void set_need_grad(cpp_bool)
+        CVariable(Shape_t) except +
+        CVariable(NdArrayPtr) except +
         Shape_t shape()
         Size_t size(Size_t) except +
         Size_t ndim()
@@ -51,6 +49,8 @@ cdef extern from "nbla/computation_graph/variable.hpp" namespace "nbla":
         CgVariable(cpp_bool need_grad) except+
         CgVariable(Shape_t shape, cpp_bool need_grad) except+
         CgVariable(VariablePtr)
+        cpp_bool need_grad() const
+        void set_need_grad(cpp_bool b)
         void set_parent(CgFunctionPtr func) except+
         CgFunctionPtr parent()
         VariablePtr variable()
@@ -69,7 +69,6 @@ cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":
         CgFunction(FunctionPtr func) except+
         FunctionPtr function() const
         cpp_bool need_grad() const
-        cpp_bool update_need_grad() except+
         int rank() const
         void set_outputs(const vector[CgVariablePtr] & outputs) except+
         const vector[CgVariablePtr] inputs()

--- a/python/src/nnabla/_variable.pxd
+++ b/python/src/nnabla/_variable.pxd
@@ -46,11 +46,20 @@ cdef extern from "nbla/computation_graph/variable.hpp" namespace "nbla":
         CCommunicatorBackwardCallback() except+
     ctypedef shared_ptr[CCommunicatorBackwardCallback] CommunicatorBackwardCallbackPtr
     cdef cppclass CgVariable:
+        CgVariable() except+
         CgVariable(cpp_bool need_grad) except+
+        CgVariable(Shape_t shape) except+
         CgVariable(Shape_t shape, cpp_bool need_grad) except+
         CgVariable(VariablePtr)
+        CgVariable(VariablePtr, cpp_bool need_grad)
         cpp_bool need_grad() const
+        cpp_bool need_grad_is_set() const
         void set_need_grad(cpp_bool b)
+        void unset_need_grad()
+        cpp_bool need_grad_state() const
+        cpp_bool need_grad_state_is_set() const
+        void set_need_grad_state(cpp_bool b)
+        void unset_need_grad_state()
         void set_parent(CgFunctionPtr func) except+
         CgFunctionPtr parent()
         VariablePtr variable()

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -34,7 +34,9 @@ cdef extern from "nbla/function.hpp" namespace "nbla":
     cdef cppclass CFunction "nbla::Function":
         void setup(const Variables&, const Variables&) nogil except +
         void forward(const Variables&, const Variables&) nogil except +
-        void backward(const Variables&, const Variables&, const vector[cpp_bool] &accum) nogil except +
+        void backward(const Variables&, const Variables&,
+                      const vector[cpp_bool] &propagate_down,
+                      const vector[cpp_bool] &accum) nogil except +
         vector[dtypes] in_types()
         vector[dtypes] out_types()
         int min_inputs()
@@ -56,7 +58,6 @@ cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":
         CgFunction(FunctionPtr func) except+
         FunctionPtr function() const
         cpp_bool need_grad() const
-        cpp_bool update_need_grad() except+
         int rank() const
         void set_outputs(const vector[CgVariablePtr] &outputs) except+
         vector[CgVariablePtr] inputs()

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -102,6 +102,14 @@ cdef vector[CVariable*] list_to_vector_variable_p(varlist):
         vec[i] = (<_Variable?> varlist[i]).varp.variable().get()
     return vec
 
+cdef vector[cpp_bool] variables_to_prop_down_flags(varlist):
+    cdef int i
+    cdef int size = len(varlist)
+    cdef vector[cpp_bool] ret
+    for i in range(size):
+        ret.push_back((<_Variable?>varlist[i]).varp.need_grad())
+    return ret
+
 cdef tuple vector_to_tuple_nd_array(const vector[NdArrayPtr] &vec):
     cdef int i
     cdef list ret = []
@@ -192,6 +200,7 @@ cdef class Function:
     def backward(self, inputs, outputs, accum=None):
         cdef vector[cpp_bool] caccum
         cdef int i
+        cdef vector[cpp_bool] prop_down = variables_to_prop_down_flags(inputs)
         if accum is None:
             caccum.resize(len(inputs), True)
             # caccum.assign(len(inputs), True)
@@ -202,6 +211,7 @@ cdef class Function:
         self.funp.function().get().backward(
             list_to_vector_variable_p(inputs),
             list_to_vector_variable_p(outputs),
+	    prop_down,
             caccum)
 
     @property

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -82,6 +82,8 @@ def test_unlinked():
     with nn.context_scope(nn.Context()), nn.auto_forward():
         v2 = F.identity(v)
         v2_u = v2.unlinked()
+        assert not v2_u.need_grad
+        v2_u.need_grad = True
         v3 = F.identity(v2_u)
     v2_u.grad.zero()
     v2_g = v2_u.g.copy()

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -19,11 +19,6 @@
 
 namespace nbla {
 
-static vector<CgVariablePtr>
-connect_core(CgFunctionPtr cg_f, const vector<CgVariablePtr> &inputs,
-             const vector<CgVariablePtr> &outputs,
-             vector<NdArrayPtr> inplace_outputs = {}, bool execute = false);
-
 using std::make_shared;
 
 static void set_function_inputs(CgFunctionPtr func,
@@ -66,24 +61,7 @@ vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
                               bool execute) {
   set_function_inputs(cg_f, inputs);
   vector<CgVariablePtr> outputs = create_function_outputs(cg_f, n_outputs);
-  return connect_core(cg_f, inputs, outputs, inplace_outputs, execute);
-}
 
-vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
-                              const vector<CgVariablePtr> &inputs,
-                              const vector<CgVariablePtr> &outputs,
-                              vector<NdArrayPtr> inplace_outputs,
-                              bool execute) {
-  cg_f->set_inputs(inputs);
-  cg_f->set_outputs(outputs);
-  return connect_core(cg_f, inputs, outputs, inplace_outputs, execute);
-}
-
-vector<CgVariablePtr> connect_core(CgFunctionPtr cg_f,
-                                   const vector<CgVariablePtr> &inputs,
-                                   const vector<CgVariablePtr> &outputs,
-                                   vector<NdArrayPtr> inplace_outputs,
-                                   bool execute) {
   // Setup function.
   cg_f->setup();
 

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -25,9 +25,6 @@ connect_core(CgFunctionPtr cg_f, const vector<CgVariablePtr> &inputs,
 
 using std::make_shared;
 
-// Just a helper function.
-static inline const char *b2str(bool b) { return b ? "true" : "false"; }
-
 vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f,
                                               int n_outputs) {
   // Check inplace outputs size and create outputs.
@@ -85,59 +82,7 @@ vector<CgVariablePtr> connect_core(CgFunctionPtr cg_f,
   auto f = cg_f->function();
   f->setup(finputs, foutputs);
 
-  // TODO: revisit this
-  if (cg_f->need_grad()) {
-    // Set inplace capability of output variables.
-    for (int i = 0; i < inputs.size(); ++i) {
-      if (!inputs[i]->need_grad_state())
-        continue;
-      if (f->inplace_grad(i)) {
-        NBLA_CHECK(f->inplace_grad(i) < Function::INPLACE ||
-                       inputs[i]->parent(),
-                   error_code::value,
-                   "A grad array of a root variable in a graph cannot be "
-                   "in-placed with modification (%d-th input "
-                   "of '%s').",
-                   i, f->name().c_str());
-        outputs[f->inplace_grad_with(i)]->set_grad_inplaced(true);
-      }
-      for (int o = 0; o < outputs.size(); ++o) {
-        // If funcition gradient computation at i-th variable depends on o-th
-        // output data, inplacing o-th variable data is prohibited.
-        if (f->grad_depends_output_data(i, o)) {
-          outputs[o]->set_allow_inplace_data(false);
-        }
-      }
-    }
-  }
-  // Check if in-place is properly used.
-  for (int i = 0; i < inputs.size(); ++i) {
-    if (inputs[i]->allow_inplace_data())
-      continue;
-    const int inplace_level = f->inplace_data(i);
-    if (inplace_level == Function::NOT_INPLACE)
-      continue;
-    NBLA_CHECK(inplace_level < Function::INPLACE, error_code::value,
-               "In-place %d-th input data of '%s' (depth=%d) is "
-               "prohibited by the parent function '%s'.",
-               i, f->name().c_str(), cg_f->rank(),
-               inputs[i]->parent()->function()->name().c_str());
-    // Since the in-placed input's data is not modified in this function,
-    // the allow-inplace flag is propagated to the output variable.
-    outputs[f->inplace_data_with(i)]->set_allow_inplace_data(false);
-  }
-
-  // Check if branching doesn't appear in in-placed variables.
-  for (int i = 0; i < inputs.size(); ++i) {
-    bool inplace = f->inplace_data(i) || f->inplace_grad(i);
-    NBLA_CHECK(
-        (!inplace) || inputs[i]->function_reference_count() < 2,
-        error_code::value,
-        "Branching a variable is prohibited if it is in-placed. %d-th input "
-        "of `%s` (depth=%d) is inplaced (data: %s, grad: %s).",
-        i, f->name().c_str(), cg_f->rank(), b2str(f->inplace_data(i)),
-        b2str(f->inplace_grad(i)));
-  }
+  cg_f->verify_during_forward();
 
   // Set array reference to function output buffer if size matches.
   for (int i = 0; i < outputs.size(); ++i) {

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -36,7 +36,8 @@ vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f,
   }
   vector<CgVariablePtr> outputs(n_outputs);
   for (int i = 0; i < n_outputs; ++i) {
-    auto v = make_shared<CgVariable>(cg_f->need_grad());
+    auto v = make_shared<CgVariable>();
+    v->set_need_grad_state(cg_f->need_grad());
     v->set_parent(cg_f);
     outputs[i] = v;
   }
@@ -84,10 +85,11 @@ vector<CgVariablePtr> connect_core(CgFunctionPtr cg_f,
   auto f = cg_f->function();
   f->setup(finputs, foutputs);
 
+  // TODO: revisit this
   if (cg_f->need_grad()) {
     // Set inplace capability of output variables.
     for (int i = 0; i < inputs.size(); ++i) {
-      if (!inputs[i]->need_grad())
+      if (!inputs[i]->need_grad_state())
         continue;
       if (f->inplace_grad(i)) {
         NBLA_CHECK(f->inplace_grad(i) < Function::INPLACE ||

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -87,7 +87,7 @@ vector<CgVariablePtr> connect_core(CgFunctionPtr cg_f,
   if (cg_f->need_grad()) {
     // Set inplace capability of output variables.
     for (int i = 0; i < inputs.size(); ++i) {
-      if (!inputs[i]->variable()->need_grad())
+      if (!inputs[i]->need_grad())
         continue;
       if (f->inplace_grad(i)) {
         NBLA_CHECK(f->inplace_grad(i) < Function::INPLACE ||
@@ -135,14 +135,6 @@ vector<CgVariablePtr> connect_core(CgFunctionPtr cg_f,
         "of `%s` (depth=%d) is inplaced (data: %s, grad: %s).",
         i, f->name().c_str(), cg_f->rank(), b2str(f->inplace_data(i)),
         b2str(f->inplace_grad(i)));
-  }
-
-  // Set clear buffer flags
-  for (int i = 0; i < inputs.size(); ++i) {
-    if (f->inplace_data(i))
-      outputs[f->inplace_data_with(i)]->set_clear_data_in_backward(false);
-    if (f->inplace_grad(i))
-      outputs[f->inplace_grad_with(i)]->set_clear_grad_in_backward(false);
   }
 
   // Set array reference to function output buffer if size matches.

--- a/src/nbla/computation_graph/function.cpp
+++ b/src/nbla/computation_graph/function.cpp
@@ -32,7 +32,7 @@ void CgFunction::set_inputs(const vector<CgVariablePtr> &inputs) {
   // Check need_grad
   need_grad_ = false;
   for (auto i : inputs) {
-    need_grad_ |= i->variable()->need_grad();
+    need_grad_ |= i->need_grad();
     rank_ = std::max(rank_, i->rank());
     i->increment_function_reference_count();
   }
@@ -50,19 +50,15 @@ void CgFunction::set_outputs(const vector<CgVariablePtr> &outputs) {
 vector<CgVariablePtr> CgFunction::outputs() {
   vector<CgVariablePtr> outputs(outputs_.size());
   for (int i = 0; i < outputs_.size(); ++i) {
-    outputs[i] = outputs_[i].lock();
+    auto o = outputs_[i].lock();
+    NBLA_CHECK(o, error_code::value,
+               "Weak reference to outputs[%d] has gone at %s.", i,
+               func_->name().c_str());
+    outputs[i] = o;
   }
   return outputs;
 }
 
-bool CgFunction::update_need_grad() {
-  bool need_grad = false;
-  for (int i = 0; i < outputs_.size(); ++i) {
-    need_grad |= outputs_[i].lock()->variable()->need_grad();
-  }
-  need_grad_ = need_grad;
-  return need_grad;
-}
 vector<Variable *> CgFunction::function_inputs() {
   vector<Variable *> ret(inputs_.size());
   for (int i = 0; i < inputs_.size(); ++i) {
@@ -71,15 +67,12 @@ vector<Variable *> CgFunction::function_inputs() {
   return ret;
 }
 
-vector<VariablePtr> CgFunction::function_outputs_shared() {
-  vector<VariablePtr> ret(outputs_.size());
-  for (int i = 0; i < outputs_.size(); ++i) {
-    auto o = outputs_[i].lock();
-    NBLA_CHECK(o, error_code::value,
-               "Output variable at %d in %s was deleted by someone.", i,
-               func_->name().c_str());
-    ret[i] = o->variable();
-  }
-  return ret;
+pair<vector<CgVariablePtr>, vector<Variable *>> CgFunction::function_outputs() {
+  auto outputs = this->outputs();
+  vector<Variable *> voutputs(outputs.size());
+  std::transform(
+      outputs.begin(), outputs.end(), voutputs.begin(),
+      [](CgVariablePtr v) -> Variable * { return v->variable().get(); });
+  return {outputs, voutputs};
 }
 }

--- a/src/nbla/computation_graph/function.cpp
+++ b/src/nbla/computation_graph/function.cpp
@@ -32,7 +32,7 @@ void CgFunction::set_inputs(const vector<CgVariablePtr> &inputs) {
   // Check need_grad
   need_grad_ = false;
   for (auto i : inputs) {
-    need_grad_ |= i->need_grad();
+    need_grad_ |= i->need_grad_state();
     rank_ = std::max(rank_, i->rank());
     i->increment_function_reference_count();
   }

--- a/src/nbla/computation_graph/function.cpp
+++ b/src/nbla/computation_graph/function.cpp
@@ -21,6 +21,9 @@ namespace nbla {
 
 using std::make_shared;
 
+// Just a helper function.
+static inline const char *b2str(bool b) { return b ? "true" : "false"; }
+
 CgFunction::CgFunction(FunctionPtr func) : rank_(0) {
   // Copy if function is already used.
   if (func->ask_if_used_and_use()) {
@@ -28,6 +31,73 @@ CgFunction::CgFunction(FunctionPtr func) : rank_(0) {
   }
   func_ = func;
 }
+
+void CgFunction::check_data_inplace(int i, CgVariablePtr input,
+                                    const vector<CgVariablePtr> &outputs) {
+  auto f = this->function();
+  // Always not allow modifying data if grad depends the output data.
+  if (input->need_grad_state()) {
+    for (int o = 0; o < outputs.size(); ++o) {
+      // If funcition gradient computation at i-th variable depends on o-th
+      // output data, inplacing o-th variable data is prohibited.
+      if (f->grad_depends_output_data(i, o)) {
+        outputs[o]->set_allow_modify_data(false);
+      }
+    }
+  }
+  int inplace_level = f->inplace_data(i);
+  if (inplace_level == Function::INPLACE) {
+    NBLA_CHECK(input->allow_modify_data(), error_code::value,
+               "Modifying data is prohibitied by the parent function of the "
+               "%d-th input data of '%s' (depth=%d). (Parent is '%s').",
+               i, f->name().c_str(), this->rank(),
+               input->parent()->function()->name().c_str());
+    NBLA_CHECK(input->function_reference_count() < 2, error_code::value,
+               "In-placing at a branching variable is prohibited. %d-th input "
+               "data of `%s` (depth=%d) is inplaced.",
+               i, f->name().c_str(), this->rank());
+  } else if (inplace_level == Function::INPLACE_NOT_MODIFY) {
+    // A variable that branches or requires grad doesn't allow modify data at
+    // the in-placed variable.
+    if (input->function_reference_count() > 1 || input->need_grad_state()) {
+      outputs[f->inplace_data_with(i)]->set_allow_modify_data(false);
+    }
+  }
+}
+
+void CgFunction::check_grad_inplace(int i, CgVariablePtr input) {
+  if (!input->need_grad_state()) {
+    return;
+  }
+  auto f = this->function();
+  int inplace_level = f->inplace_grad(i);
+  if (inplace_level == Function::INPLACE) {
+    NBLA_CHECK(input->parent(), error_code::value,
+               "A grad array of a root variable in a graph cannot be "
+               "in-placed (%d-th input of '%s').",
+               i, f->name().c_str());
+  }
+  if (inplace_level >= Function::INPLACE_NOT_MODIFY) {
+    NBLA_CHECK(input->function_reference_count() < 2, error_code::value,
+               "In-placing grad at a variable which branches"
+               " is prohibited. %d-th input "
+               "grad of `%s` (depth=%d) is inplaced.",
+               i, f->name().c_str(), this->rank());
+  }
+}
+
+void CgFunction::verify_during_forward() {
+  for (auto o : this->outputs()) {
+    o->set_allow_modify_data(true);
+  }
+  auto inputs = this->inputs();
+  auto outputs = this->outputs();
+  for (int i = 0; i < inputs.size(); ++i) {
+    this->check_data_inplace(i, inputs[i], outputs);
+    this->check_grad_inplace(i, inputs[i]);
+  }
+}
+
 void CgFunction::set_inputs(const vector<CgVariablePtr> &inputs) {
   // Check need_grad
   need_grad_ = false;

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -339,7 +339,10 @@ void CgVariable::visit_function_recursive(
                                   // because the callback may use this.
   func->set_rank(++max_rank);     // Increment rank at function.
 
-  // D. Call callback function at this function.
+  // D. Verify flags
+  func->verify_during_forward();
+
+  // E. Call callback function at this function.
   forward_callback(func);
   // std::cout << max_rank << " " << func->function()->name() << " " <<
   // func.get() << std::endl;
@@ -416,10 +419,6 @@ void CgVariable::backward(
     NdArrayPtr grad, bool clear_buffer,
     vector<CommunicatorBackwardCallbackPtr> communicator_callbacks) {
   NBLA_CHECK(parent_, error_code::value, "The variable has no parent.");
-  NBLA_CHECK(!this->grad_inplaced_, error_code::value,
-             "Backward can not be called at a variable in which grad array is "
-             "in-placed. The grad array is in-placed by '%s' (depth=%d).",
-             parent_->function()->name().c_str(), parent_->rank());
 
   // Scoped context.
   // Set flags used during backward of this variable to avoid clearing

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -21,7 +21,8 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
-// #include <iostream>  // TODO: remove
+
+// #include <iostream> // TODO: remove
 
 namespace nbla {
 
@@ -32,143 +33,317 @@ using std::unordered_set;
 using std::tuple;
 using std::make_tuple;
 using std::get;
+using std::unique_ptr;
 
-CgVariable::CgVariable(bool need_grad) {
-  var_ = make_shared<Variable>(Shape_t{}, need_grad);
+CgVariable::CgVariable(bool need_grad) : need_grad_(need_grad) {
+  var_ = make_shared<Variable>(Shape_t{});
 }
 
-CgVariable::CgVariable(Shape_t shape, bool need_grad) {
-  var_ = make_shared<Variable>(shape, need_grad);
+CgVariable::CgVariable(Shape_t shape, bool need_grad) : need_grad_(need_grad) {
+  var_ = make_shared<Variable>(shape);
 }
 
 CgVariable::CgVariable(VariablePtr var) { var_ = var; }
 
-// Return if all variables are consumed.
-inline bool remember_unseen_or_check_all_consumed_forward(
-    unordered_set<CgVariablePtr> &vseen, CgVariablePtr v) {
-  // Clear if no branch
-  if (v->function_reference_count() < 2)
-    return true;
-  // Check if the variable is seen in this forward propagation
-  auto it = vseen.find(v);
-  if (it == vseen.end()) {
-    // Initialize the variable consumption count (set one is consume).
-    v->consume(true);
-    vseen.insert(v);
-    return false;
-  }
-  int c = v->consume();
-  if (c == v->function_reference_count()) {
-    vseen.erase(it); // For better search performance of another.
-    return true;
-  }
-  return false;
-}
-
-void forward_recursive(CgFunctionPtr cg_f, unordered_set<CgFunctionPtr> &fseen,
-                       unordered_set<CgVariablePtr> &vseen,
-                       int function_reference_count, bool clear_buffer,
-                       bool clear_no_need_grad) {
-  if (!cg_f)
-    return;
-  // Seen set should be added only if the function output is branching.
-  if (cg_f->num_outputs() > 1 || function_reference_count > 1) {
-    fseen.insert(cg_f);
-  }
-  // Recursively call predecessors' forward functions.
-  for (auto cg_v : cg_f->inputs()) {
-    auto parent_f = cg_v->parent();
-    if (fseen.find(parent_f) != fseen.end())
-      continue;
-    forward_recursive(parent_f, fseen, vseen, cg_v->function_reference_count(),
-                      clear_buffer, clear_no_need_grad);
-  }
-  // Execute forward.
-  auto outputs_shared = cg_f->function_outputs_shared();
-  // std::cout << "Call forward of " << cg_f->function()->name() << "."
-  //           << std::endl;
-  auto raw_f = cg_f->function();
-  raw_f->forward(cg_f->function_inputs(), as_pointer_array(outputs_shared));
-
-  // It returns at this point if the Function prohibit clearing input buffers.
-  if (raw_f->prohibit_clear_input_buffers()) {
-    // NOTE: it returns because assume the rest of this function only clearing
-    // buffer.
-    return;
-  }
-
-  // Clear unnecessary variable buffers
-  if (clear_buffer) {
-    for (int i = 0; i < cg_f->num_inputs(); i++) {
-      auto vi = cg_f->inputs()[i];
-      if (vi->rank() == 0 || vi->persistent() || raw_f->inplace_data(i)) {
-        // Root variable, or persistent flag is set by user.
-        continue;
-      }
-      if (remember_unseen_or_check_all_consumed_forward(vseen, vi)) {
-        vi->variable()->data()->array()->clear();
-      }
-    }
-  } else if (clear_no_need_grad) {
-    for (int i = 0; i < cg_f->num_inputs(); i++) {
-      auto vi = cg_f->inputs()[i];
-      if (vi->rank() == 0 || vi->persistent() || raw_f->inplace_data(i)) {
-        // Root variable, or persistent flag is set by user.
-        continue;
-      }
-      if (cg_f->need_grad()) {
-        continue;
-      }
-      if (remember_unseen_or_check_all_consumed_forward(vseen, vi)) {
-        vi->variable()->data()->array()->clear();
-      }
-    }
-  }
-}
-
-void CgVariable::forward(bool clear_buffer, bool clear_no_need_grad) {
-  unordered_set<CgFunctionPtr> fseen; // Seen functions.
-  unordered_set<CgVariablePtr> vseen; // Seen variables.
-  forward_recursive(parent_, fseen, vseen, function_reference_count_,
-                    clear_buffer, clear_no_need_grad);
-}
-
-/** Scoped grad region switch in Variable.
- */
-class ScopedVariableGrad {
-  VariablePtr var_;
-  NdArrayPtr backup_;
+class ForwardCallback {
+  bool clear_buffer_{false};
+  bool clear_no_need_grad_{false};
+  unordered_map<CgVariablePtr, int> vseen_;
 
 public:
-  inline ScopedVariableGrad(VariablePtr var, NdArrayPtr grad) : var_(var) {
-    backup_ = var_->grad();
-    var_->set_grad(grad);
+  ForwardCallback(bool clear_buffer, bool clear_no_need_grad)
+      : clear_buffer_(clear_buffer), clear_no_need_grad_(clear_no_need_grad) {}
+
+  bool check_last_visit(CgVariablePtr v) {
+    if (v->function_reference_count() < 2) {
+      // A variable referenced by <2 is always visited last.
+      return true;
+    }
+    // Find from previous search history.
+    auto it = vseen_.find(v);
+    if (it == vseen_.end()) {
+      // The first visit.
+      vseen_.insert({v, 1});
+      return false;
+    }
+    // Check
+    if (++(it->second) == v->function_reference_count()) {
+      // For better search performance of another. (maybe not required)
+      vseen_.erase(it);
+      return true;
+    }
+    return false;
   }
-  inline ~ScopedVariableGrad() { var_->set_grad(backup_); }
+
+  vector<bool> get_clear_flags(CgFunctionPtr func) {
+    auto inputs = func->inputs();
+    vector<bool> ret(inputs.size(), false);
+    for (int i = 0; i < inputs.size(); ++i) {
+      auto vi = inputs[i];
+      // This comes first because check_last_visit must be called in order to
+      // increment the visit count of vi.
+      if (!check_last_visit(vi)) {
+        continue;
+      }
+      if (func->function()->prohibit_clear_input_buffers()) {
+        continue;
+      }
+      if (vi->rank() == 0 || vi->persistent() ||
+          func->function()->inplace_data(i)) {
+        continue;
+      }
+      if (clear_buffer_) {
+        ret[i] = true;
+        continue;
+      }
+      if (clear_no_need_grad_ && !func->need_grad()) {
+        ret[i] = true;
+        continue;
+      }
+    }
+    return ret;
+  }
+
+  void clear_inputs(const vector<CgVariablePtr> &inputs,
+                    const vector<bool> &clear_flags) {
+    // std::cout << "Clear flags: " << string_join(clear_flags, ",") <<
+    // std::endl;
+    for (int i = 0; i < inputs.size(); i++) {
+      if (clear_flags[i]) {
+        inputs[i]->variable()->data()->array()->clear();
+      }
+    }
+  }
+
+  void operator()(CgFunctionPtr func) {
+    // Execute forward.
+    // std::cout << "Call forward of " << func->function()->name() << "."
+    //           << std::endl;
+    vector<CgVariablePtr> outputs; // Get shared reference of outputs.
+    vector<Variable *> voutputs;
+    std::tie(outputs, voutputs) = func->function_outputs();
+    func->function()->forward(func->function_inputs(), voutputs);
+
+    // Clear input buffers where possible.
+    auto clear_flags = get_clear_flags(func);
+    clear_inputs(func->inputs(), clear_flags);
+  }
 };
 
-void CgVariable::backward(
-    NdArrayPtr grad, bool clear_buffer,
-    vector<CommunicatorBackwardCallbackPtr> communicator_callbacks) {
-  set<tuple<int, uint64_t, CgFunctionPtr>> cand;
-  unordered_map<CgFunctionPtr, uint64_t> ids;
-  unordered_set<CgVariablePtr> branch;
-  auto p = parent();
-  if (!p)
-    return;
-  // Set self 'clear in backward' flag to false.
-  clear_data_in_backward_ = false;
-  clear_grad_in_backward_ = false;
+class BackwardCallback {
+  bool clear_buffer_;
+  // Visit CgVaiable list. The value is whether this is cleared during backward.
+  unordered_map<CgVariablePtr, bool> vseen_;
 
-  NBLA_CHECK(!this->grad_inplaced_, error_code::value,
-             "Backward can not be called at a variable in which grad array is "
-             "in-placed. The grad array is in-placed by '%s' (depth=%d).",
-             p->function()->name().c_str(), p->rank());
-  std::unique_ptr<ScopedVariableGrad> grad_scope;
-  if (grad) {
-    grad_scope.reset(new ScopedVariableGrad(this->variable(), grad));
+  vector<bool> get_accum(const vector<CgVariablePtr> &inputs,
+                         const vector<bool> &first_visit_flags) {
+    vector<bool> accum(inputs.size(), false);
+    for (int i = 0; i < inputs.size(); i++) {
+      // No need grad.
+      if (!inputs[i]->need_grad())
+        continue;
+
+      // Root variable is always accumulated.
+      if (!inputs[i]->parent()) {
+        accum[i] = true;
+        continue;
+      }
+      // First visit graidents are copied.
+      if (first_visit_flags[i]) {
+        continue;
+      }
+      accum[i] = true;
+    }
+    return accum;
   }
 
+  void force_zero_grad_if_unseen(vector<CgVariablePtr> outputs,
+                                 const vector<bool> &first_visit) {
+    for (int i = 0; i < outputs.size(); i++) {
+      auto o = outputs[i];
+      if (first_visit[i]) {
+        // The ouput variable has not been seen during this backprop, which
+        // means no one sets the gradient previously. To prevent to propagate
+        // uninitialized gradient, the output gradients are filled as 0.
+        // std::cout << "Zero-ing output grad of "
+        //           << o->parent()->function()->name() << std::endl;
+        o->variable()->grad()->zero();
+      }
+    }
+  }
+
+  void clear_output_buffers(CgFunctionPtr func,
+                            const vector<bool> &prohibit_clear) {
+    if (clear_buffer_) {
+      auto f = func->function();
+      auto inputs = func->inputs();
+      auto outputs = func->outputs();
+      vector<pair<bool, bool>> clear(outputs.size(), {true, true});
+      for (int i = 0; i < inputs.size(); i++) {
+        if (f->inplace_data(i)) {
+          clear[f->inplace_data_with(i)].first = false;
+        }
+        if (f->inplace_grad(i)) {
+          clear[f->inplace_grad_with(i)].second = false;
+        }
+      }
+      for (int o = 0; o < outputs.size(); ++o) {
+        if (prohibit_clear[o] || outputs[o]->persistent()) {
+          continue;
+        }
+        if (clear[o].first) {
+          outputs[o]->variable()->data()->array()->clear();
+        }
+        if (clear[o].second) {
+          outputs[o]->variable()->grad()->array()->clear();
+        }
+      }
+    }
+  }
+
+  // Get first visit flags and prohibit clear flags;
+  // The prohibit clear flags are set by query_input_flags function with inputs
+  // of a previously called function.
+  pair<vector<bool>, vector<bool>>
+  query_outputs_flags(const vector<CgVariablePtr> &outputs) {
+    vector<bool> first_visit(outputs.size());
+    vector<bool> prohibit_clear(outputs.size());
+    for (int i = 0; i < outputs.size(); i++) {
+      auto v = outputs[i];
+      auto it = vseen_.find(v);
+      bool first = it == vseen_.end();
+      if (first) { // first visit
+        // Terminal variable always doesn't allow to clear buffers.
+        prohibit_clear[i] = true;
+      } else {
+        // Propagte prohibit_clear_inputs_buffers flag from the previous seen
+        // inputs.
+        prohibit_clear[i] = it->second;
+      }
+      first_visit[i] = first;
+    }
+    return {first_visit, prohibit_clear};
+  }
+
+  vector<bool> query_input_flags(const vector<CgVariablePtr> &inputs,
+                                 CgFunctionPtr func) {
+    vector<bool> ret(inputs.size());
+    bool prohibit_clear = func->function()->prohibit_clear_input_buffers();
+    for (int i = 0; i < ret.size(); i++) {
+      auto v = inputs[i];
+      auto it = vseen_.find(v);
+      bool first_visit = it == vseen_.end();
+      ret[i] = first_visit;
+      if (first_visit) {
+        vseen_.insert({v, prohibit_clear});
+        continue;
+      }
+      // Prohibits clearing if any of previous function prohibits clearing
+      // inputs.
+      it->second |= prohibit_clear;
+    }
+    return ret;
+  }
+
+public:
+  BackwardCallback(CgFunctionPtr f, bool clear_buffer)
+      : clear_buffer_(clear_buffer) {
+    // Note prohibiting clearing variable buffers where terminal.
+    for (auto o : f->outputs()) {
+      vseen_.insert({o, true});
+    }
+  }
+
+  void operator()(CgFunctionPtr f) {
+    // Check accumulation.
+    const auto inputs = f->inputs();
+    auto first_visit_flags = query_input_flags(inputs, f);
+    auto accum = get_accum(inputs, first_visit_flags);
+
+    // Get output variables
+    vector<CgVariablePtr> outputs;
+    vector<Variable *> voutputs;
+    std::tie(outputs, voutputs) = f->function_outputs();
+
+    // Query output flags according to previous trace history.
+    vector<bool> output_first_visit_flags;
+    vector<bool> output_prohibit_clear;
+    std::tie(output_first_visit_flags, output_prohibit_clear) =
+        query_outputs_flags(outputs);
+
+    // Check if any of outputs is unseen.
+    force_zero_grad_if_unseen(outputs, output_first_visit_flags);
+
+    // Call backward function
+    vector<bool> prop_down(accum.size());
+    std::transform(inputs.begin(), inputs.end(), prop_down.begin(),
+                   [](CgVariablePtr v) { return v->need_grad(); });
+    // std::cout << f->function()->name() << std::endl;
+    // std::cout << "  " << string_join(prop_down, ",") << std::endl;
+    // std::cout << "  " << string_join(accum, ",") << std::endl;
+    f->function()->backward(f->function_inputs(), voutputs, prop_down, accum);
+
+    // Clear outputs buffer
+    clear_output_buffers(f, output_prohibit_clear);
+  }
+};
+
+void CgVariable::visit_function_recursive(
+    CgFunctionPtr func, unordered_set<CgFunctionPtr> &fclosed,
+    std::function<void(CgFunctionPtr)> forward_callback) {
+
+  // A. Push the function to the closed list.
+  fclosed.insert(func);
+
+  // B. Open all inputs of the function.
+  int max_rank = 0;       // 0 if no inputs in this function.
+  bool need_grad = false; // No inputs not require grad
+  auto inputs = func->inputs();
+  for (auto input : inputs) {
+    auto parent = input->parent();
+
+    // B-1. Input with no parent doesn't require
+    if (!parent) {
+      // Same as B-3.
+      input->set_rank(0);
+      // Same as B-4.
+      max_rank = std::max(0, max_rank);
+      need_grad |= input->need_grad();
+      continue;
+    }
+
+    // B-2. Visit functions recursively if parent is not closed.
+    if (fclosed.find(parent) == fclosed.end()) {
+      visit_function_recursive(parent, fclosed, forward_callback);
+    }
+
+    // B-3. Update rank and need_grad of this input by propagating from the
+    // parent function (backward with a rewired graph requires this).
+    input->set_rank(parent->rank());
+    input->set_need_grad(parent->need_grad());
+
+    // B-4. Aggregate rank and need_grad from inputs for func.
+    max_rank = std::max(parent->rank(), max_rank);
+    need_grad |= input->need_grad();
+  }
+
+  // C. Update rank and need_grad of func (backward with a rewired graph
+  // requires this).
+  func->set_need_grad(need_grad); // This must be done before calling callback
+                                  // because the callback may use this.
+  func->set_rank(++max_rank);     // Increment rank at function.
+
+  // D. Call callback function at this function.
+  forward_callback(func);
+  // std::cout << max_rank << " " << func->function()->name() << " " <<
+  // func.get() << std::endl;
+}
+
+void CgVariable::visit_function_backward(
+    CgFunctionPtr p, std::function<void(CgFunctionPtr)> backward_callback,
+    vector<CommunicatorBackwardCallbackPtr> communicator_callbacks) {
+  // Open list of next search candidate.
+  unordered_map<CgFunctionPtr, uint64_t> ids;
   /* Returns the ID for each function (layer) */
   auto get_id = [&ids](const CgFunctionPtr &ptr) -> uint64_t {
     auto it = ids.find(ptr);
@@ -177,108 +352,85 @@ void CgVariable::backward(
       auto id = ids.size();
       ids.insert({ptr, id});
       return id;
-    } else {
-      /* Return the previous ID if the ID is already assigned */
-      return it->second;
     }
+    /* Return the previous ID if the ID is already assigned */
+    return it->second;
   };
-
-  cand.insert(make_tuple(-p->rank(), get_id(p), p));
-  while (!cand.empty()) {
-    auto rank_func = *cand.begin();
-    auto f = get<2>(rank_func);
-    cand.erase(cand.begin());
+  set<tuple<int, uint64_t, CgFunctionPtr>> open;
+  open.insert(make_tuple(-p->rank(), get_id(p), p));
+  while (!open.empty()) {
+    auto rank_func = open.begin();
+    auto f = get<2>(*rank_func);
+    DestructorCallback at_scope_exit([&]() { open.erase(rank_func); });
+    // std::cout << "size: " << open.size();
+    // std::cout << " --> " << open.size() << std::endl;
     if (!f->need_grad())
       continue;
-    auto outputs_shared = f->function_outputs_shared();
 
-    // Check accumulation.
-    const auto inputs = f->inputs();
-    vector<bool> accum(inputs.size(), false);
-    for (int i = 0; i < inputs.size(); i++) {
-      // No need grad.
-      if (!inputs[i]->variable()->need_grad())
-        continue;
+    // Callback
+    backward_callback(f);
+    // std::cout << (int)(get<1>(*rank_func)) << ": " << f->rank() << " "
+    //           << f->function()->name() << " " << f.get() << " " <<
+    //           open.size()
+    //           << std::endl;
 
-      // Root variable is always accumulated.
-      if (!inputs[i]->parent()) {
-        accum[i] = true;
-        continue;
-      }
-      // Variable not referenced by another is always not accumulated.
-      if (inputs[i]->function_reference_count() < 2) {
-        continue;
-      }
-      // Search from previously found variables.
-      auto vb = inputs[i];
-      auto it = branch.find(vb);
-      if (it == branch.end()) {
-        // Init the variable consumption count (set one is consume).
-        vb->consume(true);
-        branch.insert(vb);
-        continue;
-      }
-      int c = vb->consume();
-      if (c == inputs[i]->function_reference_count()) {
-        branch.erase(it);
-      }
-      accum[i] = true;
-    }
-    // std::cout << "Accum of (" << f->function()->name() << "):";
-    // for (auto b : accum) std::cout << " " << b;
-    // std::cout << std::endl;
-
-    // std::cout << "Call backward of " << f->function()->name() << "."
-    // 	      << std::endl;
-    f->function()->backward(f->function_inputs(),
-                            as_pointer_array(outputs_shared), accum);
-    for (auto &callback : communicator_callbacks) {
-      callback->on_finish_function_backward(f);
-    }
-
-    // Clear outputs buffer
-    if (clear_buffer) {
-      auto outputs = f->outputs();
-      for (int o = 0; o < outputs.size(); ++o) {
-        if (outputs[o]->clear_data_in_backward() && !outputs[o]->persistent()) {
-          // std::cout << "Clearing " << o << "-th output data of '"
-          // 	    << f->function()->name() << "'@" << f->rank()
-          // 	    << "." << std::endl;
-          outputs[o]->variable()->data()->array()->clear();
-        }
-        // else {
-        //   std::cout << "Not Clearing " << o << "-th output data of '"
-        // 	    << f->function()->name() << "'@" << f->rank()
-        // 	    << "." << std::endl;
-        // }
-
-        if (outputs[o]->clear_grad_in_backward() && !outputs[o]->persistent()) {
-          // std::cout << "Clearing " << o << "-th output grad of '"
-          // 	    << f->function()->name() << "'@" << f->rank()
-          // 	    << "." << std::endl;
-          outputs[o]->variable()->grad()->array()->clear();
-        }
-        // else {
-        //   std::cout << "Not Clearing " << o << "-th output grad of '"
-        // 	    << f->function()->name() << "'@" << f->rank()
-        // 	    << "." << std::endl;
-        // }
-      }
+    //
+    for (auto &com_callback : communicator_callbacks) {
+      com_callback->on_finish_function_backward(f);
     }
 
     // Propagate down.
-    for (auto inp : inputs) {
-      if (!inp->variable()->need_grad())
+    auto inputs = f->inputs();
+    for (int i = 0; i < f->num_inputs(); i++) {
+      auto inp = inputs[i];
+      if (!inp->need_grad())
         continue;
       auto p_i = inp->parent();
       if (!p_i)
         continue;
-      cand.insert(make_tuple(-p_i->rank(), get_id(p_i), p_i));
+      open.insert(make_tuple(-p_i->rank(), get_id(p_i), p_i));
     }
   }
 
-  for (auto &callback : communicator_callbacks) {
-    callback->on_finish_backward();
+  for (auto &com_callback : communicator_callbacks) {
+    com_callback->on_finish_backward();
   }
+}
+
+void CgVariable::forward(bool clear_buffer, bool clear_no_need_grad) {
+  NBLA_CHECK(parent_, error_code::value, "The variable has no parent.");
+  unordered_set<CgFunctionPtr> fclosed;
+  ForwardCallback forward_callback(clear_buffer, clear_no_need_grad);
+  visit_function_recursive(
+      parent_, fclosed,
+      [&forward_callback](CgFunctionPtr f) { forward_callback(f); });
+}
+
+void CgVariable::backward(
+    NdArrayPtr grad, bool clear_buffer,
+    vector<CommunicatorBackwardCallbackPtr> communicator_callbacks) {
+  NBLA_CHECK(parent_, error_code::value, "The variable has no parent.");
+  NBLA_CHECK(!this->grad_inplaced_, error_code::value,
+             "Backward can not be called at a variable in which grad array is "
+             "in-placed. The grad array is in-placed by '%s' (depth=%d).",
+             parent_->function()->name().c_str(), parent_->rank());
+
+  // Scoped context.
+  // Set flags used during backward of this variable to avoid clearing
+  // buffer. Also, set the grad array passed as an argument.
+  NdArrayPtr bak_grad = this->variable()->grad();
+  DestructorCallback at_scope_exit(
+      [&]() { this->variable()->set_grad(bak_grad); });
+  if (grad) {
+    this->variable()->set_grad(grad);
+  }
+
+  // Create callback
+  BackwardCallback backward_callback(parent_, clear_buffer);
+
+  // Visit backward
+  visit_function_backward(
+      parent_, [&backward_callback](CgFunctionPtr f) { backward_callback(f); },
+      communicator_callbacks);
 }
 }

--- a/src/nbla/function.cpp
+++ b/src/nbla/function.cpp
@@ -111,21 +111,14 @@ void Function::forward(const Variables &inputs, const Variables &outputs) {
 }
 
 void Function::backward(const Variables &inputs, const Variables &outputs,
+                        const vector<bool> &propagate_down,
                         const vector<bool> &accum) {
   if (fall_back_func_) {
     // Fall back to the specified Function.
-    fall_back_func_->backward(inputs, outputs, accum);
+    fall_back_func_->backward(inputs, outputs, propagate_down, accum);
     return;
   }
   check_shapes(this, inputs, outputs, in_shapes, out_shapes);
-  vector<bool> propagate_down(inputs.size());
-  transform(inputs.begin(), inputs.end(), propagate_down.begin(),
-            [](Variable *v) { return v->need_grad(); });
-  NBLA_CHECK(accum.size() == propagate_down.size(), error_code::value,
-             "The size of the flags of accumulation gradient must be equal to "
-             "the number of inputs (%d != %d). Error in '%s'.",
-             accum.size(), propagate_down.size(), this->name().c_str());
-
   // Always zero-ing gradient buffer when accum is false.
   // NNabla's backward implementation takes an accum flag for each input
   // variable. An accum flag is automatically determined by our graph engine.

--- a/src/nbla/function/generic/binary_connect_convolution.cpp
+++ b/src/nbla/function/generic/binary_connect_convolution.cpp
@@ -79,36 +79,26 @@ void BinaryConnectConvolution<T>::forward_impl(const Variables &inputs,
 }
 
 template <class T>
-void BinaryConnectConvolution<T>::backward_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &propagate_down, const vector<bool> &accum) {
-
-  if (propagate_down[1]) {
-    // reset `grad` part of binary weights to zero
-    // inputs[2]->grad()->zero();
-
-    // set `need_grad` to true for binary weights
-    inputs[2]->set_need_grad(true);
-  } else {
-    // set `need_grad` to false for binary weights
-    inputs[2]->set_need_grad(false);
-  }
+void BinaryConnectConvolution<T>::backward_impl(const Variables &inputs,
+                                                const Variables &outputs,
+                                                const vector<bool> &prop_down,
+                                                const vector<bool> &accum) {
 
   // calculate the backward pass using the already binarized weights
   if (inputs.size() == 4) { // with bias
     convolution_->backward(Variables{inputs[0], inputs[2], inputs[3]}, outputs,
+                           {prop_down[0], prop_down[1], prop_down[3]},
                            {accum[0], false, accum[3]});
   } else { // without bias
     convolution_->backward(Variables{inputs[0], inputs[2]}, outputs,
-                           {accum[0], false});
+                           {prop_down[0], prop_down[1]}, {accum[0], false});
   }
-
+  if (!prop_down[1]) {
+    return;
+  }
   // add the calculated gradient wrt the binary weights from inputs[2] to
   // inputs[1]
-  sign_->backward(Variables{inputs[1]}, Variables{inputs[2]}, {accum[1]});
-
-  inputs[2]->set_need_grad(
-      false); // reset `need_grad` to false as we do not need
-              // backward for binary variables
+  sign_->backward(Variables{inputs[1]}, Variables{inputs[2]}, {prop_down[1]},
+                  {accum[1]});
 }
 }

--- a/src/nbla/function/generic/binary_weight_affine.cpp
+++ b/src/nbla/function/generic/binary_weight_affine.cpp
@@ -124,23 +124,25 @@ void BinaryWeightAffine<T>::forward_impl(const Variables &inputs,
 template <typename T>
 void BinaryWeightAffine<T>::backward_impl(const Variables &inputs,
                                           const Variables &outputs,
-                                          const vector<bool> &propagate_down,
+                                          const vector<bool> &prop_down,
                                           const vector<bool> &accum) {
-  scaled_weights_.set_need_grad(propagate_down[1]);
-
   // calculate the backward pass using the binarized scaled weights
   if (inputs.size() == 5) { // with bias
     affine_->backward(Variables{inputs[0], &scaled_weights_, inputs[4]},
-                      outputs, {accum[0], false, accum[4]});
+                      outputs, {prop_down[0], prop_down[1], prop_down[4]},
+                      {accum[0], false, accum[4]});
   } else { // without bias
     affine_->backward(Variables{inputs[0], &scaled_weights_}, outputs,
-                      {accum[0], false});
+                      {prop_down[0], prop_down[1]}, {accum[0], false});
   }
-
+  if (!prop_down[1]) {
+    return;
+  }
   // add the calculated gradient w.r.t. the binary weights from
   // scaled_weights_ to inputs[1]
   bin_->setup(Variables{inputs[1]}, Variables{&scaled_weights_});
-  bin_->backward(Variables{inputs[1]}, Variables{&scaled_weights_}, {accum[1]});
+  bin_->backward(Variables{inputs[1]}, Variables{&scaled_weights_},
+                 {prop_down[1]}, {accum[1]});
 }
 
 } // namespace nbla

--- a/src/nbla/function/generic/constant.cpp
+++ b/src/nbla/function/generic/constant.cpp
@@ -27,7 +27,6 @@ void Constant<T>::setup_impl(const Variables &inputs,
                              const Variables &outputs) {
   Shape_t out_shape(shape_.begin(), shape_.end());
   outputs[0]->reshape(out_shape, true);
-  outputs[0]->set_need_grad(false);
 }
 
 template <typename T>

--- a/src/nbla/function/generic/inq_affine.cpp
+++ b/src/nbla/function/generic/inq_affine.cpp
@@ -200,15 +200,16 @@ void INQAffine<T, T1>::forward_impl(const Variables &inputs,
 template <typename T, typename T1>
 void INQAffine<T, T1>::backward_impl(const Variables &inputs,
                                      const Variables &outputs,
-                                     const vector<bool> &propagate_down,
+                                     const vector<bool> &prop_down,
                                      const vector<bool> &accum) {
   // Calculate the backward pass
   if (inputs.size() == 4) { // with bias
     affine_->backward(Variables{inputs[0], inputs[1], inputs[3]}, outputs,
+                      {prop_down[0], prop_down[1], prop_down[3]},
                       {accum[0], accum[1], accum[3]});
   } else { // without bias
     affine_->backward(Variables{inputs[0], inputs[1]}, outputs,
-                      {accum[0], accum[1]});
+                      {prop_down[0], prop_down[1]}, {accum[0], accum[1]});
   }
 }
 

--- a/src/nbla/function/generic/inq_convolution.cpp
+++ b/src/nbla/function/generic/inq_convolution.cpp
@@ -203,15 +203,16 @@ void INQConvolution<T, T1>::forward_impl(const Variables &inputs,
 template <typename T, typename T1>
 void INQConvolution<T, T1>::backward_impl(const Variables &inputs,
                                           const Variables &outputs,
-                                          const vector<bool> &propagate_down,
+                                          const vector<bool> &prop_down,
                                           const vector<bool> &accum) {
   // Calculate the backward pass
   if (inputs.size() == 4) { // with bias
     convolution_->backward(Variables{inputs[0], inputs[1], inputs[3]}, outputs,
+                           {prop_down[0], prop_down[1], prop_down[3]},
                            {accum[0], accum[1], accum[3]});
   } else { // without bias
     convolution_->backward(Variables{inputs[0], inputs[1]}, outputs,
-                           {accum[0], accum[1]});
+                           {prop_down[0], prop_down[1]}, {accum[0], accum[1]});
   }
 }
 

--- a/src/nbla/function/generic/max.cpp
+++ b/src/nbla/function/generic/max.cpp
@@ -23,7 +23,7 @@ template <typename T>
 void Max<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   Sum<T>::setup_impl(inputs, outputs);
   int outer_size = inputs[0]->size() / this->reduction_size_;
-  index_buff_ = make_shared<Variable>(Shape_t{outer_size}, false);
+  index_buff_ = make_shared<Variable>(Shape_t{outer_size});
 }
 
 template <typename T>

--- a/src/nbla/function/generic/prod.cpp
+++ b/src/nbla/function/generic/prod.cpp
@@ -32,9 +32,9 @@ void Prod<T>::forward_impl_reduce(const T *x, T *y, int outer_size,
 
 template <typename T>
 void Prod<T>::backward_impl(const Variables &inputs, const Variables &outputs,
-                            const vector<bool> &propagate_down,
+                            const vector<bool> &prop_down,
                             const vector<bool> &accum) {
-  if (!propagate_down[0])
+  if (!prop_down[0])
     return;
   auto _get = [this](Variable *v) {
     return v->get_data_pointer<T>(this->ctx_);
@@ -55,7 +55,7 @@ void Prod<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   if (!this->f_transpose_)
     return;
   this->f_transpose_->backward(inputs, Variables{this->o_transpose_.get()},
-                               {accum[0]});
+                               prop_down, {accum[0]});
 }
 
 template <typename T>

--- a/src/nbla/function/generic/rand.cpp
+++ b/src/nbla/function/generic/rand.cpp
@@ -27,7 +27,6 @@ NBLA_REGISTER_FUNCTION_SOURCE(Rand, float, float, const vector<int> &, int);
 template <typename T>
 void Rand<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   outputs[0]->reshape(Shape_t(shape_.cbegin(), shape_.cend()), true);
-  outputs[0]->set_need_grad(false);
   rgen_ = std::mt19937((seed_ == -1 ? std::random_device()() : seed_));
 }
 

--- a/src/nbla/function/generic/randint.cpp
+++ b/src/nbla/function/generic/randint.cpp
@@ -27,7 +27,6 @@ NBLA_REGISTER_FUNCTION_SOURCE(Randint, int, int, const vector<int> &, int);
 template <typename T>
 void Randint<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   outputs[0]->reshape(Shape_t(shape_.cbegin(), shape_.cend()), true);
-  outputs[0]->set_need_grad(false);
   rgen_ = std::mt19937((seed_ == -1 ? std::random_device()() : seed_));
 }
 

--- a/src/nbla/function/generic/randn.cpp
+++ b/src/nbla/function/generic/randn.cpp
@@ -27,7 +27,6 @@ NBLA_REGISTER_FUNCTION_SOURCE(Randn, float, float, const vector<int> &, int);
 template <typename T>
 void Randn<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   outputs[0]->reshape(Shape_t(shape_.cbegin(), shape_.cend()), true);
-  outputs[0]->set_need_grad(false);
   rgen_ = std::mt19937((seed_ == -1 ? std::random_device()() : seed_));
 }
 

--- a/src/nbla/imperative.cpp
+++ b/src/nbla/imperative.cpp
@@ -41,7 +41,7 @@ vector<NdArrayPtr> execute(FunctionPtr func, const vector<NdArrayPtr> &inputs,
   vector<VariablePtr> vinputs(inputs.size());
   vector<VariablePtr> voutputs(outputs.size());
   for (int i = 0; i < inputs.size(); ++i) {
-    vinputs[i] = make_shared<Variable>(inputs[i], false);
+    vinputs[i] = make_shared<Variable>(inputs[i]);
   }
   for (int i = 0; i < n_outputs; ++i) {
     voutputs[i] = make_shared<Variable>();

--- a/src/nbla/test/test_relu.cpp
+++ b/src/nbla/test/test_relu.cpp
@@ -62,6 +62,6 @@ TEST_F(ReLUTest, ForwardBackward) {
   relu->setup(Variables{in_.get()}, Variables{out_.get()});
   ASSERT_EQ(in_->shape(), out_->shape());
   relu->forward(Variables{in_.get()}, Variables{out_.get()});
-  relu->backward(Variables{in_.get()}, Variables{out_.get()}, {false});
+  relu->backward(Variables{in_.get()}, Variables{out_.get()}, {true}, {false});
 }
 }

--- a/src/nbla/test/test_variable.cpp
+++ b/src/nbla/test/test_variable.cpp
@@ -53,9 +53,6 @@ TEST_F(VariableManipTest, Properties) {
     }
     ASSERT_EQ(size, var_->size(i));
   }
-  ASSERT_FALSE(var_->need_grad());
-  var_->set_need_grad(true);
-  ASSERT_TRUE(var_->need_grad());
 }
 
 TEST_F(VariableManipTest, CastData) {

--- a/src/nbla/variable.cpp
+++ b/src/nbla/variable.cpp
@@ -29,19 +29,17 @@ void Variable::update_shape_info() {
   ndim_ = shape_.size();
 }
 
-Variable::Variable(const Shape_t &shape, bool need_grad) : shape_(shape) {
+Variable::Variable(const Shape_t &shape) : shape_(shape) {
   update_shape_info();
   data_.reset(new NdArray(shape_));
   grad_.reset(new NdArray(shape_));
-  set_need_grad(need_grad);
 }
 
-Variable::Variable(NdArrayPtr data, bool need_grad) {
+Variable::Variable(NdArrayPtr data) {
   shape_ = data->shape();
   update_shape_info();
   data_ = data;
   grad_.reset(new NdArray(shape_));
-  set_need_grad(need_grad);
 }
 
 void Variable::reshape(const vector<int64_t> &shape, bool force) {
@@ -65,10 +63,8 @@ void Variable::reshape(const vector<int64_t> &shape, bool force) {
   grad_->reshape(shape_, true);
 }
 
-void Variable::set_need_grad(bool need_grad) { need_grad_ = need_grad; }
-
 VariablePtr Variable::view() {
-  auto v = make_shared<Variable>(shape_, need_grad_);
+  auto v = make_shared<Variable>(shape_);
   v->set_data(data_);
   v->set_grad(grad_);
   return v;
@@ -80,7 +76,7 @@ VariablePtr Variable::view(const Shape_t &shape) {
              "The total size must be the same as the variable. "
              "Given: %d != current: %d.",
              size, size_);
-  auto v = make_shared<Variable>(shape, need_grad_);
+  auto v = make_shared<Variable>(shape_);
   v->set_data(data_->view(shape));
   v->set_grad(grad_->view(shape));
   return v;

--- a/src/nbla_utils/nnp_impl.cpp
+++ b/src/nbla_utils/nnp_impl.cpp
@@ -731,7 +731,7 @@ bool NnpImpl::save_parameters(const string &filename) {
 
     Parameter *parameter = params.add_parameter();
     parameter->set_variable_name(name);
-    parameter->set_need_grad(variable->need_grad());
+    parameter->set_need_grad(it->second->need_grad());
 
     float *data = variable->template cast_data_and_get_pointer<float>(kCpuCtx);
     for (int i = 0; i < variable->size(); i++)

--- a/src/nbla_utils/nnp_impl.cpp
+++ b/src/nbla_utils/nnp_impl.cpp
@@ -116,7 +116,7 @@ NetworkImpl::get_cgvariable_or_create(const string &name) {
     shape[0] = batch_size();
   }
   // TODO: set need_grad
-  auto cg_v = std::make_shared<nbla::CgVariable>(shape, false);
+  auto cg_v = std::make_shared<nbla::CgVariable>(shape);
   // Register variable
   variables_.insert({name, cg_v});
   return cg_v;
@@ -251,7 +251,7 @@ bool NnpImpl::parse_hdf5_dataset(std::string name, hid_t did) {
   if (err >= 0) {
     Shape_t shape(dims, dims + rank);
     // TODO: Set need_grad.
-    CgVariablePtr cg_v = std::make_shared<CgVariable>(shape, false);
+    CgVariablePtr cg_v = std::make_shared<CgVariable>(shape);
     float *data =
         cg_v->variable()->template cast_data_and_get_pointer<float>(kCpuCtx);
     for (int i = 0; i < size / sizeof(float); i++) {

--- a/src/nbla_utils/nnp_impl.cpp
+++ b/src/nbla_utils/nnp_impl.cpp
@@ -58,10 +58,13 @@ void NetworkImpl::build() {
     NBLA_LOG_INFO("      function name:{} type:{}", func.name(), func.type());
 
     std::vector<nbla::CgVariablePtr> finputs;
+    // std::cout << func.name() << ":";
     for (auto inp = func.input().begin(); inp != func.input().end(); inp++) {
+      // std::cout << " " << *inp;
       CgVariablePtr cg_v = get_cgvariable_or_create(*inp);
       finputs.push_back(cg_v);
     }
+
     auto cgfunc = create_cgfunction(func);
 
     if (cgfunc.get() == nullptr) {
@@ -70,24 +73,26 @@ void NetworkImpl::build() {
                  "Function [%s] is not supported yet", func.name().c_str());
     }
 
-    std::vector<nbla::CgVariablePtr> f_tmp_outputs;
+    // Create a graph connection.
+    auto foutputs = nbla::connect(cgfunc, finputs, func.output_size());
+
+    // Insert or rewire.
+    // std::cout << " -->";
     for (int j = 0; j < func.output_size(); j++) {
+      // std::cout << " " << func.output(j);
       auto it = variables_.find(func.output(j));
       if (it != variables_.end()) {
+        // Rewire the output to an exisiting variable.
+        // std::cout << "(r)";
         CgVariablePtr cg_v = get_cgvariable_or_create(func.output(j));
-        cg_v->set_parent(cgfunc);
-        f_tmp_outputs.push_back(cg_v);
-      }
-    }
-    // TODO: It may dangerous if output  variable exists.
-    if (f_tmp_outputs.size() == 0) {
-      auto foutputs = nbla::connect(cgfunc, finputs, func.output_size());
-      for (int j = 0; j < func.output_size(); j++) {
+        steal_variable_from_to(foutputs[j], cg_v);
+      } else {
+        // Regiser a newly created variable
+        // std::cout << "(c)";
         variables_.insert({func.output(j), foutputs[j]});
       }
-    } else {
-      nbla::connect(cgfunc, finputs, f_tmp_outputs);
     }
+    // std::cout << std::endl;
   }
 }
 
@@ -116,6 +121,7 @@ NetworkImpl::get_cgvariable_or_create(const string &name) {
     shape[0] = batch_size();
   }
   // TODO: set need_grad
+  // std::cout << "(c)";
   auto cg_v = std::make_shared<nbla::CgVariable>(shape);
   // Register variable
   variables_.insert({name, cg_v});
@@ -719,7 +725,7 @@ vector<pair<string, VariablePtr>> NnpImpl::get_parameters() {
 bool NnpImpl::save_parameters(const string &filename) {
   std::ofstream ofs(filename.c_str());
   if (!ofs.is_open()) {
-    std::cout << "Error in opening file";
+    // std::cout << "Error in opening file";
     return false;
   }
 


### PR DESCRIPTION
Important changes:

* Revert back the in-place flags in `Reshape` function. 
* `bool Variable::need_grad_` is moved to `CgVariable` as `enum CgVariable::NeedGrad`.
* Introduce a new concept `need_grad_state` to `CgVariable`. `need_grad` is a flag set by user to a specific variable to enforce gradient computation requirement, while `need_grad_state` is calculated by our graph engine during graph construction, and dynamically during forward propagation as well.   
* Graph connection can be rewired after a graph constructed by `Variable.rewire_on` in Python or `steal_variable_from_to` in C++.
* If required, setup is called during forward propagation rather than only during connect. 
* I checked the replacement didn't affect speed performance of graph execution.