### PR TITLE
Fix misspell of the comunicator

### DIFF
--- a/doc/python/tutorial/multi_device_training.rst
+++ b/doc/python/tutorial/multi_device_training.rst
@@ -105,7 +105,7 @@ Define the communicator for gradients exchange.
     %%px
     extension_module = "cudnn"
     ctx = get_extension_context(extension_module)
-    comm = C.MultiProcessDataParalellCommunicator(ctx)
+    comm = C.MultiProcessCommunicator(ctx)
     comm.init()
     n_devices = comm.size
     mpi_rank = comm.rank
@@ -199,10 +199,10 @@ it is
 3. loss.backward()
 4. solver.update()
 
-In use of ``C.MultiProcessDataParalellCommunicator``, these steps are
+In use of ``C.MultiProcessCommunicator``, these steps are
 performed in different GPUs, and the **only difference** from these
 steps is ``comm.all_reduce()``. Thus, in case of
-``C.MultiProcessDataParalellCommunicator`` training steps are as
+``C.MultiProcessCommunicator`` training steps are as
 follows,
 
 1. loss.forward()
@@ -320,11 +320,11 @@ Update weights,
     %%px
     solver.update()
 
-This concludes the usage of ``C.MultiProcessDataParalellCommunicator``
+This concludes the usage of ``C.MultiProcessDataCommunicator``
 for Data Parallel Distributed Training.
 
 Now you should have an understanding of how to use
-``C.MultiProcessDataParalellCommunicator``, go to the cifar10 example,
+``C.MultiProcessCommunicator``, go to the cifar10 example,
 
 1. **multi\_device\_multi\_process\_classification.sh**
 2. **multi\_device\_multi\_process\_classification.py**

--- a/python/src/nnabla/communicator.pyx
+++ b/python/src/nnabla/communicator.pyx
@@ -147,7 +147,7 @@ cdef class Communicator:
             # Communicator and Context
             extension_module = "cudnn"
             ctx = get_extension_context(extension_module)
-            comm = C.MultiProcessDataParalellCommunicator(ctx)
+            comm = C.MultiProcessCommunicator(ctx)
             comm.init()
 
             # New group
@@ -215,7 +215,7 @@ cdef class Communicator:
             # Communicator and Context
             extension_module = "cudnn"
             ctx = get_extension_context(extension_module)
-            comm = C.MultiProcessDataParalellCommunicator(ctx)
+            comm = C.MultiProcessCommunicator(ctx)
             comm.init()
 
             # Data
@@ -263,7 +263,7 @@ cdef class Communicator:
             # Communicator and Context
             extension_module = "cudnn"
             ctx = get_extension_context(extension_module)
-            comm = C.MultiProcessDataParalellCommunicator(ctx)
+            comm = C.MultiProcessCommunicator(ctx)
             comm.init()
 
             # Data
@@ -309,7 +309,7 @@ cdef class Communicator:
             # Communicator and Context
             extension_module = "cudnn"
             ctx = get_extension_context(extension_module)
-            comm = C.MultiProcessDataParalellCommunicator(ctx)
+            comm = C.MultiProcessCommunicator(ctx)
             comm.init()
 
             # Data
@@ -349,7 +349,7 @@ cdef class Communicator:
             # Communicator and Context
             extension_module = "cudnn"
             ctx = get_extension_context(extension_module)
-            comm = C.MultiProcessDataParalellCommunicator(ctx)
+            comm = C.MultiProcessCommunicator(ctx)
             comm.init()
 
             # Data
@@ -385,7 +385,7 @@ cdef class Communicator:
             # Communicator and Context
             extension_module = "cudnn"
             ctx = get_extension_context(extension_module)
-            comm = C.MultiProcessDataParalellCommunicator(ctx)
+            comm = C.MultiProcessCommunicator(ctx)
             comm.init()
 
             # Data
@@ -428,7 +428,7 @@ cdef class Communicator:
             # Communicator and Context
             extension_module = "cuda.cudnn"
             ctx = extension_context(extension_module)
-            comm = C.MultiProcessDataParalellCommunicator(ctx)
+            comm = C.MultiProcessCommunicator(ctx)
             comm.init()
 
             n_class = 2
@@ -458,7 +458,7 @@ cdef class Communicator:
             self.communicatorp.all_reduce_callback(cndarray_list, pack_size, division, group))
 
 
-def DataParalellCommunicator(CContext ctx):
+def DataParallelCommunicator(CContext ctx):
     """Data Parallel Communicator for Distributed Training.
 
     This class does collectives in a single-process in a machine.
@@ -474,7 +474,7 @@ def DataParalellCommunicator(CContext ctx):
 
         # Networks and Solvers building comes above
         import nnabla.communicators as C
-        comm = C.DataParalellCommunicator(ctx)
+        comm = C.DataParallelCommunicator(ctx)
 
         # Add contexts and parameters to the communicator 
         for i in range(n_devices):
@@ -506,12 +506,12 @@ def DataParalellCommunicator(CContext ctx):
     import ctypes
     if platform.system() != 'Linux':
         raise Exception(
-            "DataParalellCommunicator is not supported other than linux.")
+            "DataParallelCommunicator is not supported other than linux.")
 
     return Communicator.create(create_DataParallelCommunicatorCommunicator(ctx))
 
 
-def MultiProcessDataParalellCommunicator(CContext ctx):
+def MultiProcessDataParallelCommunicator(CContext ctx):
     """
     Multi Process Data Parallel Communicator for Distributed Training.
 
