### PR TITLE
Fix an invalid link

### DIFF
--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,4 +1,4 @@
 Contributing Guide
 ==================
 
-Moved to [Github](https://github.com/sony/nnabla/blob/master/CONTRIBUTING.md).
+Moved to `Github <https://github.com/sony/nnabla/blob/master/CONTRIBUTING.md>`_.


### PR DESCRIPTION
Fixed a link to the contributing guide in the official document.

I thought a link should be like [Github](https://github.com/), not like Github(https://github.com/).
New code follows to RST syntax.