### PR TITLE
Implement forward_all function that performs forwarding on mulptiple variables at once

### DIFF
--- a/include/nbla/computation_graph/computation_graph.hpp
+++ b/include/nbla/computation_graph/computation_graph.hpp
@@ -49,5 +49,12 @@ NBLA_API vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
     @param[in,out] to A variable 'from''s parent stolen to.
 */
 NBLA_API void steal_variable_from_to(CgVariablePtr from, CgVariablePtr to);
+
+/** Forward given variables in single inference
+ * Forward all given variables with shared fclosed flags.
+ */
+NBLA_API void forward_all(const vector<CgVariablePtr> variables,
+                          bool clear_buffer = false,
+                          bool clear_no_need_grad = false);
 }
 #endif

--- a/include/nbla/computation_graph/computation_graph.hpp
+++ b/include/nbla/computation_graph/computation_graph.hpp
@@ -54,7 +54,6 @@ NBLA_API void steal_variable_from_to(CgVariablePtr from, CgVariablePtr to);
  * Forward all given variables with shared fclosed flags.
  */
 NBLA_API void forward_all(const vector<CgVariablePtr> variables,
-                          bool clear_buffer = false,
                           bool clear_no_need_grad = false);
 }
 #endif

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -205,12 +205,15 @@ public:
                  need_grad=False during forward propagation.
                  True is usually used when calling this during training.
                  This is ignored when clear_buffer=True.
