### PR TITLE
Truncated back propagation through time (BPTT) in dynamic networks

### DIFF
--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -27,6 +27,7 @@ namespace nbla {
 
 using std::unordered_map;
 using std::unordered_set;
+using std::string;
 
 // Forward declaration
 class CgFunction;
@@ -67,6 +68,7 @@ class CgVariable {
       function_references_;
   bool allow_modify_data_{true}; ///< Whether the data can be in-placed.
   bool persistent_{false};       ///<Persistency flag against clearing.
+  string name_{""};
 
   void
   visit_function_recursive(CgFunctionPtr func,
@@ -271,6 +273,14 @@ public:
   /** Get persistent flag.
    */
   inline bool persistent() const { return persistent_; }
+
+  /** Set variable name
+   */
+  inline void set_name(string name) { name_ = name; }
+
+  /** Get variable name
+   */
+  inline string name() const { return name_; }
 };
 
 /** shared_ptr typedef of CGVariable

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -243,6 +243,11 @@ public:
    */
   void insert_function_reference(CgFunctionPtr func);
 
+  /**
+   */
+  NBLA_API
+  void remove_function_reference(CgFunction *funcp);
+
   /** Mark need_setup flag for all function references.
    */
   void mark_need_setup();

--- a/python/src/nnabla/_variable.pxd
+++ b/python/src/nnabla/_variable.pxd
@@ -71,6 +71,7 @@ cdef extern from "nbla/computation_graph/variable.hpp" namespace "nbla":
         cpp_bool persistent()
         string name() except +
         void set_name(string name) except +
+        void remove_function_reference(CgFunction * func) except+
     ctypedef shared_ptr[CgVariable] CgVariablePtr
 
 cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":

--- a/python/src/nnabla/_variable.pxd
+++ b/python/src/nnabla/_variable.pxd
@@ -32,7 +32,7 @@ cdef extern from "nbla/variable.hpp" namespace "nbla":
         Size_t ndim()
         void reshape(Shape_t, cpp_bool) except +
         shared_ptr[CVariable] view() except +
-        shared_ptr[CVariable] view(const Shape_t &) except +
+        shared_ptr[CVariable] view(const Shape_t & ) except +
         NdArrayPtr data() except +
         NdArrayPtr grad() except +
         void set_data(NdArrayPtr) except +
@@ -84,7 +84,7 @@ cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":
         int rank() const
         void set_outputs(const vector[CgVariablePtr] & outputs) except+
         const vector[CgVariablePtr] inputs()
-        vector[CVariable * ] function_inputs() except+
+        vector[CVariable *] function_inputs() except+
         vector[VariablePtr] function_outputs_shared() except+
         string info() const
         void set_info(const string & info)

--- a/python/src/nnabla/_variable.pxd
+++ b/python/src/nnabla/_variable.pxd
@@ -69,6 +69,8 @@ cdef extern from "nbla/computation_graph/variable.hpp" namespace "nbla":
         void backward(NdArrayPtr grad, cpp_bool clear_buffer, vector[CommunicatorBackwardCallbackPtr] communicator_callbacks) nogil except+
         void set_persistent(cpp_bool b)
         cpp_bool persistent()
+        string name() except +
+        void set_name(string name) except +
     ctypedef shared_ptr[CgVariable] CgVariablePtr
 
 cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -196,7 +196,7 @@ cdef class Variable:
         '''
         if op == 2:
             try:
-                return ( < Variable > self).varp == ( < Variable ?> other).varp
+                return (< Variable > self).varp == ( < Variable ?> other).varp
             except:
                 return False
         elif op == 3:
@@ -206,7 +206,8 @@ cdef class Variable:
     def __hash__(self):
         '''Returns hash of the integer address of holding C++ object.
         '''
-        return hash( < intptr_t > (( < Variable > self).varp))
+        return hash(< intptr_t > (( < Variable > self).varp))
+
     def apply(self, **kwargs):
         '''Helper for setting property, then return self.
         '''
@@ -303,7 +304,7 @@ cdef class Variable:
             var = Variable.create_from_cvariable(
                 self.varp.variable().get().view(shape))
             if self.varp.need_grad_is_set():
-                ( < Variable > var).varp.set_need_grad(self.varp.need_grad())
+                (< Variable > var).varp.set_need_grad(self.varp.need_grad())
             return var
         from nnabla.functions import reshape
         return reshape(self, shape)
@@ -358,7 +359,7 @@ cdef class Variable:
                 ya.backward()
 
         '''
-        steal_variable_from_to((< Variable?> var).var, self.var)
+        steal_variable_from_to(( < Variable?> var).var, self.var)
 
     @property
     def data(self):
@@ -458,7 +459,7 @@ cdef class Variable:
 
     @parent.setter
     def parent(self, func):
-        cdef CgFunctionPtr cg_func = ( < function.Function ?> func).fun
+        cdef CgFunctionPtr cg_func = (< function.Function ?> func).fun
         assert cg_func, "TODO"
         self.varp.set_parent(cg_func)
 
@@ -514,25 +515,25 @@ cdef class Variable:
         elif np.isscalar(grad):
             arr = NdArray(self.shape)
             arr.fill(grad)
-            p = (< NdArray > arr).arr
+            p = ( < NdArray > arr).arr
         elif isinstance(grad, NdArray):
-            p = (< NdArray > grad).arr
+            p = ( < NdArray > grad).arr
         elif isinstance(grad, np.ndarray):
             arr = NdArray(grad.shape)
             arr.data = grad
-            p = (< NdArray > arr).arr
+            p = ( < NdArray > arr).arr
         else:
             # Try to interpret as scalar value
             arr = NdArray()
             arr.data = grad
-            p = (< NdArray > arr).arr
+            p = ( < NdArray > arr).arr
 
         cdef vector[CommunicatorBackwardCallbackPtr] callback_list
         if type(communicator_callbacks) == list:
             for x in communicator_callbacks:
-                callback_list.push_back(( < CommunicatorBackwardCallback?> x).var)
+                callback_list.push_back((< CommunicatorBackwardCallback?> x).var)
         elif type(communicator_callbacks) != type(None):
-            callback_list.push_back(( < CommunicatorBackwardCallback?> communicator_callbacks).var)
+            callback_list.push_back((< CommunicatorBackwardCallback?> communicator_callbacks).var)
 
         with nogil:
             self.varp.backward(p, clear_buffer, callback_list)
@@ -582,7 +583,7 @@ cdef class Variable:
         if need_grad is not None:
             self.need_grad = need_grad
         elif self.varp.need_grad_is_set():
-            ( < Variable > var).varp.set_need_grad(self.varp.need_grad())
+            (< Variable > var).varp.set_need_grad(self.varp.need_grad())
         return var
 
     @property

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -533,6 +533,16 @@ cdef class Variable:
 
     def unlinked(self, need_grad=None):
         """
+        This function is `deprecated`, use get_unlinked_variable instead.
+        """
+        import nnabla as nn
+        nn.logger.warn(
+            "This function is `deprecated`, use get_unlinked_variable instead.")
+
+        return self.get_unlinked_variable(need_grad)
+
+    def get_unlinked_variable(self, need_grad=None):
+        """
         Gets an unlinked (forgetting parent) variable that shares a Variable buffer
         instance.
 

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -207,6 +207,12 @@ cdef class Variable:
         '''Returns hash of the integer address of holding C++ object.
         '''
         return hash( < intptr_t > (( < Variable > self).varp))
+    def apply(self, **kwargs):
+        '''Helper for setting property, then return self.
+        '''
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        return self
 
     @property
     def shape(self):

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -659,6 +659,25 @@ cdef class Variable:
         seen = set()
         return _recursive_visit_functions(self.parent, seen)
 
+    def clear_all_graph_links(self, ):
+        """Clear all intermediate functions and variables.
+
+        This method clear all intermediate functions and variables up to this variable 
+        in forward pass and is useful for the truncated backpropergation through time 
+        (truncated BPTT) in dynamic graph.
+        """
+        def _clear_all_graph_links(func):
+            for v in func.inputs:
+                v._clear_parent()
+            for v in func.outputs:
+                v._clear_parent()
+            func._clear_inputs()
+            func._clear_outputs()
+        self.visit(_clear_all_graph_links)
+
+    def _clear_parent(self, ):
+        self.varp.set_parent(< CgFunctionPtr?> NULL)
+
     def __pos__(self):
         return AOP.pos(self)
 

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -591,6 +591,14 @@ cdef class Variable:
     def persistent(self, cpp_bool b):
         self.varp.set_persistent(b)
 
+    @property
+    def name(self):
+        return self.varp.name()
+
+    @name.setter
+    def name(self, string name):
+        self.varp.set_name(name)
+
     def visit(self, f):
         '''Visit functions recursively in forward order.
 

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -59,6 +59,7 @@ cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":
         FunctionPtr function() const
         cpp_bool need_grad() const
         int rank() const
+        void set_inputs_(const vector[CgVariablePtr] &intpus) except+
         void set_outputs(const vector[CgVariablePtr] &outputs) except+
         vector[CgVariablePtr] inputs()
         vector[CgVariablePtr] outputs()

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -23,12 +23,13 @@
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp.memory cimport shared_ptr, make_shared
+from cython.operator cimport dereference
 from libcpp cimport bool as cpp_bool
 from libc.stdint cimport int64_t, intptr_t
 cimport function
 from function cimport CFunction, Variables, CgFunction
 cimport _variable
-from _variable cimport Variable as _Variable, CVariable, CContext
+from _variable cimport Variable as _Variable, CVariable, CgVariable, CContext
 from _nd_array cimport NdArray
 from _nd_array import NdArray
 from _imperative cimport *
@@ -280,8 +281,28 @@ cdef class Function:
                     return self._imperative_call(inputs, n_outputs, outputs)
         return self._cg_call(inputs, n_outputs, outputs, auto_forward)
 
+    def _clear_inputs(self):
+        """
+        """
+        inputs = self.funp.inputs()
+        cdef vector[CgVariablePtr] empty
+        self.funp.set_inputs_(empty)
         
+        # clear forward references also
+        cdef CgVariablePtr cgv
+        cdef CgFunction *funp 
+        for inp in inputs:
+            cgv = <CgVariablePtr>inp
+            funp = (<Function>self).funp
+            (<CgVariable>dereference(cgv)).remove_function_reference(funp)
+    
+    def _clear_outputs(self):
+      """
+      """
+      cdef vector[CgVariablePtr] empty
+      self.funp.set_outputs(empty)
 
+			
     """
     @property
     def in_types(self):

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -1839,7 +1839,7 @@ def lstm(x, h, c, state_size, w_init=None, b_init=None, fix_parameters=False):
 
 
 class LSTMCell:
-    def __init__(self, batch_size, state_size, h=None, c=None):
+    def __init__(self, batch_size, state_size, h=None, c=None, name=None):
         """
         Initializes an LSTM cell.
 
@@ -1848,10 +1848,11 @@ class LSTMCell:
             state_size (int): Internal state size is set to `state_size`.
             h (~nnabla.Variable): Input N-D array with shape (batch_size, state_size). If not specified, it is initialized to zero by default.
             c (~nnabla.Variable): Input N-D array with shape (batch_size, state_size). If not specified, it is initialized to zero by default.
-
+            name (str): Name for this LSTM Cell.
         """
         self.batch_size = batch_size
         self.state_size = state_size
+        self.name = name
         if h:  # when user defines h
             self.h = h
         else:
@@ -1883,5 +1884,7 @@ class LSTMCell:
 
         """
         self.h, self.c = lstm(
-            x, self.h, self.c, self.state_size, w_init, b_init, fix_parameters=fix_parameters)
+            x, self.h, self.c, self.state_size,
+            w_init, b_init,
+            fix_parameters=fix_parameters, name=self.name)
         return self.h

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -73,7 +73,7 @@ def test_data_grad():
     assert not np.all(v.d == v.g)
 
 
-def test_unlinked():
+def test_get_unlinked_variable():
     v = nn.Variable([2, 3, 4], need_grad=True)
     grad = np.random.randn(*v.shape).astype(np.float32)
     v.g = grad
@@ -81,7 +81,7 @@ def test_unlinked():
     import nnabla.functions as F
     with nn.context_scope(nn.Context()), nn.auto_forward():
         v2 = F.identity(v)
-        v2_u = v2.unlinked()
+        v2_u = v2.get_unlinked_variable()
         assert not v2_u.need_grad
         v2_u.need_grad = True
         v3 = F.identity(v2_u)

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -476,6 +476,13 @@ void CgVariable::insert_function_reference(CgFunctionPtr func) {
       {func.get(), {wp, CgVariable::FunctionReferenceInfo()}});
 }
 
+void CgVariable::remove_function_reference(CgFunction *funcp) {
+  auto it = function_references_.find(funcp);
+  if (it == function_references_.end())
+    return;
+  function_references_.erase(funcp);
+}
+
 void CgVariable::mark_need_setup() {
   for (auto it = function_references_.begin(); it != function_references_.end();
        it++) {


### PR DESCRIPTION
The following features are added

- Variable.name for naming a variable
- Varialbe.get_unlinked_variable re-named from Variable.unlinked (this remains for backward compatibility)
- LSTM API improvement with backward compatibility by adding `namescope` to the init function.
- __Truncated back propagation through time (`BPTT`) in `dynamic networks` using Variable.`clear_all_graph_links`__
- Helper method, `apply` for modifying property of Variable
