### PR TITLE
Add graph converters for inference

### DIFF
--- a/doc/python/api/experimental.rst
+++ b/doc/python/api/experimental.rst
@@ -12,3 +12,16 @@ SimpleGraph
 
 .. autoclass:: nnabla.experimental.viewers.SimpleGraph
     :members:
+
+
+GraphConveter
+-------------
+
+.. automodule:: nnabla.experimental.graph_converters
+    :classes:
+
+.. autoclass:: nnabla.experimental.graph_converters.identity_graph.IdentityGraph
+    :members:
+
+
+

--- a/doc/python/tutorial.rst
+++ b/doc/python/tutorial.rst
@@ -15,3 +15,4 @@ If you want to run these step-by-step, follow the link and see the instruction f
     tutorial/mixed_precision_training.rst
     tutorial/multi_device_training.rst
     tutorial/debugging.rst
+    tutorial/graph_converter_for_inference.rst

--- a/doc/python/tutorial/graph_converter_for_inference.rst
+++ b/doc/python/tutorial/graph_converter_for_inference.rst
@@ -1,0 +1,320 @@
+
+Graph Converter for Inference
+=============================
+
+In this tutorial, we demonstrate several graph converters mainly used
+for inference. Graph converters are basically used for a trained graph,
+neural network, so once you train a neural network, you can use graph
+converters.
+
+We show how to use the following graph converters step-by-step according
+to usecases.
+
+1. BatchNormalizationLinearConverter
+2. BatchNormalizationFoldedConverter
+3. FixedPointWeightConverter
+4. FixedPointActivationConverter
+
+**Note** before starting the following instruction, import python
+modules needed.
+
+.. code:: python
+
+    # Import
+    import numpy as np
+    import nnabla as nn
+    import nnabla.functions as F
+    import nnabla.parametric_functions as PF
+    
+    import nnabla.experimental.viewers as V
+    import nnabla.experimental.graph_converters as GC
+
+Also, define LeNet as the motif.
+
+.. code:: python
+
+    # LeNet
+    def LeNet(image, test=False):
+        h = PF.convolution(image, 16, (5, 5), (1, 1), with_bias=False, name='conv1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv1-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.relu(h)
+    
+        h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True, name='conv2')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv2-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.relu(h)
+         
+        h = PF.affine(h, 10, with_bias=False, name='fc1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='fc1-bn')
+        h = F.relu(h)
+    
+        pred = PF.affine(h, 10, with_bias=True, name='fc2')
+        return pred
+
+
+BatchNormalizationLinearConverter
+---------------------------------
+
+Typical networks contain the batch normalization layers. It serves as
+normalization in a network and uses the batch stats (the batch mean and
+variance) to normalize inputs as
+
+.. math::
+
+
+   z = \gamma \frac{x - \mu}{\sqrt{\sigma^2 + \epsilon}} + \beta,
+
+in training. :math:`\mu` and :math:`\sigma^2` are the batch mean and
+variance, and :math:`\gamma` and :math:`\beta` are the scale and bias
+parameter to be learnt.
+
+At the same time, it computes the running stats (the exponential moving
+average :math:`\mu_r` and variance :math:`\sigma_r^2` of inputs to the
+batch normalization layer), which are used later for inference.
+
+If nothing changes, in inference time, the batch normalization is
+performed as in the above equation using the running stats.
+
+.. math::
+
+
+   z = \gamma \frac{x - \mu_r}{\sqrt{\sigma_r^2 + \epsilon}} + \beta.
+
+This is the explicit normalization, so as you can see, there are many
+redundant computations (subtraction, devision, pow2, sqrt,
+multiplication, addition) in inference, which should be avoided in
+inference graph. We can do it by ourselves, but it is apparently
+troublesome.
+
+BatchNormalizationLinearConverter automatically converts this equation
+of the batch normalization to the simple linear form as
+
+.. math::
+
+
+   z = c_0 x + c_1, \\
+   c_0 = \frac{\gamma}{\sqrt{\sigma_r^2 + \epsilon}}, \\
+   c_1 = \beta - \frac{\gamma \mu_r}{\sqrt{\sigma_r^2 + \epsilon}}.
+
+After the conversion, we just have one multiplication and one addition
+since :math:`c_0` and :math:`c_1` can be precomputed in inference.
+
+Specifically, suppose that :math:`x` is the output of the
+2D-Convolution, so :math:`x` is 3D-Tensor (e.g.,
+:math:`N \times H \times W`). In the batch normalization, the number of
+:math:`c`\ s is the map size :math:`N`, respectively for :math:`c_0` and
+:math:`c_1`. Thus, the multiplication (:math:`c_0 \times x`) is
+:math:`N \times H \times W` and the addition ($ + c\_1$) is same
+:math:`N \times H \times W`. We can see much reduction compared to the
+native implementation.
+
+Example
+~~~~~~~
+
+First, create LeNet.
+
+.. code:: python
+
+    x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))
+    y = LeNet(x, test=True)
+
+Now look at LeNet visually.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+Convert it to the one with the batch normalization linearly folded.
+
+.. code:: python
+
+    converter = GC.BatchNormalizationLinearConverter(name="bn-linear-lenet")
+    y = converter.convert(y, [x])
+
+Also, show the converted graph.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+BatchNormalizationFoldedConverter
+---------------------------------
+
+As you can see in the previous converter,
+BatchNormalizationLinearConverter is the linear folding of the batch
+normalization layer in inference. However, if the preceding layer of the
+batch normalization is the convolution, affine or another layer
+performing inner-product, that the linear folding is further folded into
+the weights of the preceding layers.
+
+Suppose the sequence of a convolution and a batch normalization in
+inference, it can be written as,
+
+.. math::
+
+
+   z = c_0 \times (w \ast x + b) + c_1,
+
+where :math:`\ast` is the convolutional operator, :math:`w` is the
+convolutional weights, and :math:`b` is the bias of the convolution
+layer. Since :math:`\ast` has linearity, we can further fold :math:`c_0`
+into the weights :math:`w` and bias :math:`b`, such that we have the
+simpler form.
+
+.. math::
+
+
+   z = w' \ast x + b', \\
+   w' = c_0 w, \\
+   b' = c_0 b + c_1.
+
+BatchNormalizationFoldedConverter automatically finds a sequence of the
+convolution and the batch normalization in a given graph, then folds all
+parameters related to the batch normalization into the preceding
+convolution layer. Now, we do not need the multiplication and addition
+seen in the previous case, BatchNormalizationLinearConverter.
+
+Example
+~~~~~~~
+
+First, create LeNet.
+
+.. code:: python
+
+    x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))
+    y = LeNet(x, test=True)
+
+Now look at LeNet visually.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+Convert it to the one with the batch normalization linearly folded.
+
+.. code:: python
+
+    converter = GC.BatchNormalizationFoldedConverter(name="bn-folded-lenet")
+    y = converter.convert(y, [x])
+
+Also, show the converted graph.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+FixedPointWeightConverter
+-------------------------
+
+Once training finishes, where to deploy? Your destination of deployment
+of a trained model might be on Cloud or an embedded device. In either
+case, the typical data type, FloatingPoint32 (FP32) might be redundant
+for inference, so you may want to use SIMD operation with e.g., 4-bit or
+8-bit of your target device. Training is usually performed using FP32,
+while interfence might be performed FixedPoint. Hence, you have to
+change corresponding layers, e.g., the convolution and affine.
+
+FixedPointWeightConverter automatically converts the affine,
+convolution, and deconvolution of a given graph to that of fixed point
+version.
+
+Example
+~~~~~~~
+
+First, create LeNet.
+
+.. code:: python
+
+    x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))
+    y = LeNet(x, test=True)
+
+Now look at LeNet visually.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+Convert it to the one with the batch normalization linearly folded.
+
+.. code:: python
+
+    converter = GC.FixedPointWeightConverter(name="fixed-point-weight-lenet")
+    y = converter.convert(y, [x])
+
+Also, show the converted graph.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+FixedPointActivationConverter
+-----------------------------
+
+FixedPointWeightConverter converts layers of weights, but
+FixedPointActivationConverter automatically converts activation layers,
+e.g., ReLU. The typial neural network architecture contains the sequence
+of the block ``ReLU -> Convolution -> BatchNormalization``; therefore,
+when you convert both ``ReLU`` and ``Convolution`` to the fixed-point
+ones with proper hyper-paremters (step-size and bitwidth), you can
+utilize your SIMD operation of your target device because both of the
+weights and inputs of the convolution are fixed-point.
+
+Example
+~~~~~~~
+
+First, create LeNet.
+
+.. code:: python
+
+    x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))
+    y = LeNet(x, test=True)
+
+Now look at LeNet visually.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+Convert it to the one with the batch normalization linearly folded.
+
+.. code:: python
+
+    converter = GC.FixedPointActivationConverter(name="fixed-point-activation-lenet")
+    y = converter.convert(y, [x])
+
+Also, show the converted graph.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)
+
+Tipically, FixedPointWeightConverter and FixedPointActivationConverter
+are used togather. For such purposes, you can use
+``GC.SequentialConverter``.
+
+.. code:: python
+
+    converter_w = GC.FixedPointWeightConverter(name="fixed-point-lenet")
+    converter_a = GC.FixedPointActivationConverter(name="fixed-point-lenet")
+    converter = GC.SequentialConverter([converter_w, converter_a])
+    y = converter.convert(y, [x])
+
+Needless to say, ``GC.SequentialConverter`` is not limited to using this
+case. One you creat your own ``Conveterter``\ s, then you can add these
+converters to ``GC.SequentialConverter`` if these are used togather.
+
+Look at the converted graph visually.
+
+.. code:: python
+
+    viewer = V.SimpleGraph()
+    viewer.view(y)

