### PR TITLE
fix_parameters gives a Variable reference with a specified need_grad flag in parametric functions

### DIFF
--- a/doc/python/api/parametric_function.rst
+++ b/doc/python/api/parametric_function.rst
@@ -42,6 +42,20 @@ Like functions listed in :ref:`functions`, they take :obj:`~nnabla.Variable` (s)
 first argument(s) followed by options specific to a parametric function. In addition,
 they register parameter :obj:`~nnabla.Variable` (s) into the parameter scope.
 
+The parameter variables are registered with ``need_grad`` properties specific
+to a parametric function. The variables with ``need_grad=False`` flag will not
+be updated by gradient descent. Hence, backward computation is not executed for
+those variables. ``False`` is usually specified when the parameters are updated
+during foward pass and/or backward pass, e.g., batch normalization.
+
+All parametric functions take an optional argument ``fix_parameters=False``.
+By giving ``True``, the associated parameter variables are connected to a
+computation graph with a property ``need_grad=False`` regardless properties
+of the registered variables, then backward gradient
+computation is not executed for those variables. This is useful when you create
+a computation graph for evaluation purpose, fixing parameters partially in a
+graph, and so on.
+
 All parametric functions listed below are decorated with the following decorator.
 
 .. autofunction:: parametric_function_api

--- a/python/src/nnabla/parameter.py
+++ b/python/src/nnabla/parameter.py
@@ -151,7 +151,8 @@ def set_parameter(key, param):
     current_scope[names[0]] = param
 
 
-def get_parameter_or_create(name, shape=None, initializer=None, need_grad=True):
+def get_parameter_or_create(name, shape=None, initializer=None, need_grad=True,
+                            as_need_grad=None):
     """
     Returns an existing parameter variable with the provided name.
     If a variable with the provided name does not exist,
@@ -164,8 +165,18 @@ def get_parameter_or_create(name, shape=None, initializer=None, need_grad=True):
       shape (:obj:`tuple` of :obj:`int`): Shape of created parameter. The shape of the specified
           parameter must match with this shape. The default is None which is only valid if initializer is given as an :obj:`numpy.ndarray`.
       initializer (:obj:`nnabla.initializer.BaseInitializer` or :obj:`numpy.ndarray`): An initialization function to be applied to the parameter. :obj:`numpy.ndarray` can also be given to initialize parameters from numpy array data.
-      need_grad (bool): The value for `need_grad` .
-          The default is True.
+      need_grad (bool):
+          Register the parameter with the specified ``need_grad`` flag.
+          The default is True. If the flag is different from the previously
+          specified one, the flag will be overwritten, but the values will be
+          kept.
+      as_need_grad (bool):
+          Get a parameter variable with the specified ``need_grad`` flag.
+          Note that this doesn't overwrite the flag of the registered parameter
+          variable with the provided name. Instead, if the given flag
+          mismatches with the previously registered ``need_grad`` flag, it
+          returns a new variable referring to the same array contents but with
+          ``need_grad=as_need_grad``.
 
     """
     names = name.split('/')
@@ -198,8 +209,12 @@ def get_parameter_or_create(name, shape=None, initializer=None, need_grad=True):
     else:
         assert param.shape == tuple(shape)
         if need_grad != param.need_grad:
-            param = param.unlinked()
             param.need_grad = need_grad
+    if as_need_grad is None:
+        return param
+    if param.need_grad != as_need_grad:
+        param = param.unlinked()
+        param.need_grad = as_need_grad
     return param
 
 


### PR DESCRIPTION
The issue was when I created two models that shares parameters each other. I first created a model where all weight parameters are fixed by giving `fix_parameters=True` in all parametric functions. Then, I created a model where parameters are not fixed by `fix_parameters=False`. If we call `nn.get_parameters()` in this case, it returns nothing (this was what I didn't expect).
This sometimes happens, i.e., when we create a validation model where gradient descent is not performed earlier than a training model.
I decided to add a new option argument `as_need_grad` to `get_parameter_or_create`, which enables users to choose whether to fix or not to fix parameters in a temporary way. Consequently, `need_grad` option is used to specify a **permanent** `need_grad` property of a parameter variable, while `as_need_grad` is **temporary**.
I also modified all parametric functions to use `fix_parameters` as a temporary `need_grad` property, while permanent `need_grad` flags are embedded in the implementations of parametric functions.

The following changes are made;

* Add `as_need_grad` option to `get_parameter_or_create`.
* Add documentation of parameters to be registered to all parametric functions.
