### PR TITLE
Fix missing SCL package issue

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -19,23 +19,50 @@ ENV LANG C
 ENV LANGUAGE C
 
 RUN yum install -y \
-        centos-release-scl \
         epel-release \
         yum-utils \
-    && yum-config-manager --enable rhel-server-rhscl-7-rpms \
     && yum install -y \
         curl \
-        devtoolset-4-binutils \
-        devtoolset-4-gcc \
-        devtoolset-4-gcc-c++ \
-        devtoolset-4-gcc-gfortran \
-        git19 \
         hdf5 \
         hdf5-devel \
         unzip \
         wget \
         zip \
         zlib-static \
+    && yum clean all
+
+# ----------------------------------------------------------------------------
+# TODO: More sustainable way of installing gcc 5.x.
+# ----------------------------------------------------------------------------
+# It seems like devtoolset-4 is no longer provided in SCL repository,
+# but RPM packages for devtoolset-4 are still available in centos SCL
+# repoitory. We directly install these packages and their dependencies
+# from RPMs using yum command.
+# Packages we want to install are as follows:
+#   devtoolset-4-gcc
+#   devtoolset-4-gcc-c++
+#   devtoolset-4-gcc-gfortran
+#   git19
+# ----------------------------------------------------------------------------
+
+# Installing devtoolset-4 directly from RPMs.
+RUN PKGS="\
+    devtoolset-4-runtime-4.1-3.el6.x86_64.rpm \
+    devtoolset-4-binutils-2.25.1-8.el6.x86_64.rpm \
+    devtoolset-4-gcc-5.3.1-6.1.el6.x86_64.rpm \
+    devtoolset-4-libstdc++-devel-5.3.1-6.1.el6.x86_64.rpm \
+    devtoolset-4-gcc-c++-5.3.1-6.1.el6.x86_64.rpm \
+    devtoolset-4-libquadmath-devel-5.3.1-6.1.el6.x86_64.rpm \
+    devtoolset-4-gcc-gfortran-5.3.1-6.1.el6.x86_64.rpm" \
+    && for pkg in $PKGS; do yum install -y http://mirror.centos.org/centos/6/sclo/x86_64/rh/devtoolset-4/$pkg; done \
+    && yum clean all
+
+# Installing git19 directly from RPMs.
+RUN REPO_BASE=http://mirror.centos.org/centos/6/sclo/x86_64/rh/git19 \
+    && yum install -y \
+       $REPO_BASE/git19-runtime-1.2-4.el6.x86_64.rpm \
+       $REPO_BASE/git19-perl-Git-1.9.4-4.el6.1.noarch.rpm \
+       $REPO_BASE/git19-git-1.9.4-4.el6.1.x86_64.rpm \
     && yum clean all
 
 ENV PATH=/opt/rh/git19/root/usr/bin:/opt/rh/devtoolset-4/root/usr/bin:$PATH


### PR DESCRIPTION
It seems like devtoolset-4 used in Docker file is no longer provided in SCL repository due to EOL. Devtoolset-4 (GCC5.3) is required to build libraries with CUDA8.

RPM packages for devtoolset-4 are still available in centos SCL repoitory. We directly install these packages and their dependencies from RPMs using yum command. Packages we want to install are as follows:
* devtoolset-4-gcc
* devtoolset-4-gcc-c++
* devtoolset-4-gcc-gfortran
* git19