--- a/python/setup.py
+++ b/python/setup.py
@@ -233,6 +233,7 @@ if __name__ == '__main__':
     packages = ['nnabla',
                 'nnabla.contrib',
                 'nnabla.experimental',
+                'nnabla.experimental.graph_converters',
                 'nnabla.utils',
                 'nnabla.utils.cli',
                 'nnabla.utils.converter',

--- a/python/src/nnabla/experimental/graph_converters/__init__.py
+++ b/python/src/nnabla/experimental/graph_converters/__init__.py
@@ -1,0 +1,7 @@
+from .helpers import *
+from .batch_normalization_folded import *
+from .batch_normalization_linear import *
+from .fixed_point_activation import *
+from .fixed_point_weight import *
+from .identity import *
+from .sequential import *

--- a/python/src/nnabla/experimental/graph_converters/batch_normalization_folded.py
+++ b/python/src/nnabla/experimental/graph_converters/batch_normalization_folded.py
@@ -1,0 +1,169 @@
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+import numpy as np
+
+import os
+
+from .identity import IdentityConverter
+from .helpers import GraphInfo
+
+
+class BatchNormalizationFoldedConverter(IdentityConverter):
+    """
+    Single `Convolution -> BatchNormalization` pass is folded into one `Convolution`.
+
+    If there is a `Convolution -> BatchNormalization` pass, fold the batch normalization paramters to the kernel and bias (if it exists) of the preceeding convolution, then skip the batch normalization following the convolution.
+
+    Args:
+        black_list (list): Black list of the function list.
+        params (:obj:`OrderedDict`): Result of nn.get_parameters().
+        name (:obj:`str`): Prefix of the parameter scope.
+
+    """
+
+    def __init__(self,
+                 black_list=[], params=None,
+                 inner_prod_functions=None,
+                 name="bn-folded"):
+
+        import nnabla.function_bases as FB
+        import nnabla as nn
+
+        super(BatchNormalizationFoldedConverter, self).__init__(black_list,
+                                                                params, name)
+
+        self.inner_prod_functions = inner_prod_functions if inner_prod_functions \
+            else ["Affine",
+                  "Convolution",
+                  "Deconvolution"]
+
+    def convert(self, vroot, entry_variables):
+        """
+        All functions are replaced with the same `new` function.
+
+        Args:
+            vroot (:obj:`Variable`): NNabla Variable
+            entry_variables (:obj:`Variable`): Entry variable from which the conversion starts.
+        """
+        self.graph_info = GraphInfo(vroot)
+        self.entry_variables = entry_variables
+
+        with nn.parameter_scope(self.name):
+            # Function loop in the forward order
+            for t, func in enumerate(self.graph_info.funcs):
+                # TODO: error check
+
+                # Batch normalization check, then skip
+                if func.name == "BatchNormalization":
+                    i0 = func.inputs[0]
+                    bn_func = func
+                    # Test mode check
+                    if bn_func.info.args["batch_stat"] == False:
+                        # `Target Func -> BN` check from BN
+                        if i0.parent.info.type_name in self.inner_prod_functions:
+                            nn.logger.info("{} is skipped.".format(func.name))
+                            continue
+
+                # `Target Func -> BN` conversion
+                if func.name in self.inner_prod_functions:
+                    inner_prod_func = func
+
+                    o0 = inner_prod_func.outputs[0]
+                    fs = self.graph_info.variable_to_funcs[o0]
+                    # No branch check #TODO: branching check (really needed?)
+                    if fs is not None and len(fs) == 1:
+                        # `Target Func -> BN` check
+                        bn_func = fs[0]
+                        if bn_func.name == "BatchNormalization":
+
+                            # Test mode check
+                            if bn_func.info.args["batch_stat"] == False:
+
+                                # Perform `Target Func -> BN` conversion
+                                nn.logger.info("BatchNormalization parameters are folded to "
+                                               "the preceding convolution.")
+                                o = self._inner_prod_bn_conversion(
+                                    inner_prod_func, bn_func)
+                                continue
+
+                # Identity conversion
+                o = self._identity_conversion(func)
+
+        self.end_variable = o
+        return self.end_variable
+
+    def _compute_folded_parameters(self, inner_prod_func, bn_func):
+        # Squeeze
+        beta_data = np.squeeze(bn_func.inputs[1].d)
+        gamma_data = np.squeeze(bn_func.inputs[2].d)
+        mean_data = np.squeeze(bn_func.inputs[3].d)
+        var_data = np.squeeze(bn_func.inputs[4].d)
+        eps_data = bn_func.info.args["eps"]
+        # Reshape
+        w = inner_prod_func.inputs[1]
+        r_shape = [1 for _ in range(len(w.shape) - len(beta_data.shape))]
+        beta_data = beta_data.reshape(list(beta_data.shape) + r_shape)
+        gamma_data = gamma_data.reshape(list(gamma_data.shape) + r_shape)
+        mean_data = mean_data.reshape(list(mean_data.shape) + r_shape)
+        var_data = var_data.reshape(list(var_data.shape) + r_shape)
+        sigma_data = np.sqrt(var_data + eps_data)
+        # Reshape again if affine
+        if inner_prod_func.name == "Affine":  # (inp, out) -> (out, inp)
+            beta_data = beta_data.reshape(
+                beta_data.shape[1], beta_data.shape[0])
+            gamma_data = gamma_data.reshape(
+                gamma_data.shape[1], gamma_data.shape[0])
+            mean_data = mean_data.reshape(
+                mean_data.shape[1], mean_data.shape[0])
+            var_data = var_data.reshape(var_data.shape[1], var_data.shape[0])
+            sigma_data = np.sqrt(var_data + eps_data)
+        # Fold
+        c0 = gamma_data / sigma_data
+        c1 = beta_data - (gamma_data * mean_data) / sigma_data
+        w_data = w.d
+        w_data = c0 * w_data
+        b_data = c1
+        if len(inner_prod_func.inputs) == 3:
+            b = inner_prod_func.inputs[2]
+            b_data += c0 * b.d.reshape(b_data.shape)
+        return w_data, np.squeeze(b_data)
+
+    def _inner_prod_bn_conversion(self, inner_prod_func, bn_func):
+        # Fold parameters
+        w_data, b_data = self._compute_folded_parameters(
+            inner_prod_func, bn_func)
+
+        # W
+        w = inner_prod_func.inputs[1]
+        idx = list(self.params.values()).index(w)
+        name = list(self.params.keys())[idx]
+        w = nn.parameter.get_parameter_or_create(name,
+                                                 w.shape,
+                                                 w_data,
+                                                 w.need_grad)
+        # b (borrow from w)
+        name = os.path.join("/".join(name.rstrip().split("/")[:-1]), "b")
+        b = nn.parameter.get_parameter_or_create(name,
+                                                 b_data.shape,
+                                                 b_data,
+                                                 need_grad=True)
+
+        # Input conversion
+        x = inner_prod_func.inputs[0]
+        x = self.input_map[x] if x in self.input_map else x
+        inputs = [x, w, b]
+
+        # Function call
+        o = self._call_function(inner_prod_func.name,
+                                inputs,
+                                inner_prod_func.info.args)
+
+        # Map output of ref graph (BN output) to output of new graph
+        o_bn = bn_func.outputs[0]
+        self.input_map[o_bn] = o  # new input
+
+        # Store output (just in case)
+        self.outputs.append(o)
+
+        return o

--- a/python/src/nnabla/experimental/graph_converters/batch_normalization_linear.py
+++ b/python/src/nnabla/experimental/graph_converters/batch_normalization_linear.py
@@ -1,0 +1,89 @@
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+import numpy as np
+
+from .identity import IdentityConverter
+from .helpers import GraphInfo
+
+
+class BatchNormalizationLinearConverter(IdentityConverter):
+    """
+    The parameters of the batch normalization replaced simple scale and bias.
+
+    Args:
+        black_list (list): Black list of the function list.
+        params (:obj:`OrderedDict`): Result of nn.get_parameters().
+        name (:obj:`str`): Prefix of the parameter scope.
+
+    """
+
+    def __init__(self,
+                 black_list=[], params=None,
+                 name="bn-linear"):
+        super(BatchNormalizationLinearConverter, self).__init__(black_list,
+                                                                params, name)
+
+    def convert(self, vroot, entry_variables):
+        """
+        All functions are replaced with the same `new` function.
+
+        Args:
+            vroot (:obj:`Variable`): NNabla Variable
+            entry_variables (:obj:`Variable`): Entry variable from which the conversion starts.
+        """
+        self.graph_info = GraphInfo(vroot)
+        self.entry_variables = entry_variables
+
+        cnt = 0
+        with nn.parameter_scope(self.name):
+            # Function loop in the forward order
+            for t, func in enumerate(self.graph_info.funcs):
+                if func.name == "BatchNormalization":
+                    bn_func = func
+                    # TODO: should deal with both?
+                    if bn_func.info.args["batch_stat"] == False:
+                        o = self._bn_linear_conversion(bn_func, cnt)
+                        cnt += 1
+                        continue
+                # Identity conversion
+                o = self._identity_conversion(func)
+
+        self.end_variable = o
+        return self.end_variable
+
+    def _bn_linear_conversion(self, bn_func, cnt):
+        # Conversion
+        eps_data = bn_func.info.args["eps"]
+        beta_data = np.squeeze(bn_func.inputs[1].d)
+        gamma_data = np.squeeze(bn_func.inputs[2].d)
+        mean_data = np.squeeze(bn_func.inputs[3].d)
+        var_data = np.squeeze(bn_func.inputs[4].d)
+        sigma_data = np.sqrt(var_data + eps_data)
+        c0_data = gamma_data / sigma_data
+        c1_data = beta_data - (gamma_data * mean_data) / sigma_data
+        # Reshape
+        oshape = bn_func.inputs[1].shape
+        c0_data = c0_data.reshape(oshape)
+        c1_data = c1_data.reshape(oshape)
+
+        # Inputs
+        x = bn_func.inputs[0]
+        x = self.input_map[x] if x in self.input_map else x
+
+        c0 = nn.parameter.get_parameter_or_create("c0-{}-{}".format(self.name, cnt),
+                                                  c0_data.shape, c0_data)
+        c1 = nn.parameter.get_parameter_or_create("c1-{}-{}".format(self.name, cnt),
+                                                  c1_data.shape, c1_data)
+
+        # Function call
+        o = c0 * x + c1
+
+        # Map output of ref graph to output of new graph
+        x = bn_func.outputs[0]
+        self.input_map[x] = o
+
+        # Store output (just in case)
+        self.outputs.append(o)
+
+        return o

--- a/python/src/nnabla/experimental/graph_converters/fixed_point_activation.py
+++ b/python/src/nnabla/experimental/graph_converters/fixed_point_activation.py
@@ -1,0 +1,81 @@
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+import numpy as np
+
+from .identity import IdentityConverter
+from .helpers import GraphInfo
+
+
+class FixedPointActivationConverter(IdentityConverter):
+    """
+    All functions specified by `activation_functions` are replaced with the fixed-point quantization function. The other functions are replaced with the same `new` function.
+
+    Args:
+        black_list (list): Black list of the function list.
+        params (:obj:`OrderedDict`): Result of nn.get_parameters().
+        activation_functions (list of function name): Function names to be replaced. Default is ["ReLU"].
+        args_fpq (`dict`): Argument into F.quantize. Default is `{"sign": True, "n": 8, "delta": 2e-4, "quantize": True}`.
+        name (:obj:`str`): Prefix of the parameter scope.
+    """
+
+    def __init__(self,
+                 black_list=[], params=None,
+                 activation_functions=None,
+                 args_fpq={"n": 8, "sign": False,
+                           "delta": 2e-4, "quantize": True},
+                 name="fixed-point-activation-graph"):
+        import nnabla.function_bases as FB
+        import nnabla as nn
+        super(FixedPointActivationConverter, self).__init__(
+            black_list, params, name)
+
+        self.activation_functions = ["ReLU"] if activation_functions is None \
+            else activation_functions
+        self.args_fpq = args_fpq
+
+    def convert(self, vroot, entry_variables):
+        """
+        All functions are replaced with the same `new` function.
+
+        Args:
+            vroot (:obj:`Variable`): NNabla Variable
+            entry_variables (:obj:`Variable`): Entry variable from which the conversion starts.
+        """
+        self.graph_info = GraphInfo(vroot)
+        self.entry_variables = entry_variables
+
+        with nn.parameter_scope(self.name):
+            # Function loop in the forward order
+            for t, func in enumerate(self.graph_info.funcs):
+                # Activation check
+                if func.name in self.activation_functions:
+                    activation_func = func
+                    o = self._fixed_point_activation_conversion(
+                        activation_func)
+                    continue
+                # Identity conversion
+                o = self._identity_conversion(func)
+
+        self.end_variable = o
+        return self.end_variable
+
+    def _fixed_point_activation_conversion(self, activation_func):
+        # Input
+        x = activation_func.inputs[0]
+        x = self.input_map[x] if x in self.input_map else x
+
+        # Conversion
+        n = self.args_fpq["n"]
+        sign = self.args_fpq["sign"]
+        delta = self.args_fpq["delta"]
+        o = F.fixed_point_quantize(x, n=n, sign=sign, delta=delta)
+
+        # Map output of ref graph to output of new graph
+        x = activation_func.outputs[0]
+        self.input_map[x] = o
+
+        # Store output (just in case)
+        self.outputs.append(o)
+
+        return o

--- a/python/src/nnabla/experimental/graph_converters/fixed_point_weight.py
+++ b/python/src/nnabla/experimental/graph_converters/fixed_point_weight.py
@@ -1,0 +1,150 @@
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+import numpy as np
+
+from .identity import IdentityConverter
+from .helpers import GraphInfo
+
+
+class FixedPointWeightConverter(IdentityConverter):
+    """
+    All functions specified by `inner_prod_functions` are replaced with the fixed-point counter-part. The other functions are replaced with the same `new` function.
+
+    Args:
+        black_list (list): Black list of the function list.
+        params (:obj:`OrderedDict`): Result of nn.get_parameters().
+        inner_prod_functions (list of function name): Function names to be replaced. Default is ["Affine", "Convolution", "Deconvolution"].
+        call_forward (:obj:`bool`): Call forward function to obtain `W_q`. Default is "True", so ones do not need to call the forward function to synch quantized weights. Take care that if the network contains the batch normalization or like other normalization which computes running stats (e.g., a running mean and variance), these stats can not help being updated by this `call_forward`. To avoid that, change the argument `batch_stat` of the batch normalization layer to `False` when using this `call_foward` option `True`.
+        floor (:obj:`bool`): When computing the step size, it is coerced to be the power-of-2 by using either :math:`2^ceil(log_2(abs(W)_max / (2^n - 1)))` or :math:`2^floor(log_2(abs(W)_max / (2^n - 1)))`. Default is `False`.
+        args_fpq (`dict`): Argument into F.quantize. Default is `{"sign_w": True, "n_w": 8, "delta_w": 2e-4, "quantize_w": True, "sign_b": True, "n_b": 8, "delta_b": 2e-4, "quantize_b": True}`
+        name (:obj:`str`): Prefix of the parameter scope.
+    """
+
+    def __init__(self,
+                 black_list=[], params=None,
+                 inner_prod_functions=None,
+                 call_forward=True,
+                 floor=False,
+                 args_fpq={"sign_w": True, "n_w": 8, "delta_w": 2e-4, "quantize_w": True,
+                           "sign_b": True, "n_b": 8, "delta_b": 2e-4, "quantize_b": True},
+                 name="fixed-point-weight-graph"):
+        super(FixedPointWeightConverter, self).__init__(
+            black_list, params, name)
+
+        self.call_forward = call_forward
+        self.round_func = np.ceil if not floor else np.floor
+        self.args_fpq = args_fpq
+
+        self.inner_prod_functions = ["Affine",
+                                     "Convolution",
+                                     "Deconvolution"] if inner_prod_functions is None \
+            else inner_prod_functions
+
+    def convert(self, vroot, entry_variables):
+        """
+        All functions are replaced with the same `new` function.
+
+        Args:
+            vroot (:obj:`Variable`): NNabla Variable
+            entry_variables (:obj:`Variable`): Entry variable from which the conversion starts.
+        """
+        self.graph_info = GraphInfo(vroot)
+        self.entry_variables = entry_variables
+
+        with nn.parameter_scope(self.name):
+            # Function loop in the forward order
+            for t, func in enumerate(self.graph_info.funcs):
+                if func.name in self.inner_prod_functions:
+                    inner_prod_func = func
+                    o = self._fixed_point_weight_conversion(inner_prod_func)
+                    continue
+                # Identity conversion
+                o = self._identity_conversion(func)
+
+        self.end_variable = o
+
+        if self.call_forward:
+            o.forward(clear_buffer=True)
+        return self.end_variable
+
+    def _fixed_point_weight_conversion(self, inner_prod_func):
+        # Input
+        w_init = inner_prod_func.inputs[1].d
+        b_init = inner_prod_func.inputs[2].d if len(
+            inner_prod_func.inputs) == 3 else None
+        x = inner_prod_func.inputs[0]
+        x = self.input_map[x] if x in self.input_map else x
+
+        # Quantization params
+        sign_w = self.args_fpq["sign_w"]
+        n_w = self.args_fpq["n_w"]
+        delta_w = self.args_fpq["delta_w"]
+        sign_b = self.args_fpq["sign_b"]
+        n_b = self.args_fpq["n_b"]
+        quantize_b = self.args_fpq["quantize_b"]
+        delta_b = self.args_fpq["delta_b"]
+
+        # Determine delta
+        if not "delta_w" in self.args_fpq:
+            n = n_w - 1 if sign_w is True else n_w
+            w_abs_max = np.sort(np.abs(w_init.flatten()))[-1]
+            delta_w = 2 ** np.round_func(np.log2(w_abs_max / (2**n - 1)))
+
+        if not "delta_b" in self.args_fpq and len(inner_prod_func.inputs) == 3:
+            n = n_b - 1 if sign_b is True else n_b
+            b_abs_max = np.sort(np.abs(b_init.flatten()))[-1]
+            if b_abs_max != 0:
+                delta_b = 2 ** np.round_func(np.log2(b_abs_max / (2**n - 1)))
+            else:
+                delta_b = 0
+
+        # Parameter name
+        w = inner_prod_func.inputs[1]
+        idx = list(self.params.values()).index(w)
+        name = list(self.params.keys())[idx].rstrip("W/")
+
+        # Bias
+        with_bias = True if len(inner_prod_func.inputs) == 3 else False
+
+        # Conversion
+        if inner_prod_func.name == "Affine":
+            omaps = w_init.shape[1]
+            args = inner_prod_func.info.args
+            o = PF.fixed_point_quantized_affine(x, omaps, with_bias=with_bias,
+                                                w_init=w_init, b_init=b_init,
+                                                sign_w=sign_w, n_w=n_w, delta_w=delta_w,
+                                                sign_b=sign_b, n_b=n_b, delta_b=delta_b,
+                                                name=name,
+                                                **args)
+
+        if inner_prod_func.name == "Convolution":
+            omaps = w_init.shape[0]
+            kernel = w_init.shape[2:]
+            args = inner_prod_func.info.args
+            o = PF.fixed_point_quantized_convolution(x, omaps, kernel, with_bias=with_bias,
+                                                     w_init=w_init, b_init=b_init,
+                                                     sign_w=sign_w, n_w=n_w, delta_w=delta_w,
+                                                     sign_b=sign_b, n_b=n_b, delta_b=delta_b,
+                                                     name=name,
+                                                     **args)
+
+        if inner_prod_func.name == "Deconvolution":
+            omaps = w_init.shape[0]
+            kernel = w_init.shape[2:]
+            args = inner_prod_func.info.args
+            o = PF.fixed_point_quantized_deconvolution(x, omaps, kernel, with_bias=with_bias,
+                                                       w_init=w_init, b_init=b_init,
+                                                       sign_w=sign_w, n_w=n_w, delta_w=delta_w,
+                                                       sign_b=sign_b, n_b=n_b, delta_b=delta_b,
+                                                       name=name,
+                                                       **args)
+
+        # Map output of ref graph to output of new graph
+        x = inner_prod_func.outputs[0]
+        self.input_map[x] = o
+
+        # Store output (just in case)
+        self.outputs.append(o)
+
+        return o

--- a/python/src/nnabla/experimental/graph_converters/helpers.py
+++ b/python/src/nnabla/experimental/graph_converters/helpers.py
@@ -1,0 +1,52 @@
+from collections import defaultdict
+
+
+class PrintFuncName(object):
+
+    def __init__(self, ):
+        pass
+
+    def __call__(self, nnabla_func):
+        print(nnabla_func.name)
+
+
+class GraphInfo(object):
+    """Graph Information
+
+
+    Args:
+      pred (:obj:`Variable`): The end of `Variable`.
+
+    Attributes: 
+      funcs (list of :obj:`Function`): :obj:`Function` list to be call in the forward order.
+      inputs (`list` of :obj:`Variable`): :obj:`Variable` list coming to :obj:`Function`.
+      outputs (`list` of :obj:`Variable`): :obj:`Function` list to coming from :obj:`Function`.
+      variable_to_funcs (`dict`): Dictionary from :obj:`Variable` to :obj:`Function`.
+
+    """
+    class Functor(object):
+
+        def __init__(self, funcs, inputs, outputs,
+                     variable_to_funcs):
+            self.funcs = funcs
+            self.inputs = inputs
+            self.outputs = outputs
+            self.variable_to_funcs = variable_to_funcs
+
+        def __call__(self, func):
+            self.funcs.append(func)
+            self.inputs.append(func.inputs)
+            self.outputs.append(func.outputs)
+            for i in func.inputs:
+                self.variable_to_funcs[i].append(func)
+
+    def __init__(self, pred):
+        self.funcs = []
+        self.inputs = []
+        self.outputs = []
+        self.variable_to_funcs = defaultdict(list)
+
+        functor = GraphInfo.Functor(self.funcs,
+                                    self.inputs, self.outputs,
+                                    self.variable_to_funcs)
+        pred.visit(functor)

--- a/python/src/nnabla/experimental/graph_converters/identity.py
+++ b/python/src/nnabla/experimental/graph_converters/identity.py
@@ -1,0 +1,94 @@
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+import numpy as np
+
+from .helpers import GraphInfo
+
+
+class IdentityConverter(object):
+    """
+    All functions are replaced with the same `new` function.
+
+    Args:
+        black_list (list): Black list of the function list.
+        params (:obj:`OrderedDict`): Result of nn.get_parameters().
+        name (:obj:`str`): Prefix of the parameter scope.
+
+    """
+
+    def __init__(self, black_list=[], params=None, name="identity"):
+        self.graph_info = None
+        self.entry_variables = None
+
+        self.black_list = black_list
+        self.params = params if params is not None else nn.get_parameters(
+            grad_only=False)
+        self.name = name
+
+        self.end_variable = None
+        self.outputs = []
+        # output of ref graph to output of new graph (TODO: change name)
+        self.input_map = {}
+
+    def convert(self, vroot, entry_variables):
+        """
+        All functions are replaced with the same `new` function.
+
+        Args:
+            vroot (:obj:`Variable`): NNabla Variable
+            entry_variables (:obj:`Variable`): Entry variable from which the conversion starts.
+        """
+        self.graph_info = GraphInfo(vroot)
+        self.entry_variables = entry_variables
+
+        with nn.parameter_scope(self.name):
+            # Function loop in the forward order
+            for func in self.graph_info.funcs:
+                o = self._identity_conversion(func)
+            self.end_variable = o
+        return self.end_variable
+
+    def _call_function(self, type_name, inputs, args):
+        import nnabla.function_bases as FB
+        function_expr = "FB.F.{type_name}(nn.{ctx}, **{args})".format(
+            type_name=type_name,
+            ctx=nn.Context(),
+            args=args)
+        function = eval(function_expr)
+        o = function(*inputs)
+        return o
+
+    def _identity_conversion(self, func):
+        import nnabla.function_bases as FB
+        inputs = []
+
+        # Inputs conversion
+        for i in func.inputs:
+            if i in self.entry_variables:    # entry input given by user
+                idx = self.entry_variables.index(i)
+                inputs.append(self.entry_variables[idx])
+            elif i in self.input_map:        # new input
+                inputs.append(self.input_map[i])
+            elif i in self.params.values():  # parameter input
+                idx = list(self.params.values()).index(i)
+                name = list(self.params.keys())[idx]
+                i = nn.parameter.get_parameter_or_create(name,
+                                                         i.shape,
+                                                         i.d,
+                                                         i.need_grad)
+                inputs.append(i)
+            else:                            # old inputs shared by the reference graph
+                inputs.append(i)
+
+        # Function Call
+        o = self._call_function(func.name, inputs, func.info.args)
+
+        # Map output of ref graph to output of new graph
+        x = func.outputs[0]
+        self.input_map[x] = o
+
+        # Store output (just in case)
+        self.outputs.append(o)
+
+        return o

--- a/python/src/nnabla/experimental/graph_converters/sequential.py
+++ b/python/src/nnabla/experimental/graph_converters/sequential.py
@@ -1,0 +1,29 @@
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+import numpy as np
+
+
+class SequentialConverter(object):
+    """Convert a given graph accoring to `converters`
+
+    Args:
+        converters (`list` of Converters): List of converters (e.g., FixedPointWeightConverter and FixedPointActivationConverter).
+    """
+
+    def __init__(self, converters=[]):
+        self.converters = converters
+
+    def convert(self, vroot, entry_variables):
+        """Convert a given graph.
+
+        Convert a given graph using the `converters` in the order of the registeration, i.e., sequentially.
+
+        Args:
+            vroot (:obj:`Variable`): NNabla Variable
+            entry_variables (:obj:`Variable`): Entry variable from which the conversion starts.
+        """
+
+        for converter in self.converters:
+            vroot = converter.convert(vroot, entry_variables)
+        return vroot

--- a/python/test/utils/test_graph_converters/graph_converter_test_utils.py
+++ b/python/test/utils/test_graph_converters/graph_converter_test_utils.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import time
+import numpy as np
+
+import nnabla as nn
+import nnabla.communicators as C
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+from nnabla.ext_utils import get_extension_context
+
+import nnabla.experimental.graph_converters as GC
+
+# -------
+# Testers
+# -------
+
+
+def structure_tester(vleaf_ref, vleaf_act):
+    ginfo_ref = GC.GraphInfo(vleaf_ref)
+    ginfo_act = GC.GraphInfo(vleaf_act)
+
+    # Length check
+    assert len(ginfo_ref.funcs) == len(ginfo_act.funcs)
+    assert len(ginfo_ref.inputs) == len(ginfo_act.inputs)
+    assert len(ginfo_ref.outputs) == len(ginfo_act.outputs)
+
+    # Input shape check
+    for is_ref, is_act in zip(ginfo_ref.inputs, ginfo_act.inputs):
+        assert len(is_ref) == len(is_act)
+        for i_ref, i_act in zip(is_ref, is_act):
+            assert i_ref.shape == i_act.shape
+
+    # Output shape check
+    for os_ref, os_act in zip(ginfo_ref.outputs, ginfo_act.outputs):
+        assert len(os_ref) == len(os_act)
+        for o_ref, o_act in zip(os_ref, os_act):
+            assert o_ref.shape == o_act.shape
+
+    # Func name check
+    for f_ref, f_act in zip(ginfo_ref.funcs, ginfo_act.funcs):
+        assert f_ref.name == f_act.name
+
+
+def value_tester(vleaf_ref, vleaf_act, rtol=1e-04, atol=1e-05):
+    vleaf_ref.forward()
+    vleaf_act.forward()
+    print("--- Values----")
+    print(vleaf_ref.d, vleaf_act.d)
+    print("--- Abs Diff ----")
+    print(np.abs(vleaf_ref.d - vleaf_act.d))
+    print("--- Sign Diff ----")
+    print(np.sign(vleaf_ref.d) - np.sign(vleaf_act.d))
+    assert np.allclose(vleaf_ref.d, vleaf_act.d, rtol=rtol, atol=atol)
+
+# -------
+# Helpers
+# -------
+
+
+def set_same_params(params_ref, params_act):
+    for i0, i1 in zip(params_ref.items(), params_act.items()):
+        k0, v0 = i0
+        k1, v1 = i1
+        v0.d = v1.d.copy()
+
+
+def print_params(params_ref, params_act, only_diff=False):
+    for i0, i1 in zip(params_ref.items(), params_act.items()):
+        k0, v0 = i0
+        k1, v1 = i1
+        print("params_ref, params_act", k0, k1)
+        print("params_ref, params_act", v0.shape, v1.shape)

--- a/python/test/utils/test_graph_converters/ref_graphs/helper.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/helper.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from nnabla.parameter import get_parameter_or_create
+
+
+def create_scale_bias(idx, maps, ndim=4):
+    shape = [1] * ndim
+    shape[1] = maps
+    a = get_parameter_or_create("a{}".format(idx), list(shape),
+                                None, True, True)
+    b = get_parameter_or_create("b{}".format(idx), list(shape),
+                                None, True, True)
+    return a, b

--- a/python/test/utils/test_graph_converters/ref_graphs/lenets.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/lenets.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from nnabla.parameter import get_parameter_or_create
+
+from .helper import create_scale_bias
+
+# LeNet
+
+
+def lenet(image, test=False):
+    h = PF.convolution(image, 16, (5, 5), (1, 1),
+                       with_bias=False, name='conv1')
+    h = PF.batch_normalization(h, batch_stat=not test, name='conv1-bn')
+    h = F.max_pooling(h, (2, 2))
+    h = F.relu(h)
+
+    h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True, name='conv2')
+    h = PF.batch_normalization(h, batch_stat=not test, name='conv2-bn')
+    h = F.max_pooling(h, (2, 2))
+    h = F.relu(h)
+
+    h = PF.affine(h, 10, with_bias=False, name='fc1')
+    h = PF.batch_normalization(h, batch_stat=not test, name='fc1-bn')
+    h = F.relu(h)
+
+    pred = PF.affine(h, 10, with_bias=True, name='fc2')
+    return pred
+
+
+# Small Fixed-point-weight LeNet
+def fpq_weight_lenet(image, test=False, n=8, delta=2e-4, name="fixed-point-weight-graph-ref"):
+    with nn.parameter_scope(name):
+        h = PF.fixed_point_quantized_convolution(image, 16, (5, 5), (1, 1),
+                                                 with_bias=False, n_w=n, delta_w=delta,
+                                                 name='conv1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv1-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.relu(h)
+
+        h = PF.fixed_point_quantized_convolution(h, 16, (5, 5), (1, 1),
+                                                 with_bias=True, n_w=n, delta_w=delta,
+                                                 name='conv2')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv2-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.relu(h)
+
+        h = PF.fixed_point_quantized_affine(
+            h, 10, with_bias=False, n_w=n, delta_w=delta, name='fc1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='fc1-bn')
+        h = F.relu(h)
+
+        pred = PF.fixed_point_quantized_affine(
+            h, 10, with_bias=True, n_w=n, delta_w=delta, name='fc2')
+    return pred
+
+# Small Fixed-point-activation LeNet
+
+
+def fpq_relu_lenet(image, test=False, n=8, delta=2e-4, name="fixed-point-relu-graph-ref"):
+    with nn.parameter_scope(name):
+        h = PF.convolution(image, 16, (5, 5), (1, 1),
+                           with_bias=False, name='conv1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv1-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.fixed_point_quantize(h, n=n, delta=delta, sign=False)
+
+        h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True, name='conv2')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv2-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.fixed_point_quantize(h, n=n, delta=delta, sign=False)
+
+        h = PF.affine(h, 10, with_bias=False, name='fc1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='fc1-bn')
+        h = F.fixed_point_quantize(h, n=n, delta=delta, sign=False)
+
+        pred = PF.affine(h, 10, with_bias=True, name='fc2')
+    return pred
+
+
+# Small Fixed-point LeNet
+def fpq_lenet(image, test=False, n=8, delta=2e-4, name="fixed-point-graph-ref"):
+    with nn.parameter_scope(name):
+        h = PF.fixed_point_quantized_convolution(image, 16, (5, 5), (1, 1),
+                                                 with_bias=False, delta_w=delta,
+                                                 name='conv1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv1-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.fixed_point_quantize(h, n=n, delta=delta, sign=False)
+
+        h = PF.fixed_point_quantized_convolution(h, 16, (5, 5), (1, 1),
+                                                 with_bias=True, delta_w=delta,
+                                                 name='conv2')
+        h = PF.batch_normalization(h, batch_stat=not test, name='conv2-bn')
+        h = F.max_pooling(h, (2, 2))
+        h = F.fixed_point_quantize(h, n=n, delta=delta, sign=False)
+
+        h = PF.fixed_point_quantized_affine(
+            h, 10, with_bias=False, delta_w=delta, name='fc1')
+        h = PF.batch_normalization(h, batch_stat=not test, name='fc1-bn')
+        h = F.fixed_point_quantize(h, n=n, delta=delta, sign=False)
+
+        pred = PF.fixed_point_quantized_affine(
+            h, 10, with_bias=True, delta_w=delta, name='fc2')
+    return pred
+
+
+# BatchNormalization Linear Small LeNet
+def bn_linear_lenet(image, test=False, name="bn-linear-graph-ref"):
+    with nn.parameter_scope(name):
+        h = PF.convolution(image, 16, (5, 5), (1, 1),
+                           with_bias=False, name='conv1')
+        a, b = create_scale_bias(1, h.shape[1])
+        h = a * h + b
+        h = F.max_pooling(h, (2, 2))
+        h = F.relu(h)
+
+        h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True, name='conv2')
+        a, b = create_scale_bias(2, h.shape[1])
+        h = a * h + b
+        h = F.max_pooling(h, (2, 2))
+        h = F.relu(h)
+
+        h = PF.affine(h, 10, with_bias=False, name='fc1')
+        a, b = create_scale_bias(4, h.shape[1], 2)
+        h = a * h + b
+        h = F.relu(h)
+
+        pred = PF.affine(h, 10, with_bias=True, name='fc2')
+    return pred
+
+
+# Batch Normalization Small LeNet
+def bn_folded_lenet(image, test=False, name="bn-folded-graph-ref"):
+    h = PF.convolution(image, 16, (5, 5), (1, 1), with_bias=True, name='conv1')
+    h = F.max_pooling(h, (2, 2))
+    h = F.relu(h)
+
+    h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True, name='conv2')
+    h = F.max_pooling(h, (2, 2))
+    h = F.relu(h)
+
+    h = PF.affine(h, 10, with_bias=True, name='fc1')
+    h = F.relu(h)
+
+    pred = PF.affine(h, 10, with_bias=True, name='fc2')
+    return pred

--- a/python/test/utils/test_graph_converters/ref_graphs/resnets.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/resnets.py
@@ -1,0 +1,226 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from nnabla.logger import logger
+from nnabla.config import nnabla_config
+from nnabla.utils.data_source_loader import load_image
+from nnabla.utils.data_iterator import data_iterator_csv_dataset
+from nnabla.utils.data_iterator import data_iterator_simple
+
+from nnabla.experimental import graph_converters as GC
+
+from .helper import create_scale_bias
+
+
+# Small ResNet
+def resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1), test=False, name="convblock"):
+    h = x
+    with nn.parameter_scope(name):
+        h = PF.convolution(h, maps, kernel=kernel, pad=pad,
+                           stride=stride, with_bias=False)
+        h = PF.batch_normalization(h, batch_stat=not test)
+    return F.relu(h + x)
+
+
+def small_resnet(image, test=False):
+    h = image
+    h /= 255.0
+    h = PF.convolution(h, 16, kernel=(3, 3), pad=(
+        1, 1), name="first-conv", with_bias=False)
+    h = PF.batch_normalization(h, name="first-bn", batch_stat=not test)
+    h = F.relu(h)
+    h = resblock(h, maps=16, test=test, name="cb1")
+    h = resblock(h, maps=16, test=test, name="cb2")
+    h = resblock(h, maps=16, test=test, name="cb3")
+    h = resblock(h, maps=16, test=test, name="cb4")
+    pred = PF.affine(h, 10, name='fc')
+    return pred
+
+
+# Small Fixed-point-weight ResNet
+def fpq_weight_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1), test=False,
+                        sign=True, n=8, delta=2e-4,
+                        name="convblock"):
+    h = x
+    with nn.parameter_scope(name):
+        h = PF.fixed_point_quantized_convolution(h, maps, kernel=kernel, pad=pad, stride=stride,
+                                                 with_bias=False,
+                                                 sign_w=sign, n_w=n, delta_w=delta,
+                                                 sign_b=sign, n_b=n, delta_b=delta)
+        h = PF.batch_normalization(h, batch_stat=not test)
+    return F.relu(h + x)
+
+
+def fpq_weight_small_resnet(image, test=False, sign=True, n=8, delta=2e-4,
+                            name="fixed-point-graph-ref"):
+    with nn.parameter_scope(name):
+        h = image
+        h /= 255.0
+        h = PF.fixed_point_quantized_convolution(h, 16, kernel=(3, 3), pad=(1, 1),
+                                                 sign_w=sign, n_w=n, delta_w=delta,
+                                                 sign_b=sign, n_b=n, delta_b=delta,
+                                                 with_bias=False,
+                                                 name="first-conv")
+        h = PF.batch_normalization(h, name="first-bn", batch_stat=not test)
+        h = F.relu(h)
+        h = fpq_weight_resblock(h, maps=16, test=test,
+                                sign=sign, n=n, delta=delta, name="cb1")
+        h = fpq_weight_resblock(h, maps=16, test=test,
+                                sign=sign, n=n, delta=delta, name="cb2")
+        h = fpq_weight_resblock(h, maps=16, test=test,
+                                sign=sign, n=n, delta=delta, name="cb3")
+        h = fpq_weight_resblock(h, maps=16, test=test,
+                                sign=sign, n=n, delta=delta, name="cb4")
+        pred = PF.fixed_point_quantized_affine(h, 10,
+                                               sign_w=sign, n_w=n, delta_w=delta,
+                                               sign_b=sign, n_b=n, delta_b=delta,
+                                               name='fc')
+    return pred
+
+
+# Small Fixed-point-activation ResNet
+def fpq_relu_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1), test=False,
+                      sign=False, n=8, delta=2e-4,
+                      name="convblock"):
+    h = x
+    with nn.parameter_scope(name):
+        h = PF.convolution(h, maps, kernel=kernel, pad=pad,
+                           stride=stride, with_bias=False)
+        h = PF.batch_normalization(h, batch_stat=not test)
+    return F.fixed_point_quantize(h + x, n=n, sign=sign, delta=delta)
+
+
+def fpq_relu_small_resnet(image, test=False,
+                          sign=False, n=8, delta=2e-4,
+                          name="fixed-point-graph-ref"):
+    with nn.parameter_scope(name):
+        h = image
+        h /= 255.0
+        h = PF.convolution(h, 16, kernel=(3, 3), pad=(
+            1, 1), name="first-conv", with_bias=False)
+        h = PF.batch_normalization(h, name="first-bn", batch_stat=not test)
+        h = F.fixed_point_quantize(h, sign=sign, n=n, delta=delta)
+        h = fpq_relu_resblock(h, maps=16, test=test,
+                              sign=sign, n=n, delta=delta, name="cb1")
+        h = fpq_relu_resblock(h, maps=16, test=test,
+                              sign=sign, n=n, delta=delta, name="cb2")
+        h = fpq_relu_resblock(h, maps=16, test=test,
+                              sign=sign, n=n, delta=delta, name="cb3")
+        h = fpq_relu_resblock(h, maps=16, test=test,
+                              sign=sign, n=n, delta=delta, name="cb4")
+        pred = PF.affine(h, 10, name='fc')
+    return pred
+
+
+# Small Fixed-point ResNet
+def fpq_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1), test=False,
+                 sign=True, n=8, delta=2e-4,
+                 name="convblock"):
+    h = x
+    with nn.parameter_scope(name):
+        h = PF.fixed_point_quantized_convolution(h, maps, kernel=kernel, pad=pad, stride=stride,
+                                                 with_bias=False,
+                                                 sign_w=sign, n_w=n, delta_w=delta,
+                                                 sign_b=sign, n_b=n, delta_b=delta)
+        h = PF.batch_normalization(h, batch_stat=not test)
+    return F.fixed_point_quantize(h + x, n=n, sign=sign, delta=delta)
+
+
+def fpq_small_resnet(image, test=False, sign=True, n=8, delta=2e-4,
+                     name="fixed-point-graph-ref"):
+    with nn.parameter_scope(name):
+        h = image
+        h /= 255.0
+        h = PF.fixed_point_quantized_convolution(h, 16, kernel=(3, 3), pad=(1, 1),
+                                                 sign_w=sign, n_w=n, delta_w=delta,
+                                                 sign_b=sign, n_b=n, delta_b=delta,
+                                                 with_bias=False,
+                                                 name="first-conv")
+        h = PF.batch_normalization(h, name="first-bn", batch_stat=not test)
+        h = F.fixed_point_quantize(h, n=n, sign=sign, delta=delta)
+        h = fpq_resblock(h, maps=16, test=test, sign=sign,
+                         n=n, delta=delta, name="cb1")
+        h = fpq_resblock(h, maps=16, test=test, sign=sign,
+                         n=n, delta=delta, name="cb2")
+        h = fpq_resblock(h, maps=16, test=test, sign=sign,
+                         n=n, delta=delta, name="cb3")
+        h = fpq_resblock(h, maps=16, test=test, sign=sign,
+                         n=n, delta=delta, name="cb4")
+        pred = PF.fixed_point_quantized_affine(h, 10,
+                                               sign_w=sign, n_w=n, delta_w=delta,
+                                               sign_b=sign, n_b=n, delta_b=delta,
+                                               name='fc')
+    return pred
+
+# BatchNormalization Linear Small ResNet
+
+
+def bn_linear_resblock(x, i, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1), name="convblock"):
+    h = x
+    with nn.parameter_scope(name):
+        h = PF.convolution(h, maps, kernel=kernel, pad=pad,
+                           stride=stride, with_bias=False)
+        a, b = create_scale_bias(i, h.shape[1])
+        h = a * h + b
+    return F.relu(h + x)
+
+
+def bn_linear_small_resnet(image,
+                           name="bn-linear-graph-ref"):
+    h = image
+    h /= 255.0
+    h = PF.convolution(h, 16, kernel=(3, 3), pad=(
+        1, 1), name="first-conv", with_bias=False)
+    a, b = create_scale_bias(1, h.shape[1])
+    h = a * h + b
+    h = F.relu(h)
+    h = bn_linear_resblock(h, 2, maps=16, name="cb1")
+    h = bn_linear_resblock(h, 3, maps=16, name="cb2")
+    h = bn_linear_resblock(h, 4, maps=16, name="cb3")
+    h = bn_linear_resblock(h, 5, maps=16, name="cb4")
+    pred = PF.affine(h, 10, name='fc')
+    return pred
+
+
+# Batch Normalization Folded Small ResNet
+def bn_folded_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1), test=False, name="convblock"):
+    h = x
+    with nn.parameter_scope(name):
+        h = PF.convolution(h, maps, kernel=kernel, pad=pad,
+                           stride=stride, with_bias=True)
+    return F.relu(h + x)
+
+
+def bn_folded_small_resnet(image, test=False,
+                           name="bn-folded-graph-ref"):
+    h = image
+    h /= 255.0
+    h = PF.convolution(h, 16, kernel=(3, 3), pad=(
+        1, 1), name="first-conv", with_bias=True)
+    h = F.relu(h)
+    h = bn_folded_resblock(h, maps=16, test=test, name="cb1")
+    h = bn_folded_resblock(h, maps=16, test=test, name="cb2")
+    h = bn_folded_resblock(h, maps=16, test=test, name="cb3")
+    h = bn_folded_resblock(h, maps=16, test=test, name="cb4")
+    pred = PF.affine(h, 10, name='fc')
+    return pred

