### PR TITLE
[python] PF batch normaliation `var` initialization with 1 (break behavior backward compatibility)

### DIFF
--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -1372,7 +1372,7 @@ def batch_normalization(inp, axes=[1], decay_rate=0.9, eps=1e-5,
     beta_init = param_init.get('beta', ConstantInitializer(0))
     gamma_init = param_init.get('gamma', ConstantInitializer(1))
     mean_init = param_init.get('mean', ConstantInitializer(0))
-    var_init = param_init.get('var', ConstantInitializer(0))
+    var_init = param_init.get('var', ConstantInitializer(1))
     beta = get_parameter_or_create(
         "beta", shape_stat, beta_init, True, not fix_parameters)
     gamma = get_parameter_or_create(


### PR DESCRIPTION
(This PR must be merged after merging #293)

This changes the default initialization of `bn/var` parameter from zero to one. Initialization with 0 biased the running variance towards 0. Also, the 0 initialization led to unstable inference at the early stage of training due to near-0 division in bn.

Note that this breaks the behavior backward compatibility in parametric_functions.batch_normalization. Any experiment previously performed can be reproduced by passing `param_init={'var': I.ConstantInitializer(0)}` option.