### PR TITLE
Fix behavior of `get_unlinked_variable` and its `need_grad` option

### DIFF
--- a/python/src/nnabla/parameter.py
+++ b/python/src/nnabla/parameter.py
@@ -213,8 +213,7 @@ def get_parameter_or_create(name, shape=None, initializer=None, need_grad=True,
     if as_need_grad is None:
         return param
     if param.need_grad != as_need_grad:
-        param = param.unlinked()
-        param.need_grad = as_need_grad
+        param = param.get_unlinked_variable(need_grad=as_need_grad)
     return param
 
 

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -290,10 +290,9 @@ def svd_affine(inp, n_outmaps, r, base_axis=1, uv_init=None,
         v.d = v_
         nn.parameter.set_parameter("V", v)
     if fix_parameters == u.need_grad:
-        u = u.unlinked()
-        u.need_grad = not fix_parameters
+        u = u.get_unlinked_variable(need_grad=not fix_parameters)
     if fix_parameters == v.need_grad:
-        v = v.unlinked()
+        v = v.get_unlinked_variable(need_grad=not fix_parameters)
         v.need_grad = not fix_parameters
 
     if with_bias and b_init is None:
@@ -738,11 +737,9 @@ def svd_convolution(inp, outmaps, kernel, r, pad=None, stride=None,
         nn.parameter.set_parameter("V", v)
 
     if fix_parameters == u.need_grad:
-        u = u.unlinked()
-        u.need_grad = not fix_parameters
+        u = u.get_unlinked_variable(need_grad=not fix_parameters)
     if fix_parameters == v.need_grad:
-        v = v.unlinked()
-        v.need_grad = not fix_parameters
+        v = v.get_unlinked_variable(need_grad=not fix_parameters)
     if with_bias and b_init is None:
         b_init = ConstantInitializer()
     b = None
@@ -880,14 +877,11 @@ def cpd3_convolution(inp, outmaps, kernel, r,
         nn.parameter.set_parameter("K", k)
 
     if fix_parameters == o.need_grad:
-        o = o.unlinked()
-        o.need_grad = not fix_parameters
+        o = o.get_unlinked_variable(need_grad=not fix_parameters)
     if fix_parameters == i.need_grad:
-        i = i.unlinked()
-        i.need_grad = not fix_parameters
+        i = i.get_unlinked_variable(need_grad=not fix_parameters)
     if fix_parameters == k.need_grad:
-        k = k.unlinked()
-        k.need_grad = not fix_parameters
+        k = k.get_unlinked_variable(need_grad=not fix_parameters)
     if with_bias and b_init is None:
         b_init = ConstantInitializer()
     b = None

--- a/src/nbla/variable.cpp
+++ b/src/nbla/variable.cpp
@@ -76,7 +76,7 @@ VariablePtr Variable::view(const Shape_t &shape) {
              "The total size must be the same as the variable. "
              "Given: %d != current: %d.",
              size, size_);
-  auto v = make_shared<Variable>(shape_);
+  auto v = make_shared<Variable>(shape);
   v->set_data(data_->view(shape));
   v->set_grad(grad_->view(shape));
   return v;


### PR DESCRIPTION
The behavior of derivation of `need_grad` flag of unlinked variable was inconsistent with the behavior described in docstring. Also, `need_grad` option was not properly handled in the function, which caused unintentional modification of the flag of an origin variable.