--- a/python/test/utils/test_graph_converters/test_batch_normalization_folded.py
+++ b/python/test/utils/test_graph_converters/test_batch_normalization_folded.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from collections import OrderedDict
+
+from ref_graphs.lenets import lenet, bn_folded_lenet
+from ref_graphs.resnets import small_resnet, bn_folded_small_resnet
+
+
+lenet_ref = bn_folded_lenet
+small_resnet_ref = bn_folded_small_resnet
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("test", [True])
+@pytest.mark.parametrize("graph_ref, graph_act",
+                         [(lenet_ref, lenet),
+                          (small_resnet_ref, small_resnet)
+                          ])
+def test_batch_normalization_folded(seed, test, graph_ref, graph_act):
+    from graph_converter_test_utils import structure_tester, value_tester, print_params
+
+    nn.clear_parameters()
+
+    # Random number
+    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
+
+    # Graph
+    x_data = rng.randn(4, 3, 32, 32)
+    x = nn.Variable.from_numpy_array(x_data)
+    y_tgt = graph_act(x, test=test)
+
+    # Convert
+    name = "bn-folded-graph"
+    converter = GC.BatchNormalizationFoldedConverter(name=name)
+    y_act = converter.convert(y_tgt, [x])
+
+    # Ref Graph
+    name = "bn-folded-graph-ref"
+    y_ref = graph_ref(x, name=name)
+
+    # Test
+    structure_tester(y_ref, y_act)
+    value_tester(y_tgt, y_act)

