### PR TITLE
[c++][python] Allow read-only or/and write-only access to NdArray values in CPU

### DIFF
--- a/include/nbla/array.hpp
+++ b/include/nbla/array.hpp
@@ -112,6 +112,9 @@ protected:
 ///< Shared pointer of NdArray
 typedef Array::Ptr ArrayPtr;
 
+typedef const Array ConstArray;
+typedef shared_ptr<ConstArray> ConstArrayPtr;
+
 /*@}*/
 /** \defgroup ArrayImplGrp Array list */
 /*@{*/

--- a/include/nbla/nd_array.hpp
+++ b/include/nbla/nd_array.hpp
@@ -115,6 +115,12 @@ public:
    */
   NBLA_API const Array *get(dtypes dtype, const Context &ctx);
 
+  /** Get const array as a shared_ptr.
+
+      @sa get
+   */
+  NBLA_API shared_ptr<const Array> get_sp(dtypes dtype, const Context &ctx);
+
   /** Get mutable array with specified dtype and backend description.
 
       @param[in] dtype Enum of data type.

--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -81,6 +81,10 @@ public:
   */
   const Array *get(dtypes dtype, const Context &ctx);
 
+  /** Get array as a shared pointer.
+   */
+  shared_ptr<const Array> get_sp(dtypes dtype, const Context &ctx);
+
   /** Get dtype
   */
   inline dtypes dtype() const {

--- a/python/src/nnabla/_array.pxd
+++ b/python/src/nnabla/_array.pxd
@@ -20,12 +20,14 @@ cdef extern from "nbla/array.hpp" namespace "nbla":
 
     cdef cppclass CArray "nbla::Array":
         void * pointer "nbla::Array::pointer<void>" ()
-        void * const_pointer "nbla::Array::const_pointer<void>" ()
+        const void * const_pointer "nbla::Array::const_pointer<const void>" () const
 
     ctypedef shared_ptr[CArray] ArrayPtr
+    ctypedef const CArray ConstArray
+    ctypedef shared_ptr[ConstArray] ConstArrayPtr
 
 cdef class Array:
-    cdef ArrayPtr arr
+    cdef shared_ptr[const CArray] arr
 
     @staticmethod
-    cdef object create(ArrayPtr arr)
+    cdef object create(shared_ptr[const CArray] arr)

--- a/python/src/nnabla/_array.pyx
+++ b/python/src/nnabla/_array.pyx
@@ -4,9 +4,9 @@ cdef class Array:
     """Holding a shared pointer of C Array class.
     """
     @staticmethod
-    cdef object create(ArrayPtr arr):
+    cdef object create(ConstArrayPtr arr):
         a = Array()
-        a.arr = arr
+        a.arr = <shared_ptr[const CArray] > arr
         return a
 
     def __init__(self):

--- a/python/src/nnabla/_nd_array.pxd
+++ b/python/src/nnabla/_nd_array.pxd
@@ -24,9 +24,9 @@ cdef extern from "nbla/synced_array.hpp" namespace "nbla":
 
     cdef cppclass CSyncedArray "nbla::SyncedArray":
         CSyncedArray(Size_t size) except +
-        CArray * cast(dtypes dtype, const CContext & ctx) except+
-        ArrayPtr cast_sp(dtypes dtype, const CContext & ctx) except+
-        const CArray * get(dtypes dtype, const CContext & ctx) except+
+        CArray * cast(dtypes dtype, const CContext & ctx) nogil except+
+        ArrayPtr cast_sp(dtypes dtype, const CContext & ctx) nogil except+
+        const CArray * get(dtypes dtype, const CContext & ctx) nogil except+
         dtypes dtype() except+
         Size_t size() except+
         void zero() except+
@@ -52,9 +52,10 @@ cdef extern from "nbla/nd_array.hpp" namespace "nbla":
         void set_array(SyncedArrayPtr array) except+
         void zero() except+
         void fill(double v) except+
-        const CArray * get(dtypes dtype, const CContext & ctx) except+
-        CArray * cast(dtypes dtype, const CContext & ctx) nogil except +
-        ArrayPtr cast_sp(dtypes dtype, const CContext & ctx) nogil except +
+        const CArray * get(dtypes dtype, const CContext & ctx) nogil except+
+        shared_ptr[const CArray] get_sp(dtypes dtype, const CContext & ctx) nogil except+
+        CArray * cast(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
+        ArrayPtr cast_sp(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
 
     ctypedef shared_ptr[CNdArray] NdArrayPtr
 

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 from __future__ import division
+from libcpp cimport bool as cpp_bool
 from libcpp.algorithm cimport copy
-from libcpp.memory cimport make_shared
+from libcpp.memory cimport make_shared, shared_ptr
 from libc.stdint cimport intptr_t
 from cpython cimport PyObject, Py_INCREF
 
@@ -28,6 +29,65 @@ cimport _indexing as IDX
 import numpy as np
 cimport numpy as np
 np.import_array()
+
+# Older cython doesn't expose const_pointer_cast in <memory>
+cdef extern from "<memory>" namespace "std" nogil:
+    cdef shared_ptr[T] const_pointer_cast[T, U](const shared_ptr[U] & )
+
+
+cdef c_get_numpy_array(CNdArray * arrp, vector[np.npy_intp] & shape,
+                       int type_num, CContext cctx):
+    cdef shared_ptr[const CArray] arr
+    with nogil:
+        arr = <shared_ptr[const CArray] > (arrp.get_sp( < dtypes > type_num, cctx))
+    cdef np.ndarray ndarray = np.PyArray_SimpleNewFromData(
+        shape.size(), shape.data(), type_num, < void*>(arr.get().const_pointer()))
+    ndarray.flags.writeable = False
+    pyarr = Array.create(arr)
+    ndarray.base = <PyObject * > pyarr
+    Py_INCREF(pyarr)
+    return ndarray
+
+
+cdef c_cast_numpy_array(CNdArray * arrp, vector[np.npy_intp] & shape,
+                        int type_num, CContext cctx, cpp_bool write_only):
+    cdef ArrayPtr arr
+    with nogil:
+        arr = <ArrayPtr > (arrp.cast_sp(< dtypes > type_num, cctx, write_only))
+    cdef np.ndarray ndarray = np.PyArray_SimpleNewFromData(
+        shape.size(), shape.data(), type_num, arr.get().pointer())
+    cdef shared_ptr[const CArray] carr = < shared_ptr[const CArray] > const_pointer_cast[ConstArray, CArray](arr)
+    pyarr = Array.create(carr)
+    ndarray.base = <PyObject * > pyarr
+    Py_INCREF(pyarr)
+    return ndarray
+
+
+cdef c_as_numpy_array(CNdArray * arrp, str mode):
+    cdef int type_num
+    cdef vector[np.npy_intp] shape
+    cdef Shape_t shape_base
+    from nnabla_ext.cpu import context
+    ctx = context()
+    cdef CContext cctx = <CContext > ctx
+
+    # Getting current data type
+    try:
+        type_num = <int > arrp.array().get().dtype()
+    except:
+        type_num = np.dtype(np.float32).num
+
+    # Create numpy shape array
+    shape.resize(arrp.ndim())
+    shape_base = arrp.shape()
+    copy(shape_base.begin(), shape_base.end(), shape.begin())
+
+    # Convert to numpy array with flags depending on the mode option.
+    if mode == 'r':
+        return c_get_numpy_array(arrp, shape, type_num, cctx)
+    else:
+        assert mode in ('w', 'rw'), 'Invalid mode is given: "%s"' % mode
+        return c_cast_numpy_array(arrp, shape, type_num, cctx, mode == 'w')
 
 
 cdef class NdArray:
@@ -194,7 +254,7 @@ cdef class NdArray:
         cdef int type_num = np.dtype(dtype).num
         cdef CContext cctx = <CContext ?> ctx_
         with nogil:
-            self.arrp.cast(< dtypes > type_num, cctx)
+            self.arrp.cast(< dtypes > type_num, cctx, False)
         if ctx is None:
             return self.data
 
@@ -214,33 +274,27 @@ cdef class NdArray:
         Returns: :obj:`numpy.ndarray`
 
         """
-        cdef int type_num
-        cdef vector[np.npy_intp] shape
-        cdef Shape_t shape_base
-        cdef ArrayPtr arr
-        cdef CArray * arrp
-        from nnabla_ext.cpu import context
-        ctx = context()
-        cdef CContext cctx = <CContext > ctx
-        try:
-            type_num = <int > self.arrp.array().get().dtype()
-        except:
-            type_num = np.dtype(np.float32).num
-        shape.resize(self.arrp.ndim())
-        shape_base = self.arrp.shape()
-        copy(shape_base.begin(), shape_base.end(), shape.begin())
-        with nogil:
-            arr = <ArrayPtr > (self.arrp.cast_sp(< dtypes > type_num, cctx))
-        cdef np.ndarray ndarray = np.PyArray_SimpleNewFromData(
-            shape.size(), shape.data(), type_num, arr.get().pointer())
-        pyarr = Array.create(arr)
-        ndarray.base = <PyObject * > pyarr
-        Py_INCREF(pyarr)
-        return ndarray
+        return c_as_numpy_array(self.arrp, 'rw')
 
     @data.setter
     def data(self, value):
         self.data[...] = value
+
+    def get_data(self, str mode='rw'):
+        '''
+        Returns the values held by this array as a :class:`numpy.ndarray`
+        with a specified mode.
+
+        Args:
+            mode (str): Computation becomes more efficient if right one is chosen.
+                * 'r': Read-only access.
+                * 'w': Write-only access.
+                * 'rw': You can both read and write.
+
+        See :function:`nnabla._nd_array.NdArray.data for more details.
+
+        '''
+        return c_as_numpy_array(self.arrp, mode)
 
     def zero(self):
         """

--- a/src/nbla/nd_array.cpp
+++ b/src/nbla/nd_array.cpp
@@ -82,6 +82,9 @@ void NdArray::fill(double v) { array_->fill(v); }
 const Array *NdArray::get(dtypes dtype, const Context &ctx) {
   return array_->get(dtype, ctx);
 }
+shared_ptr<const Array> NdArray::get_sp(dtypes dtype, const Context &ctx) {
+  return array_->get_sp(dtype, ctx);
+}
 Array *NdArray::cast(dtypes dtype, const Context &ctx, bool write_only) {
   return array_->cast(dtype, ctx, write_only);
 }

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -78,9 +78,13 @@ shared_ptr<Array> SyncedArray::cast_sp(dtypes dtype, const Context &ctx,
 }
 
 const Array *SyncedArray::get(dtypes dtype, const Context &ctx) {
+  return get_sp(dtype, ctx).get();
+}
+
+shared_ptr<const Array> SyncedArray::get_sp(dtypes dtype, const Context &ctx) {
   ArrayDesc desc = sync(dtype, ctx); // get() does not change head.
   array_[desc.key].second = true;    // Set as at-head.
-  return array_[desc.key].first.get();
+  return std::const_pointer_cast<const Array>(array_[desc.key].first);
 }
 
 void SyncedArray::zero() {


### PR DESCRIPTION
Previously, Python `NdArray` only allows read-read access to the internal contents as following;

```python
a = NdArray(shape=(2,))
a.data[...] = 1
print(a.data)  # This is read-write access
# [1, 1] is shown
```
Now, users can specify read-write option by using a method `NdArray.get_data(mode)`  as following;

```python
# numpy.ndarray instance referring to the internal cpu memory is returned.
# Note that even if the `v` has already some values which are set previously,
# the contents in warr is undefined because it doesn't have to preserve the previous contents.
warr = a.get_data(mode='w')
print(warr) # This gives undefined values.
warr[...] = 2

# Read-only ndarray is returned.
rarr = a.get_data(mode='r')
print(rarr)  # prints [2, 2]
rarr[...] = 4  # raises an exception because it's read-only.
```
`NdArray` internally keeps one or more device arrays, and returns a numpy array in which the values are copied from the latest device array accessed with writable permission. The write-only access is useful if we want to avoid unnecessary copy from another device. The read-only access is useful to avoid unnecessary copy from the CPU array to another device array by informing this doesn't change the array contents.