### PR TITLE
[python][c++] Fix leaking memory in PythonFunction

### DIFF
--- a/include/nbla/function/callback.hpp
+++ b/include/nbla/function/callback.hpp
@@ -49,25 +49,27 @@ public:
 
 private:
   void *obj_;
+  int min_outputs_;
   setup_callback_type setup_callback_;
   forward_callback_type forward_callback_;
   backward_callback_type backward_callback_;
   cleanup_callback_type cleanup_callback_;
 
 public:
-  Callback(const Context &ctx, void *obj, setup_callback_type s,
-           forward_callback_type f, backward_callback_type b,
-           cleanup_callback_type c)
-      : BaseFunction(ctx), obj_(obj), setup_callback_(s), forward_callback_(f),
-        backward_callback_(b), cleanup_callback_(c) {}
+  Callback(const Context &ctx, void *obj, int min_outputs,
+           setup_callback_type s, forward_callback_type f,
+           backward_callback_type b, cleanup_callback_type c)
+      : BaseFunction(ctx), obj_(obj), min_outputs_(min_outputs),
+        setup_callback_(s), forward_callback_(f), backward_callback_(b),
+        cleanup_callback_(c) {}
   virtual ~Callback() { cleanup_callback_(obj_); }
   virtual shared_ptr<Function> copy() const {
-    return std::make_shared<Callback>(ctx_, obj_, setup_callback_,
+    return std::make_shared<Callback>(ctx_, obj_, min_outputs_, setup_callback_,
                                       forward_callback_, backward_callback_,
                                       cleanup_callback_);
   }
   virtual int min_inputs() { return 1; }
-  virtual int min_outputs() { return 1; }
+  virtual int min_outputs() { return min_outputs_; }
   virtual vector<dtypes> in_types() {
     return vector<dtypes>{get_dtype<float>()};
   }

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -71,7 +71,7 @@ cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":
     
 cdef extern from "nbla/function/callback.hpp":
     shared_ptr[CFunction] create_Callback "std::make_shared<nbla::Callback>" (
-        const CContext &, void *,
+        const CContext &, void *, int,
         void(void *, const Variables&, const Variables &) nogil except+,
         void(void *, const Variables&, const Variables &) nogil except+,
         void(void *, const Variables&, const Variables &,

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -481,27 +481,34 @@ cdef void backward_callback(void *cself, const Variables &cinputs,
                        [accum[i] for i in range(accum.size())])
 
 cdef void cleanup_callback(void *cself) with gil:
-    """Decrease a reference count of PythonFunction.
+    """Decrement a reference count of PythonFunction.
     """
     Py_DECREF(<object> cself)
     
 
-cdef class PythonFunction(Function):
+class PythonFunction:
     """
     """
-    def __cinit__(self):
-        # Need to increment reference count of Python Function object because
-        # The Function Object in Python is deallocated when Python side holds explicitly
-        # the object instance even if the function graph (C++ side) is alive.
+    def __call__(self, *inputs, n_outputs=-1, outputs=None):
+        from .auto_forward import get_auto_forward
+        info = Info()
+        info.type_name = 'PythonFunction'
+        from pickle import dumps
+        info.args = {'pickle': dumps(self)}
+        # Increment reference count to prevent deleting this object as long as
+        # the CgFunction instance created below exists.
+        # The reference count is decremented at the cleanup_callback function
+        # which will be called when the Callback function created below is
+        # deleted.
         Py_INCREF(self)
-        self.fun = make_shared[CgFunction](
-            create_Callback(CContext(), <void*>self,
+        f = Function.create(create_Callback(CContext(), <void*>self,
+                            self.min_outputs(),
                             setup_callback,
                             forward_callback,
                             backward_callback,
-                            cleanup_callback))
-        self.funp = self.fun.get()
-        self.funp.set_info(repr({'name': 'PythonFunction (cannot save/load)', 'args': {}}).encode('ascii'))
+                            cleanup_callback), info)
+        return f(*inputs, n_outputs=n_outputs,
+                 auto_forward=get_auto_forward(), outputs=outputs)
 
     @property
     def name(self):

--- a/python/test/test_python_function.py
+++ b/python/test/test_python_function.py
@@ -51,14 +51,10 @@ class Add2(PythonFunction):
                 inputs[1].g = outputs[0].g
 
 
-@F.function_api
-def add2(ctx, x0, x1, n_outputs=-1, outputs=None):
-    return Add2()(x0, x1, n_outputs=n_outputs, auto_forward=nn.get_auto_forward(), outputs=outputs)
-
-
 @pytest.mark.parametrize("seed", [314])
 def test_python_add2_forward_backward(seed):
     from nbla_test_utils import function_tester
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2 for _ in range(2)]
+    add2 = Add2()
     function_tester(rng, add2, lambda x, y: x + y, inputs, atol_b=2e-3)

--- a/src/nbla/test/test_cgvariable.cpp
+++ b/src/nbla/test/test_cgvariable.cpp
@@ -58,11 +58,11 @@ TEST_F(CgVariableTest, OrderOfBackwardForGraphWithoutBranches) {
   };
 
   /* Generate network */
-  auto a = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto a = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("A"), ignore2);
-  auto b = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto b = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("B"), ignore2);
-  auto c = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto c = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("C"), ignore2);
   auto input = make_shared<CgVariable>(Shape_t{1, 1, 1}, true);
   auto h1 = connect(make_shared<CgFunction>(a), {input}, 1);
@@ -85,15 +85,15 @@ TEST_F(CgVariableTest, OrderOfBackwardForGraphWithBranches) {
   };
 
   /* Generate network */
-  auto a = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto a = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("A"), ignore2);
-  auto b = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto b = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("B"), ignore2);
-  auto c = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto c = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("C"), ignore2);
-  auto d = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto d = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("D"), ignore2);
-  auto e = make_shared<Callback>(this->ctx_, nullptr, ignore1, ignore1,
+  auto e = make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
                                  generate_backward("E"), ignore2);
   auto input = make_shared<CgVariable>(Shape_t{1, 1, 1}, true);
   auto h1 = connect(make_shared<CgFunction>(a), {input}, 1);
@@ -116,12 +116,15 @@ TEST_F(CgVariableTest, CommunicatorBackwardCallback) {
   };
 
   /* Generate network */
-  auto a = make_shared<CgFunction>(make_shared<Callback>(
-      this->ctx_, nullptr, ignore1, ignore1, generate_backward("A"), ignore2));
-  auto b = make_shared<CgFunction>(make_shared<Callback>(
-      this->ctx_, nullptr, ignore1, ignore1, generate_backward("B"), ignore2));
-  auto c = make_shared<CgFunction>(make_shared<Callback>(
-      this->ctx_, nullptr, ignore1, ignore1, generate_backward("C"), ignore2));
+  auto a = make_shared<CgFunction>(
+      make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
+                            generate_backward("A"), ignore2));
+  auto b = make_shared<CgFunction>(
+      make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
+                            generate_backward("B"), ignore2));
+  auto c = make_shared<CgFunction>(
+      make_shared<Callback>(this->ctx_, nullptr, 1, ignore1, ignore1,
+                            generate_backward("C"), ignore2));
   auto in = make_shared<CgVariable>(Shape_t{1, 1, 1}, false);
   auto p1 = make_shared<CgVariable>(Shape_t{1, 1, 1}, true);
   auto p2 = make_shared<CgVariable>(Shape_t{1, 1, 1}, true);


### PR DESCRIPTION
Fixed memory leak in PythonFunction instance, which was an issue in a dynamic graph scenario.
Changes breaking backward compatibility;
* The API of `PythonFucnction`  is changed.
* The API of `Callback` function class in C++ is changed.