--- a/python/test/utils/test_graph_converters/test_batch_normalization_linear.py
+++ b/python/test/utils/test_graph_converters/test_batch_normalization_linear.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from collections import OrderedDict
+
+from ref_graphs.lenets import lenet, bn_linear_lenet
+from ref_graphs.resnets import small_resnet, bn_linear_small_resnet
+
+
+lenet_ref = bn_linear_lenet
+small_resnet_ref = bn_linear_small_resnet
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("test", [True])
+@pytest.mark.parametrize("graph_ref, graph_act",
+                         [(lenet_ref, lenet),
+                          (small_resnet_ref, small_resnet)
+                          ])
+def test_batch_normalization_linear(seed, test, graph_ref, graph_act):
+    from graph_converter_test_utils import structure_tester, value_tester, print_params
+    # because linearized parameters (c0, c1) are to be shared among models
+    nn.clear_parameters()
+
+    # Random number
+    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
+
+    # Graph
+    x_data = rng.randn(4, 3, 32, 32)
+    x = nn.Variable.from_numpy_array(x_data)
+    y_tgt = graph_act(x, test=test)
+
+    # Convert
+    name = "bn-linear-graph"
+    converter = GC.BatchNormalizationLinearConverter(name=name)
+    y_act = converter.convert(y_tgt, [x])
+
+    # Ref Graph
+    name = "bn-linear-graph-ref"
+    y_ref = graph_ref(x, name=name)
+
+    # Test
+    structure_tester(y_ref, y_act)
+    value_tester(y_tgt, y_act)