@@ -527,7 +527,7 @@ def MultiProcessDataParalellCommunicator(CContext ctx):
         # Communicator and Context
         extension_module = "cudnn"
         ctx = get_extension_context(extension_module)
-        comm = C.MultiProcessDataParalellCommunicator(ctx)
+        comm = C.MultiProcessCommunicator(ctx)
         comm.init()
         n_devices = comm.size
         mpi_rank = comm.rank
@@ -543,7 +543,7 @@ def MultiProcessDataParalellCommunicator(CContext ctx):
         # Training loop
         for itr in range(num_itr):
             # Forward, zerograd, backward
-            losse.forward()
+            loss.forward()
             solver.zero_grad()
             loss.backward()
 
@@ -573,5 +573,14 @@ def MultiProcessDataParalellCommunicator(CContext ctx):
             nn.logger.warn(msg)
     else:
         raise Exception(
-            "MultiProcessDataParalellCommunicator is not supported other than linux.")
+            "MultiProcessDataParallelCommunicator is not supported other than linux.")
     return Communicator.create(create_MultiProcessDataParallelCommunicatorCommunicator(ctx))
+
+
+# Aliases 
+## backward compatibility
+MultiProcessDataParalellCommunicator = MultiProcessDataParallelCommunicator
+# More suitable name since `MultiProcessDataParallelCommunicator` is not limited to the data parallel distributed training
+MultiProcessCommunicator = MultiProcessDataParallelCommunicator
+Comm = MultiProcessDataParallelCommunicator
+Dist = MultiProcessDataParallelCommunicator

--- a/python/src/nnabla/utils/communicator_util.py
+++ b/python/src/nnabla/utils/communicator_util.py
@@ -32,7 +32,7 @@ def create_communicator(ignore_error=False):
     context = get_extension_context(extension_module)
     try:
         logger.log(99, 'Create communicator with contexts {}'.format(context))
-        _current_communicator = C.MultiProcessDataParalellCommunicator(context)
+        _current_communicator = C.MultiProcessCommunicator(context)
         _current_communicator.init()
         context.device_id = str(_current_communicator.rank %
                                 _current_communicator.size)

--- a/python/test/communicator/conftest.py
+++ b/python/test/communicator/conftest.py
@@ -60,7 +60,7 @@ def comm_nccl_opts(request):
     type_config = request.config.getoption('--type-config')
     ctx = get_extension_context(extension_module, type_config=type_config)
     try:
-        comm = C.MultiProcessDataParalellCommunicator(ctx)
+        comm = C.MultiProcessCommunicator(ctx)
     except Exception as e:
         raise RuntimeError(
             "Communicator could not be created. You may haven't build with distributed support.\n{}".format(e))

--- a/tutorial/multi_device_training.ipynb
+++ b/tutorial/multi_device_training.ipynb
@@ -145,7 +145,7 @@
     "%%px\n",
     "extension_module = \"cudnn\"\n",
     "ctx = get_extension_context(extension_module)\n",
-    "comm = C.MultiProcessDataParalellCommunicator(ctx)\n",
+    "comm = C.MultiProcessCommunicator(ctx)\n",
     "comm.init()\n",
     "n_devices = comm.size\n",
     "mpi_rank = comm.rank\n",
@@ -301,9 +301,9 @@
     "3. loss.backward()\n",
     "4. solver.update()\n",
     "\n",
-    "In use of `C.MultiProcessDataParalellCommunicator`, these steps are performed in \n",
+    "In use of `C.MultiProcessCommunicator`, these steps are performed in \n",
     "different GPUs, and the **only difference** from these steps is `comm.all_reduce()`.\n",
-    "Thus, in case of `C.MultiProcessDataParalellCommunicator` training steps are \n",
+    "Thus, in case of `C.MultiProcessCommunicator` training steps are \n",
     "as follows, \n",
     "  \n",
     "1. loss.forward()\n",
@@ -495,7 +495,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This concludes the usage of ``C.MultiProcessDataParalellCommunicator`` for\n",
+    "This concludes the usage of ``C.MultiProcessCommunicator`` for\n",
     "Data Parallel Distributed Training."
    ]
   },
@@ -503,7 +503,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now you should have an understanding of how to use ``C.MultiProcessDataParalellCommunicator``, \n",
+    "Now you should have an understanding of how to use ``C.MultiProcessCommunicator``, \n",
     "go to the cifar10 example,\n",
     "\n",
     "1. **multi_device_multi_process_classification.sh**\n",


### PR DESCRIPTION
The factory method name was fixed from `MultiProcessDataParalellCommunicator` to `MultiProcessDataParallelCommunicator`, but also add some aliases, one is for the backward compatibility.

- MultiProcessDataParalellCommunicator = MultiProcessDataParallelCommunicator
- MultiProcessCommunicator = MultiProcessDataParallelCommunicator
- Comm = MultiProcessDataParallelCommunicator
- Dist = MultiProcessDataParallelCommunicator