+      @param[in] fclosed Set arbitrary fclosed flags to control forward
+                 computation. This is used for forward_all function.
 
       @seealso set_persistent() to prevent a specific variable to be cleared
                during forward propagation.
    */
   NBLA_API void forward(bool clear_buffer = false,
-                        bool clear_no_need_grad = false);
+                        bool clear_no_need_grad = false,
+                        unordered_set<CgFunctionPtr> *fclosed = nullptr);
   /** Performs a backward propagation
 
       starting from this variable until the root variable(s) is/are reached

--- a/python/setup.py
+++ b/python/setup.py
@@ -161,6 +161,7 @@ if __name__ == '__main__':
         'communicator',
         '_init',
         '_nd_array',
+        '_computation_graph',
         '_array',
         '_arithmetic_ops',
         '_indexing']

--- a/python/src/nnabla/__init__.py
+++ b/python/src/nnabla/__init__.py
@@ -36,6 +36,7 @@ from .parameter import (
 from .context import (
     context_scope, set_default_context, get_current_context)
 from .auto_forward import auto_forward, set_auto_forward, get_auto_forward
+from._computation_graph import forward_all
 
 # Prefer cached array by default for performance.
 prefer_cached_array(True)

--- a/python/src/nnabla/_computation_graph.pxd
+++ b/python/src/nnabla/_computation_graph.pxd
@@ -28,4 +28,4 @@ cdef extern from "nbla/computation_graph/computation_graph.hpp" namespace "nbla"
         cpp_bool) except+
     void steal_variable_from_to(CgVariablePtr f, CgVariablePtr t) except+
     void forward_all(
-        const vector[CgVariablePtr] &, cpp_bool, cpp_bool) except+
+        const vector[CgVariablePtr] &, cpp_bool, cpp_bool) nogil except+

--- a/python/src/nnabla/_computation_graph.pxd
+++ b/python/src/nnabla/_computation_graph.pxd
@@ -27,5 +27,4 @@ cdef extern from "nbla/computation_graph/computation_graph.hpp" namespace "nbla"
         vector[NdArrayPtr],
         cpp_bool) except+
     void steal_variable_from_to(CgVariablePtr f, CgVariablePtr t) except+
-    void forward_all(
-        const vector[CgVariablePtr] &, cpp_bool, cpp_bool) nogil except+
+    void forward_all(const vector[CgVariablePtr] &, cpp_bool) nogil except+

--- a/python/src/nnabla/_computation_graph.pyx
+++ b/python/src/nnabla/_computation_graph.pyx
@@ -18,7 +18,7 @@ from _variable cimport Variable as _Variable
 from _computation_graph cimport forward_all as cforward_all
 
 
-def forward_all(variables, cpp_bool clear_buffer=False, cpp_bool clear_no_need_grad=False):
+def forward_all(variables, cpp_bool clear_no_need_grad=False):
     cdef vector[CgVariablePtr] cg_variables
     cdef int i
     cdef int size
@@ -27,4 +27,4 @@ def forward_all(variables, cpp_bool clear_buffer=False, cpp_bool clear_no_need_g
     for i in range(size):
         cg_variables[i] = (<_Variable?> variables[i]).var
     with nogil:
-        cforward_all(cg_variables, clear_buffer, clear_no_need_grad)
+        cforward_all(cg_variables, clear_no_need_grad)

--- a/python/src/nnabla/_computation_graph.pyx
+++ b/python/src/nnabla/_computation_graph.pyx
@@ -12,20 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from libcpp.vector cimport vector
 from libcpp cimport bool as cpp_bool
-from _nd_array cimport *
-from function cimport *
-from _variable cimport *
+from libcpp.vector cimport vector
+from _variable cimport Variable as _Variable
+from _computation_graph cimport forward_all as cforward_all
 
 
-cdef extern from "nbla/computation_graph/computation_graph.hpp" namespace "nbla":
-    vector[CgVariablePtr] connect(
-        CgFunctionPtr,
-        const vector[CgVariablePtr] & ,
-        int,
-        vector[NdArrayPtr],
-        cpp_bool) except+
-    void steal_variable_from_to(CgVariablePtr f, CgVariablePtr t) except+
-    void forward_all(
-        const vector[CgVariablePtr] &, cpp_bool, cpp_bool) except+
+def forward_all(variables, cpp_bool clear_buffer=False, cpp_bool clear_no_need_grad=False):
+    cdef vector[CgVariablePtr] cg_variables
+    cdef int i
+    cdef int size
+    size = len(variables)
+    cg_variables.resize(size)
+    for i in range(size):
+        cg_variables[i] = (<_Variable?> variables[i]).var
+    cforward_all(cg_variables, clear_buffer, clear_no_need_grad)

--- a/python/src/nnabla/_computation_graph.pyx
+++ b/python/src/nnabla/_computation_graph.pyx
@@ -26,4 +26,5 @@ def forward_all(variables, cpp_bool clear_buffer=False, cpp_bool clear_no_need_g
     cg_variables.resize(size)
     for i in range(size):
         cg_variables[i] = (<_Variable?> variables[i]).var
-    cforward_all(cg_variables, clear_buffer, clear_no_need_grad)
+    with nogil:
+        cforward_all(cg_variables, clear_buffer, clear_no_need_grad)

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -52,7 +52,8 @@ def list_ctx_and_func_name(fnames):
 
 
 def compute_analytical_and_numerical_grad_graph(terminal, inputs,
-                                                epsilon=1e-3):
+                                                epsilon=1e-3,
+                                                recompute_graph=True):
     def set_inputs(x0):
         begin = 0
         for i in inputs:
@@ -68,11 +69,15 @@ def compute_analytical_and_numerical_grad_graph(terminal, inputs,
     def grad(x0):
         set_inputs(x0)
         backups = [i.g.copy() for i in inputs]
-        terminal.forward()
-        terminal.backward()
+        if recompute_graph:
+            terminal.forward()
+            terminal.backward()
         gx0 = []
         for i, b in zip(inputs, backups):
-            gx0.append((i.g.copy() - b).flatten())
+            if recompute_graph:
+                gx0.append((i.g.copy() - b).flatten())
+            else:
+                gx0.append(i.g.copy().flatten())
             i.g = b
         return np.concatenate(gx0)
 

--- a/python/test/test_forward_all.py
+++ b/python/test/test_forward_all.py
@@ -57,7 +57,6 @@ def test_graph_logreg(seed):
     w1.g = 0
     b1.g = 0
     L1.backward(clear_buffer=True)
-    #x.g = rng.randn(*x.shape)
 
     inputs = [x, w1, b1]
 
@@ -72,7 +71,6 @@ def test_graph_logreg(seed):
     w2.g = 0
     b2.g = 0
     L2.backward(clear_buffer=True)
-    #x.g = rng.randn(*x.shape)
 
     inputs = [x, w2, b2]
 

--- a/python/test/test_forward_all.py
+++ b/python/test/test_forward_all.py
@@ -1,0 +1,308 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from six.moves import range
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+
+def initialize_grad(parameters):
+    for param in parameters.values():
+        param.grad.zero()
+
+@pytest.mark.parametrize("seed", [313])
+def test_graph_logreg(seed):
+    rng = np.random.RandomState(seed)
+    x = nn.Variable([2, 3, 4], need_grad=True)
+    w1 = nn.Variable([12, 5], need_grad=True)
+    w2 = nn.Variable([12, 5], need_grad=True)
+    b1 = nn.Variable([5], need_grad=True)
+    b2 = nn.Variable([5], need_grad=True)
+    t = nn.Variable([2, 1])
+    x.d = rng.randn(*x.shape)
+    w1.d = rng.randn(*w1.shape)
+    w2.d = rng.randn(*w2.shape)
+    b1.d = rng.randn(*b1.shape)
+    b2.d = rng.randn(*b2.shape)
+    t.d = rng.randint(0, 5, size=t.shape)
+
+    nn.set_default_context(nn.Context())
+
+    # Forwardprop by definintion
+    z1 = F.affine(x, w1, b1, 1)
+    z2 = F.affine(x, w1, b1, 1)
+    l1 = F.softmax_cross_entropy(z1, t, 1)
+    L1 = F.mean(l1)
+    l2 = F.softmax_cross_entropy(z2, t, 1)
+    L2 = F.mean(l2)
+    nn.forward_all([L1, L2])
+
+    # Backprop for z1
+    # Diff should be initialized since they are always accumulated
+    x.g = 0
+    w1.g = 0
+    b1.g = 0
+    L1.backward(clear_buffer=True)
+    #x.g = rng.randn(*x.shape)
+
+    inputs = [x, w1, b1]
+
+    from nbla_test_utils import \
+        compute_analytical_and_numerical_grad_graph as grads
+    agrad, ngrad = grads(L1, inputs, 1e-3, False)
+    assert np.allclose(ngrad, agrad, atol=1e-2)
+
+    # Backprop for z2
+    # Diff should be initialized since they are always accumulated
+    x.g = 0
+    w2.g = 0
+    b2.g = 0
+    L2.backward(clear_buffer=True)
+    #x.g = rng.randn(*x.shape)
+
+    inputs = [x, w2, b2]
+
+    from nbla_test_utils import \
+        compute_analytical_and_numerical_grad_graph as grads
+    agrad, ngrad = grads(L2, inputs, 1e-3, False)
+    assert np.allclose(ngrad, agrad, atol=1e-2)
+
+
+@pytest.mark.parametrize("seed", [311])
+@pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
+def test_graph_model(model, seed):
+    np.random.seed(313)
+    rng = np.random.RandomState(seed)
+    x = nn.Variable([2, 3, 4, 4], need_grad=True)
+    t = nn.Variable([2, 1])
+    x.d = rng.randn(*x.shape)
+    t.d = rng.randint(0, 5, size=t.shape)
+
+    nn.set_default_context(nn.Context())
+
+    # Forwardprop by definintion
+    nn.clear_parameters()
+    if model == "mlp":
+        with nn.parameter_scope('fc1'):
+            z = PF.affine(x, 3)
+        z2 = F.relu(z, inplace=True)
+        with nn.parameter_scope('fc2'):
+            z3 = PF.affine(z2, 5)
+            z4 = PF.affine(z2, 5)
+    elif model == "recurrent":
+        with nn.parameter_scope('fc1'):
+            z = PF.affine(x, 3)
+            z2 = F.relu(z, inplace=True)
+        h = z2
+        for _ in range(2):
+            with nn.parameter_scope('fc2'):
+                h = PF.affine(h, 3)
+                h = F.relu(h, inplace=True)
+        with nn.parameter_scope('fc3'):
+            z3 = PF.affine(h, 5)
+            z4 = PF.affine(h, 5)
+    elif model == "convolution":
+        with nn.parameter_scope('conv1'):
+            z = PF.convolution(x, 3, (2, 2))
+            z2 = F.relu(z, inplace=True)
+        with nn.parameter_scope('fc2'):
+            z3 = PF.affine(z2, 5)
+            z4 = PF.affine(z2, 5)
+    else:
+        raise ValueError()
+    l1 = F.softmax_cross_entropy(z3, t, 1)
+    L1 = F.mean(l1)
+    l2 = F.softmax_cross_entropy(z4, t, 1)
+    L2 = F.mean(l2)
+
+    # Forwardprop
+    nn.forward_all([L1, L2])
+
+    parameters = nn.get_parameters()
+
+    # Backprop for L1
+    # Diff should be initialized since they are always accumulated
+    x.grad.zero()
+    initialize_grad(parameters)
+    L1.backward(clear_buffer=True)
+    inputs = [x] + list(parameters.values())
+
+    from nbla_test_utils import \
+        compute_analytical_and_numerical_grad_graph as grads
+    agrad, ngrad = grads(L1, inputs, 1e-3, False)
+    assert np.allclose(ngrad, agrad, atol=1.05e-2)
+
+    # Backprop for L2
+    # Diff should be initialized since they are always accumulated
+    x.grad.zero()
+    initialize_grad(parameters)
+    L2.backward(clear_buffer=True)
+    inputs = [x] + list(parameters.values())
+
+    from nbla_test_utils import \
+        compute_analytical_and_numerical_grad_graph as grads
+    agrad, ngrad = grads(L2, inputs, 1e-3, False)
+    assert np.allclose(ngrad, agrad, atol=1.05e-2)
+
+
+@pytest.mark.parametrize("seed", [311])
+def test_graph_unlink_backward(seed):
+    rng = np.random.RandomState(seed)
+    x0 = nn.Variable([2, 4], need_grad=True)
+    x1 = nn.Variable([2, 4], need_grad=True)
+    x0.d = rng.randn(*x0.shape)
+    x1.d = rng.randn(*x1.shape)
+    x0.grad.zero()
+    x1.grad.zero()
+    with nn.parameter_scope("fc0"):
+        h0 = PF.affine(x0, 2)
+        h0.need_grad = False
+    with nn.parameter_scope("fc1"):
+        h1 = PF.affine(x1, 2)
+    h = h0 + h1
+    with nn.parameter_scope("fc"):
+        y1 = PF.affine(h, 1)
+        y2 = PF.affine(h, 1)
+    nn.forward_all([y1, y2])
+
+    y1.backward(clear_buffer=True)
+    assert np.all(x0.g == 0)
+    assert not np.all(x1.g == 0)
+
+    y2.backward(clear_buffer=True)
+    assert np.all(x0.g == 0)
+    assert not np.all(x1.g == 0)
+
+
+@pytest.mark.parametrize("seed", [311])
+def test_graph_clear_buffer(seed):
+    np.random.seed(313)
+    rng = np.random.RandomState(seed)
+    x = nn.Variable([2, 3, 4, 4])
+    t = nn.Variable([2, 1])
+    x.d = rng.randn(*x.shape)
+    t.d = rng.randint(0, 5, size=t.shape)
+
+    # Network definition
+    nn.set_default_context(nn.Context())
+    nn.clear_parameters()
+    x1 = x + 1
+    x2 = x1 - 1
+    with nn.parameter_scope('conv1'):
+        z = PF.convolution(x2, 3, (2, 2))
+        z2 = F.relu(z, inplace=True)
+    with nn.parameter_scope('fc2'):
+        z3 = PF.affine(z2, 5)
+        z4 = PF.affine(z2, 5)
+    l1 = F.softmax_cross_entropy(z3, t, 1)
+    L1 = F.mean(l1)
+    l2 = F.softmax_cross_entropy(z4, t, 1)
+    L2 = F.mean(l2)
+
+    # Forwardprop
+    import tempfile
+    import os
+    tmpd = tempfile.mkdtemp()
+    nn.save_parameters(os.path.join(tmpd, 'parameter.h5'))
+    first = False
+    for cnng in [False, True]:
+        for cb in [False, True]:
+            _ = nn.load_parameters(os.path.join(tmpd, 'parameter.h5'))
+            for v in nn.get_parameters().values():
+                v.grad.zero()
+            nn.forward_all([L1, L2], clear_no_need_grad=cnng)
+
+            L1.backward(clear_buffer=cb)
+            L2.backward(clear_buffer=cb)
+            if not first:
+                first = True
+                g = list(nn.get_parameters().values())[0].g.copy()
+            else:
+                g2 = list(nn.get_parameters().values())[0].g.copy()
+                assert np.all(g == g2)
+
+
+@pytest.mark.parametrize("seed", [311])
+@pytest.mark.parametrize("clear_buffer", [True, False])
+def test_graph_rewire(seed, clear_buffer):
+    nn.clear_parameters()
+
+    # A. defining graph definition utility
+    def mlp2(x, scope):
+        with nn.parameter_scope(scope):
+            h = F.tanh(PF.affine(x, 10, name='a1'))
+            h = F.tanh(PF.affine(h, 10, name='a1'))
+            return h
+
+    # A. Create a graph A.
+    xa = nn.Variable((2, 10), need_grad=True)
+    ya = mlp2(xa, 'a')
+
+    # B. Create a graph B.
+    xb = nn.Variable((2, 10), need_grad=True)
+    yb1 = mlp2(xb, 'b1')
+    yb2 = mlp2(xb, 'b2')
+
+    # C. Create directly connected graph.
+    xc = nn.Variable((2, 10))
+    h = mlp2(xc, 'a')
+    yc1 = mlp2(h, 'b1')
+    yc2 = mlp2(h, 'b2')
+
+    # D. Rewire the graphs A and B.
+    xb.rewire_on(ya)
+
+    # E. Check whether the results are the same.
+    rng = np.random.RandomState(seed)
+    data = rng.randn(*xa.shape)
+    xa.d = data
+    xc.d = data
+    params = nn.get_parameters()
+
+    def zero_grad():
+        for p in params.values():
+            p.grad.zero()
+
+    def backup_params():
+        return [p.g.copy() for p in params.values()]
+
+    # Checking forward
+    nn.forward_all([yb1, yb2, yc1, yc2], clear_no_need_grad=clear_buffer)
+    assert np.allclose(yb1.d, yc1.d)
+    assert np.allclose(yb2.d, yc2.d)
+
+    # Checking backward for yb1 and yc1
+    zero_grad()
+    yb1.backward(clear_buffer=clear_buffer)
+    gb = backup_params()
+    zero_grad()
+    yc1.backward(clear_buffer=clear_buffer)
+    gc = backup_params()
+    assert np.allclose(xa.d, xc.d)
+    for b, c in zip(gb, gc):
+        assert np.allclose(b, c)
+
+    # Checking backward for yb2 and yc2
+    zero_grad()
+    yb2.backward(clear_buffer=clear_buffer)
+    gb = backup_params()
+    zero_grad()
+    yc2.backward(clear_buffer=clear_buffer)
+    gc = backup_params()
+    assert np.allclose(xa.d, xc.d)
+    for b, c in zip(gb, gc):
+        assert np.allclose(b, c)

--- a/python/test/test_forward_all.py
+++ b/python/test/test_forward_all.py
@@ -44,7 +44,7 @@ def test_graph_logreg(seed):
 
     # Forwardprop by definintion
     z1 = F.affine(x, w1, b1, 1)
-    z2 = F.affine(x, w1, b1, 1)
+    z2 = F.affine(x, w2, b2, 1)
     l1 = F.softmax_cross_entropy(z1, t, 1)
     L1 = F.mean(l1)
     l2 = F.softmax_cross_entropy(z2, t, 1)

--- a/python/test/test_forward_all.py
+++ b/python/test/test_forward_all.py
@@ -224,7 +224,9 @@ def test_graph_clear_buffer(seed):
                 v.grad.zero()
             nn.forward_all([L1, L2], clear_no_need_grad=cnng)
 
-            L1.backward(clear_buffer=cb)
+            # for now, the first backward cannot be
+            # called with clear_buffer=True
+            L1.backward(clear_buffer=False)
             L2.backward(clear_buffer=cb)
             if not first:
                 first = True
@@ -284,11 +286,12 @@ def test_graph_rewire(seed, clear_buffer):
     assert np.allclose(yb2.d, yc2.d)
 
     # Checking backward for yb1 and yc1
+    # for now, the first backward cannot be called with clear_buffer=True
     zero_grad()
-    yb1.backward(clear_buffer=clear_buffer)
+    yb1.backward(clear_buffer=False)
     gb = backup_params()
     zero_grad()
-    yc1.backward(clear_buffer=clear_buffer)
+    yc1.backward(clear_buffer=False)
     gc = backup_params()
     assert np.allclose(xa.d, xc.d)
     for b, c in zip(gb, gc):

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -134,4 +134,13 @@ void steal_variable_from_to(CgVariablePtr from, CgVariablePtr to) {
   // G. Set setup flag.
   to->mark_need_setup();
 }
+
+void forward_all(const vector<CgVariablePtr> variables, bool clear_buffer,
+                 bool clear_no_need_grad) {
+  unordered_set<CgFunctionPtr> fclosed;
+  for (int i = 0; i < variables.size(); ++i) {
+    variables[i]->forward(clear_buffer, clear_no_need_grad, &fclosed);
+  }
+}
+
 }

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -135,11 +135,11 @@ void steal_variable_from_to(CgVariablePtr from, CgVariablePtr to) {
   to->mark_need_setup();
 }
 
-void forward_all(const vector<CgVariablePtr> variables, bool clear_buffer,
+void forward_all(const vector<CgVariablePtr> variables,
                  bool clear_no_need_grad) {
   unordered_set<CgFunctionPtr> fclosed;
   for (int i = 0; i < variables.size(); ++i) {
-    variables[i]->forward(clear_buffer, clear_no_need_grad, &fclosed);
+    variables[i]->forward(false, clear_no_need_grad, &fclosed);
   }
 }
 

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -460,12 +460,15 @@ void CgVariable::visit_function_backward(
   }
 }
 
-void CgVariable::forward(bool clear_buffer, bool clear_no_need_grad) {
+void CgVariable::forward(bool clear_buffer, bool clear_no_need_grad,
+                         unordered_set<CgFunctionPtr> *fclosed) {
+  if (fclosed == nullptr) {
+    fclosed = new unordered_set<CgFunctionPtr>;
+  }
   NBLA_CHECK(parent_, error_code::value, "The variable has no parent.");
-  unordered_set<CgFunctionPtr> fclosed;
   ForwardCallback forward_callback(clear_buffer, clear_no_need_grad);
   visit_function_recursive(
-      parent_, fclosed,
+      parent_, *fclosed,
       [&forward_callback](CgFunctionPtr f) { forward_callback(f); });
 }
 


### PR DESCRIPTION
Hi, @TE-TakuyaNarihira san.

I added new function `forward_all`.

Formerly, forwarding multiple outputs which shared hidden layers (just like policy and value of actor-critic) requires multiple forwardings in static graph. See the example below.
```py
x = nn.Variable((3, 3))
h = PF.affine(x, 3, name='hidden')
y1 = PF.affine(h, 3, name='y1')
y2 = PF.affine(h, 3, name='y2')

y1.forward()
y2.forward() # hidden layer was computed twice!!
```
This is critical at huge architectures.

Thus, I added `forward_all` function.
```py
x = nn.Variable((3, 3))
h = PF.affine(x, 3, name='hidden')
y1 = PF.affine(h, 3, name='y1')
y2 = PF.affine(h, 3, name='y2')

# compute h only once!
nn.forward_all([y1, y2])
```
This function performs forwarding with shared fclosed, which prevents shared layers from being revisited.



What do you think of this?