--- a/python/test/utils/test_graph_converters/test_fixed_point_activation.py
+++ b/python/test/utils/test_graph_converters/test_fixed_point_activation.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from collections import OrderedDict
+
+from ref_graphs.lenets import lenet, fpq_relu_lenet
+from ref_graphs.resnets import small_resnet, fpq_relu_small_resnet
+
+
+lenet_ref = fpq_relu_lenet
+small_resnet_ref = fpq_relu_small_resnet
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("graph_ref, graph_act",
+                         [(lenet_ref, lenet),
+                          (small_resnet_ref, small_resnet)
+                          ])
+def test_fixed_point_activation(seed, graph_ref, graph_act):
+    from graph_converter_test_utils import structure_tester, value_tester, print_params
+
+    # Random number
+    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
+
+    # Graph
+    x_data = rng.randn(4, 3, 32, 32)
+    x = nn.Variable.from_numpy_array(x_data)
+    y_tgt = graph_act(x)
+
+    # Convert
+    args_fpq = {"n": 8, "sign": False, "delta": 2e-4}
+    name = "fixed-point-activation-graph"
+    converter = GC.FixedPointActivationConverter(args_fpq=args_fpq, name=name)
+    y_act = converter.convert(y_tgt, [x])
+
+    # Ref Graph
+    name = "fixed-point-activation-graph-ref"
+    y_ref = graph_ref(x, name=name)
+
+    # Test
+    structure_tester(y_ref, y_act)
+    #value_tester(y_tgt, y_act, rtol=1e-03, atol=1e-02)

--- a/python/test/utils/test_graph_converters/test_fixed_point_graph.py
+++ b/python/test/utils/test_graph_converters/test_fixed_point_graph.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from collections import OrderedDict
+
+from ref_graphs.lenets import lenet, fpq_lenet
+from ref_graphs.resnets import small_resnet, fpq_small_resnet
+
+
+lenet_ref = fpq_lenet
+small_resnet_ref = fpq_small_resnet
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("graph_ref, graph_act",
+                         [(lenet_ref, lenet),
+                          (small_resnet_ref, small_resnet)
+                          ])
+def test_fixed_point_graph(seed, graph_ref, graph_act):
+    # TODO: adaptive delta case (how to test it...)
+
+    from graph_converter_test_utils import structure_tester, value_tester, print_params
+
+    # Random number
+    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
+
+    # Graph
+    x_data = rng.randn(4, 3, 32, 32)
+    x = nn.Variable.from_numpy_array(x_data)
+    y_tgt = graph_act(x)
+
+    # Convert weights/activations
+    args_fpq = {"sign_w": True, "n_w": 8, "delta_w": 2e-4, "quantize_w": True,
+                "sign_b": True, "n_b": 8, "delta_b": 2e-4, "quantize_b": True}
+    name = "fixed-point-graph"
+    converter_w = GC.FixedPointWeightConverter(args_fpq=args_fpq, name=name)
+
+    name = "fixed-point-graph"
+    args_fpq = {"n": 8, "sign": False, "delta": 2e-4}
+    converter_a = GC.FixedPointActivationConverter(
+        args_fpq=args_fpq, name=name)
+
+    # Convert sequentially
+    converter = GC.SequentialConverter([converter_w, converter_a])
+    y_act = converter.convert(y_tgt, [x])
+
+    # Ref Graph
+    name = "fixed-point-graph-ref"
+    y_ref = graph_ref(x, name=name)
+
+    # Test
+    structure_tester(y_ref, y_act)
+    #value_tester(y_tgt, y_act, rtol=1e-03, atol=1e-02)

--- a/python/test/utils/test_graph_converters/test_fixed_point_weight.py
+++ b/python/test/utils/test_graph_converters/test_fixed_point_weight.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from collections import OrderedDict
+
+from ref_graphs.lenets import lenet, fpq_weight_lenet
+from ref_graphs.resnets import small_resnet, fpq_weight_small_resnet
+
+
+lenet_ref = fpq_weight_lenet
+small_resnet_ref = fpq_weight_small_resnet
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("graph_ref, graph_act",
+                         [(lenet_ref, lenet),
+                          (small_resnet_ref, small_resnet)
+                          ])
+def test_fixed_point_weight(seed, graph_ref, graph_act):
+    # TODO: adaptive delta case (how to test it...)
+
+    from graph_converter_test_utils import structure_tester, value_tester, print_params
+
+    # Random number
+    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
+
+    # Graph
+    x_data = rng.randn(4, 3, 32, 32)
+    x = nn.Variable.from_numpy_array(x_data)
+    y_tgt = graph_act(x)
+
+    # Convert
+    args_fpq = {"sign_w": True, "n_w": 8, "delta_w": 2e-4, "quantize_w": True,
+                "sign_b": True, "n_b": 8, "delta_b": 2e-4, "quantize_b": True}
+    name = "fixed-point-graph"
+    converter = GC.FixedPointWeightConverter(args_fpq=args_fpq, name=name)
+    y_act = converter.convert(y_tgt, [x])
+
+    # Ref Graph
+    name = "fixed-point-weight-graph-ref"
+    y_ref = graph_ref(x, name=name)
+
+    # Test
+    structure_tester(y_ref, y_act)
+    #value_tester(y_tgt, y_act, rtol=1e-03, atol=1e-02)

--- a/python/test/utils/test_graph_converters/test_identity_gc.py
+++ b/python/test/utils/test_graph_converters/test_identity_gc.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+from nnabla.logger import logger
+from nnabla.config import nnabla_config
+from nnabla.utils.data_source_loader import load_image
+from nnabla.utils.data_iterator import data_iterator_csv_dataset
+from nnabla.utils.data_iterator import data_iterator_simple
+
+from ref_graphs.lenets import lenet
+from ref_graphs.resnets import small_resnet
+
+
+lenet_ref = lenet
+small_resnet_ref = small_resnet
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("graph_ref, graph_act",
+                         [(lenet_ref, lenet),
+                          (small_resnet_ref, small_resnet)])
+def test_identity(seed, graph_ref, graph_act):
+    from graph_converter_test_utils import structure_tester, value_tester
+
+    # Random number
+    rng = np.random.RandomState(seed)
+
+    # Graph
+    x_data = rng.randn(4, 3, 32, 32)
+    x = nn.Variable.from_numpy_array(x_data)
+    y_tgt = graph_act(x)
+
+    # Convert
+    converter = GC.IdentityConverter()
+    y_act = converter.convert(y_tgt, [x])
+
+    # Ref Graph
+    y_ref = graph_ref(x)
+
+    # Test
+    structure_tester(y_ref, y_act)
+    value_tester(y_tgt, y_act)

--- a/tutorial/graph_converter_for_inference.ipynb
+++ b/tutorial/graph_converter_for_inference.ipynb
@@ -1,0 +1,603 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Graph Converter for Inference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial, we demonstrate several graph converters mainly used for inference. Graph converters are basically used for a trained graph, neural network, so once you train a neural network, you can use graph converters.  \n",
+    "\n",
+    "We show how to use the following graph converters step-by-step according to usecases."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1. BatchNormalizationLinearConverter\n",
+    "2. BatchNormalizationFoldedConverter\n",
+    "3. FixedPointWeightConverter\n",
+    "4. FixedPointActivationConverter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Note** before starting the following instruction, import python modules needed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Import\n",
+    "import numpy as np\n",
+    "import nnabla as nn\n",
+    "import nnabla.functions as F\n",
+    "import nnabla.parametric_functions as PF\n",
+    "\n",
+    "import nnabla.experimental.viewers as V\n",
+    "import nnabla.experimental.graph_converters as GC"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, define LeNet as the motif."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# LeNet\n",
+    "def LeNet(image, test=False):\n",
+    "    h = PF.convolution(image, 16, (5, 5), (1, 1), with_bias=False, name='conv1')\n",
+    "    h = PF.batch_normalization(h, batch_stat=not test, name='conv1-bn')\n",
+    "    h = F.max_pooling(h, (2, 2))\n",
+    "    h = F.relu(h)\n",
+    "\n",
+    "    h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True, name='conv2')\n",
+    "    h = PF.batch_normalization(h, batch_stat=not test, name='conv2-bn')\n",
+    "    h = F.max_pooling(h, (2, 2))\n",
+    "    h = F.relu(h)\n",
+    "     \n",
+    "    h = PF.affine(h, 10, with_bias=False, name='fc1')\n",
+    "    h = PF.batch_normalization(h, batch_stat=not test, name='fc1-bn')\n",
+    "    h = F.relu(h)\n",
+    "\n",
+    "    pred = PF.affine(h, 10, with_bias=True, name='fc2')\n",
+    "    return pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BatchNormalizationLinearConverter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Typical networks contain the batch normalization layers. It serves as normalization in a network and uses the batch stats (the batch mean and variance) to normalize inputs as \n",
+    "\n",
+    "$$\n",
+    "z = \\gamma \\frac{x - \\mu}{\\sqrt{\\sigma^2 + \\epsilon}} + \\beta,\n",
+    "$$\n",
+    "\n",
+    "\n",
+    "in training. $\\mu$ and $\\sigma^2$ are the batch mean and variance, and $\\gamma$ and $\\beta$ are the scale and bias parameter to be learnt.\n",
+    "\n",
+    "At the same time, it computes the running stats (the exponential moving average $\\mu_r$ and variance $\\sigma_r^2$ of inputs to the batch normalization layer), which are used later for inference.\n",
+    "\n",
+    "\n",
+    "If nothing changes, in inference time, the batch normalization is performed as in the above equation using the running stats.\n",
+    "\n",
+    "$$\n",
+    "z = \\gamma \\frac{x - \\mu_r}{\\sqrt{\\sigma_r^2 + \\epsilon}} + \\beta.\n",
+    "$$\n",
+    "\n",
+    "This is the explicit normalization, so as you can see, there are many redundant computations (subtraction, devision, pow2, sqrt, multiplication, addition) in inference, which should be avoided in inference graph. We can do it by ourselves, but it is apparently troublesome.\n",
+    "\n",
+    "BatchNormalizationLinearConverter automatically converts this equation of the batch normalization to the simple linear form as \n",
+    "\n",
+    "$$\n",
+    "z = c_0 x + c_1, \\\\\n",
+    "c_0 = \\frac{\\gamma}{\\sqrt{\\sigma_r^2 + \\epsilon}}, \\\\\n",
+    "c_1 = \\beta - \\frac{\\gamma \\mu_r}{\\sqrt{\\sigma_r^2 + \\epsilon}}.\n",
+    "$$\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "After the conversion, we just have one multiplication and one addition since $c_0$ and $c_1$ can be precomputed in inference.\n",
+    "\n",
+    "Specifically, suppose that $x$ is the output of the 2D-Convolution, so $x$ is 3D-Tensor (e.g., $N \\times H \\times W$). In the batch normalization, the number of $c$s is the map size $N$, respectively for $c_0$ and $c_1$. Thus, the multiplication ($c_0 \\times x$) is $N \\times H \\times W$ and the addition ($ + c_1$) is same $N \\times H \\times W$. We can see much reduction compared to the native implementation."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, create LeNet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))\n",
+    "y = LeNet(x, test=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now look at LeNet visually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert it to the one with the batch normalization linearly folded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "converter = GC.BatchNormalizationLinearConverter(name=\"bn-linear-lenet\")\n",
+    "y = converter.convert(y, [x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, show the converted graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## BatchNormalizationFoldedConverter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see in the previous converter, BatchNormalizationLinearConverter is the linear folding of the batch normalization layer in inference. However, if the preceding layer of the batch normalization is the convolution, affine or another layer performing inner-product, that the linear folding is further folded into the weights of the preceding layers.\n",
+    "\n",
+    "Suppose the sequence of a convolution and a batch normalization in inference, it can be written as, \n",
+    "\n",
+    "$$\n",
+    "z = c_0 \\times (w \\ast x + b) + c_1,\n",
+    "$$\n",
+    "\n",
+    "where $\\ast$ is the convolutional operator, $w$ is the convolutional weights, and $b$ is the bias of the convolution layer. Since $\\ast$ has linearity, we can further fold $c_0$ into the weights $w$ and bias $b$, such that we have the simpler form.\n",
+    "\n",
+    "$$\n",
+    "z = w' \\ast x + b', \\\\\n",
+    "w' = c_0 w, \\\\\n",
+    "b' = c_0 b + c_1.\n",
+    "$$\n",
+    "\n",
+    "BatchNormalizationFoldedConverter automatically finds a sequence of the convolution and the batch normalization in a given graph, then folds all parameters related to the batch normalization into the preceding convolution layer. Now, we do not need the multiplication and addition seen in the previous case, BatchNormalizationLinearConverter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, create LeNet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))\n",
+    "y = LeNet(x, test=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now look at LeNet visually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert it to the one with the batch normalization linearly folded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "converter = GC.BatchNormalizationFoldedConverter(name=\"bn-folded-lenet\")\n",
+    "y = converter.convert(y, [x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, show the converted graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FixedPointWeightConverter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Once training finishes, where to deploy? Your destination of deployment of a trained model might be on Cloud or an embedded device. In either case, the typical data type, FloatingPoint32 (FP32) might be redundant for inference, so you may want to use SIMD operation with e.g., 4-bit or 8-bit of your target device. Training is usually performed using FP32, while interfence might be performed FixedPoint. Hence, you have to change corresponding layers, e.g., the convolution and affine.\n",
+    "\n",
+    "FixedPointWeightConverter automatically converts the affine, convolution, and deconvolution of a given graph to that of fixed point version. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, create LeNet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))\n",
+    "y = LeNet(x, test=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now look at LeNet visually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert it to the one with the batch normalization linearly folded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "converter = GC.FixedPointWeightConverter(name=\"fixed-point-weight-lenet\")\n",
+    "y = converter.convert(y, [x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, show the converted graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FixedPointActivationConverter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "FixedPointWeightConverter converts layers of weights, but FixedPointActivationConverter automatically converts activation layers, e.g., ReLU. The typial neural network architecture contains the sequence of the block `ReLU -> Convolution -> BatchNormalization`; therefore, when you convert both `ReLU` and `Convolution` to the fixed-point ones with proper hyper-paremters (step-size and bitwidth), you can utilize your SIMD operation of your target device because both of the weights and inputs of the convolution are fixed-point. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First, create LeNet."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "x = nn.Variable.from_numpy_array(np.random.rand(4, 3, 28, 28))\n",
+    "y = LeNet(x, test=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now look at LeNet visually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Convert it to the one with the batch normalization linearly folded."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "converter = GC.FixedPointActivationConverter(name=\"fixed-point-activation-lenet\")\n",
+    "y = converter.convert(y, [x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, show the converted graph."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Tipically, FixedPointWeightConverter and FixedPointActivationConverter are used togather. For such purposes, you can use `GC.SequentialConverter`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "converter_w = GC.FixedPointWeightConverter(name=\"fixed-point-lenet\")\n",
+    "converter_a = GC.FixedPointActivationConverter(name=\"fixed-point-lenet\")\n",
+    "converter = GC.SequentialConverter([converter_w, converter_a])\n",
+    "y = converter.convert(y, [x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Needless to say, `GC.SequentialConverter` is not limited to using this case. One you creat your own `Conveterter`s, then you can add these converters to `GC.SequentialConverter` if these are used togather.\n",
+    "\n",
+    "Look at the converted graph visually."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "viewer = V.SimpleGraph()\n",
+    "viewer.view(y)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
Typical graph conversion (experimental):

Convert in a computational graph

|Name| from | to |
| --- | --- | --- |
|BatchNormalizationLinearConverter|gamma, beta, mean, std|scale and bias (i.e., multiply and addtion) |
|BatchNormalizationFoldedConverter|gamma, beta, mean, std|preceding convolution weight and bias|
|FixedPointWeightConverter|convolution, affine|fixed-point counterparts|
|FixedPointActivationConverter|relu|fixed-point counterpart|
|IdentityConverter|*|*|