### PR TITLE
[Experimental] PyTorch-like Functions

### DIFF
--- a/doc/python/api/experimental.rst
+++ b/doc/python/api/experimental.rst
@@ -33,7 +33,56 @@ GraphConveter
     :members:
 
 
+Parametric Function Classes
+---------------------------
+
+.. autoclass:: nnabla.experimental.parametric_function_class.affine.Affine
     :members:
 
+.. autoclass:: nnabla.experimental.parametric_function_class.affine.Linear
+    :members:
 
+.. autoclass:: nnabla.experimental.parametric_function_class.convolution.Convolution
+    :members:
 
+.. autoclass:: nnabla.experimental.parametric_function_class.convolution.Conv1d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.convolution.Conv2d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.convolution.Conv3d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.convolution.ConvNd
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.deconvolution.Deconvolution
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.deconvolution.Deconv1d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.deconvolution.Deconv2d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.deconvolution.Deconv3d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.deconvolution.DeconvNd
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.batch_normalization.BatchNormalization
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.batch_normalization.BatchNorm1d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.batch_normalization.BatchNorm2d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.batch_normalization.BatchNorm3d
+    :members:
+
+.. autoclass:: nnabla.experimental.parametric_function_class.embed.Embed
+    :members:

--- a/doc/python/api/experimental.rst
+++ b/doc/python/api/experimental.rst
@@ -17,10 +17,22 @@ SimpleGraph
 GraphConveter
 -------------
 
-.. automodule:: nnabla.experimental.graph_converters
-    :classes:
+.. autoclass:: nnabla.experimental.graph_converters.identity.IdentityConverter
+    :members:
 
-.. autoclass:: nnabla.experimental.graph_converters.identity_graph.IdentityGraph
+.. autoclass:: nnabla.experimental.graph_converters.batch_normalization_linear.BatchNormalizationLinearConverter
+    :members:
+
+.. autoclass:: nnabla.experimental.graph_converters.batch_normalization_folded.BatchNormalizationFoldedConverter
+    :members:
+
+.. autoclass:: nnabla.experimental.graph_converters.fixed_point_weight.FixedPointWeightConverter
+    :members:
+
+.. autoclass:: nnabla.experimental.graph_converters.fixed_point_activation.FixedPointActivationConverter
+    :members:
+
+
     :members:
 
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -233,6 +233,7 @@ if __name__ == '__main__':
                 'nnabla.contrib',
                 'nnabla.experimental',
                 'nnabla.experimental.graph_converters',
+                'nnabla.experimental.parametric_function_class',
                 'nnabla.utils',
                 'nnabla.utils.cli',
                 'nnabla.utils.converter',

--- a/python/src/nnabla/experimental/parametric_function_class/__init__.py
+++ b/python/src/nnabla/experimental/parametric_function_class/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/src/nnabla/experimental/parametric_function_class/affine.py
+++ b/python/src/nnabla/experimental/parametric_function_class/affine.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as F
+from nnabla.parameter import get_parameter_or_create, get_parameter
+from nnabla.initializer import (
+    calc_uniform_lim_glorot,
+    ConstantInitializer, NormalInitializer, UniformInitializer)
+
+from .module import Module
+
+class Affine(Module):
+    """
+    The affine layer, also known as the fully connected layer. Computes
+
+    .. math::
+        {\\mathbf y} = {\\mathbf A} {\\mathbf x} + {\\mathbf b}.
+
+    where :math:`{\\mathbf x}, {\\mathbf y}` are the inputs and outputs respectively,
+    and :math:`{\\mathbf A}, {\\mathbf b}` are constants.
+
+    Args:
+        inp (~nnabla.Variable): Input N-D array with shape (:math:`M_0 \\times \ldots \\times M_{B-1} \\times D_B \\times \ldots \\times D_N`). Dimensions before and after base_axis are flattened as if it is a matrix.
+        n_outmaps (:obj:`int` or :obj:`tuple` of :obj:`int`): Number of output neurons per data.
+        base_axis (int): Dimensions up to `base_axis` are treated as the sample dimensions.
+        w_init (:obj:`nnabla.initializer.BaseInitializer` or :obj:`numpy.ndarray`): Initializer for weight. By default, it is initialized with :obj:`nnabla.initializer.UniformInitializer` within the range determined by :obj:`nnabla.initializer.calc_uniform_lim_glorot`.
+        b_init (:obj:`nnabla.initializer.BaseInitializer` or :obj:`numpy.ndarray`): Initializer for bias. By default, it is initialized with zeros if `with_bias` is `True`.
+        fix_parameters (bool): When set to `True`, the weights and biases will not be updated.
+        rng (numpy.random.RandomState): Random generator for Initializer.
+        with_bias (bool): Specify whether to include the bias term.
+
+    Returns:
+        :class:`~nnabla.Variable`: :math:`(B + 1)`-D array. (:math:`M_0 \\times \ldots \\times M_{B-1} \\times L`)f
+
+    """
+
+    def __init__(self, n_inmaps, n_outmaps, base_axis=1, w_init=None, b_init=None, 
+                 fix_parameters=False, rng=None, with_bias=True):
+        if not hasattr(n_outmaps, '__iter__'):
+            n_outmaps = [n_outmaps]
+        n_outmaps = list(n_outmaps)
+        n_outmap = int(np.prod(n_outmaps))
+        if w_init is None:
+            w_init = UniformInitializer(
+                calc_uniform_lim_glorot(n_inmaps, n_outmap), rng=rng)
+        if with_bias and b_init is None:
+            b_init = ConstantInitializer()
+        w_shape = (n_inmaps, n_outmap)
+        w = nn.Variable.from_numpy_array(w_init(w_shape)).apply(need_grad=not fix_parameters)
+        b = None
+        if with_bias:
+            b_shape = (n_outmap, )
+            b = nn.Variable.from_numpy_array(b_init(b_shape)).apply(need_grad=not fix_parameters)
+        
+        self.W = w
+        self.b = b
+        self.base_axis = base_axis
+        
+    def __call__(self, inp):
+        return F.affine(inp, self.W, self.b, self.base_axis)
+
+Linear = Affine

--- a/python/src/nnabla/experimental/parametric_function_class/batch_normalization.py
+++ b/python/src/nnabla/experimental/parametric_function_class/batch_normalization.py
@@ -1,0 +1,284 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as F
+from nnabla.parameter import get_parameter_or_create, get_parameter
+from nnabla.initializer import (
+    calc_uniform_lim_glorot,
+    ConstantInitializer, NormalInitializer, UniformInitializer)
+
+from .module import Module
+
+class BatchNormalization(Module):
+    """
+    Batch normalization layer.
+
+    .. math::
+
+        \\begin{array}{lcl}
+        \\mu &=& \\frac{1}{M} \\sum x_i\\\\
+        \\sigma^2 &=& \\frac{1}{M} \\left(\\sum x_i - \\mu\\right)^2\\\\
+        \\hat{x}_i &=& \\frac{x_i - \\mu}{\\sqrt{\\sigma^2 + \\epsilon }}\\\\
+        y_i &= & \\hat{x}_i \\gamma + \\beta.
+        \\end{array}
+
+    where :math:`x_i, y_i` are the inputs.
+    In testing, the mean and variance computed by moving average calculated during training are used.
+
+    Args:
+        inp (~nnabla.Variable): N-D array of input.
+        axes (:obj:`tuple` of :obj:`int`):
+            Mean and variance for each element in ``axes`` are calculated using
+            elements on the rest axes. For example, if an input is 4 dimensions,
+            and ``axes`` is ``[1]``,  batch mean is calculated as
+            ``np.mean(inp.d, axis=(0, 2, 3), keepdims=True)``
+            (using numpy expression as an example).
+        decay_rate (float): Decay rate of running mean and variance.
+        eps (float): Tiny value to avoid zero division by std.
+        batch_stat (bool): Use mini-batch statistics rather than running ones.
+        output_stat (bool): Output batch mean and variance.
+        fix_parameters (bool): When set to `True`, the beta and gamma will not be updated.
+        param_init (dict):
+            Parameter initializers can be set with a dict. A key of the dict must
+            be ``'beta'``, ``'gamma'``, ``'mean'`` or ``'var'``.
+            A value of the dict must be an :obj:`~nnabla.initializer.Initializer`
+            or a :obj:`numpy.ndarray`.
+            E.g. ``{'beta': ConstantIntializer(0), 'gamma': np.ones(gamma_shape) * 2}``.
+
+    Returns:
+        :class:`~nnabla.Variable`: N-D array.
+
+    References:
+
+        - Ioffe and Szegedy, Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift. https://arxiv.org/abs/1502.03167
+
+    The shape of parameters has the same number of dimensions with the input
+    data, and the shapes in ``axes`` has the same dimensions with the input, while the rest has ``1``.
+    If an input is 4-dim and ``axes=[1]``, the parameter shape will be
+    ``param_shape  = np.mean(inp.d, axis=(0, 2, 3), keepdims=True).shape``
+    (using numpy expression as an example).
+
+    """
+    
+    def __init__(self, n_features, n_dims, axes=[1], decay_rate=0.9, eps=1e-5,
+                 batch_stat=True, output_stat=False, fix_parameters=False,
+                 param_init=None):
+        assert len(axes) == 1
+        shape_stat = [1 for _ in range(n_dims)]
+        shape_stat[axes[0]] = n_features
+    
+        if param_init is None:
+            param_init = {}
+        beta_init = param_init.get('beta', ConstantInitializer(0))
+        gamma_init = param_init.get('gamma', ConstantInitializer(1))
+        mean_init = param_init.get('mean', ConstantInitializer(0))
+        var_init = param_init.get('var', ConstantInitializer(1))
+        
+        beta = nn.Variable.from_numpy_array(beta_init(shape_stat)).apply(need_grad=not fix_parameters)
+        gamma = nn.Variable.from_numpy_array(gamma_init(shape_stat)).apply(need_grad=not fix_parameters)
+        mean = nn.Variable.from_numpy_array(mean_init(shape_stat))
+        var = nn.Variable.from_numpy_array(var_init(shape_stat))
+
+        self.beta = beta
+        self.gamma = gamma
+        self.mean = mean
+        self.var = var
+        self.axes = axes
+        self.decay_rate = decay_rate
+        self.eps = eps
+        self.output_stat = output_stat
+
+    def __call__(self, inp, test=False):
+        return F.batch_normalization(inp, self.beta, self.gamma, self.mean, self.var, self.axes,
+                                     self.decay_rate, self.eps, not test, self.output_stat)
+
+class BatchNorm1d(BatchNormalization):
+    """
+    Batch normalization layer for 3d-Array or 3d-Variable. This is typically used together with `Conv1d`.
+
+    .. math::
+
+        \\begin{array}{lcl}
+        \\mu &=& \\frac{1}{M} \\sum x_i\\\\
+        \\sigma^2 &=& \\frac{1}{M} \\left(\\sum x_i - \\mu\\right)^2\\\\
+        \\hat{x}_i &=& \\frac{x_i - \\mu}{\\sqrt{\\sigma^2 + \\epsilon }}\\\\
+        y_i &= & \\hat{x}_i \\gamma + \\beta.
+        \\end{array}
+
+    where :math:`x_i, y_i` are the inputs.
+    In testing, the mean and variance computed by moving average calculated during training are used.
+
+    Args:
+        inp (~nnabla.Variable): N-D array of input.
+        axes (:obj:`tuple` of :obj:`int`):
+            Mean and variance for each element in ``axes`` are calculated using
+            elements on the rest axes. For example, if an input is 4 dimensions,
+            and ``axes`` is ``[1]``,  batch mean is calculated as
+            ``np.mean(inp.d, axis=(0, 2, 3), keepdims=True)``
+            (using numpy expression as an example).
+        decay_rate (float): Decay rate of running mean and variance.
+        eps (float): Tiny value to avoid zero division by std.
+        batch_stat (bool): Use mini-batch statistics rather than running ones.
+        output_stat (bool): Output batch mean and variance.
+        fix_parameters (bool): When set to `True`, the beta and gamma will not be updated.
+        param_init (dict):
+            Parameter initializers can be set with a dict. A key of the dict must
+            be ``'beta'``, ``'gamma'``, ``'mean'`` or ``'var'``.
+            A value of the dict must be an :obj:`~nnabla.initializer.Initializer`
+            or a :obj:`numpy.ndarray`.
+            E.g. ``{'beta': ConstantIntializer(0), 'gamma': np.ones(gamma_shape) * 2}``.
+
+    Returns:
+        :class:`~nnabla.Variable`: N-D array.
+
+    References:
+
+        - Ioffe and Szegedy, Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift. https://arxiv.org/abs/1502.03167
+
+    The shape of parameters has the same number of dimensions with the input
+    data, and the shapes in ``axes`` has the same dimensions with the input, while the rest has ``1``.
+    If an input is 4-dim and ``axes=[1]``, the parameter shape will be
+    ``param_shape  = np.mean(inp.d, axis=(0, 2, 3), keepdims=True).shape``
+    (using numpy expression as an example).
+
+    """
+    
+    def __init__(self, n_features, axes=[1], decay_rate=0.9, eps=1e-5,
+                 batch_stat=True, output_stat=False, fix_parameters=False,
+                 param_init=None):
+        super(BatchNorm1d, self).__init__(n_features, 3, axes=axes, decay_rate=decay_rate, 
+                                          eps=1e-5, batch_stat=batch_stat, output_stat=output_stat, 
+                                          fix_parameters=fix_parameters,
+                                          param_init=param_init)
+
+class BatchNorm2d(BatchNormalization):
+    """
+    Batch normalization layer for 4d-Array or 4d-Variable. This is typically used together with `Conv2d`.
+
+    .. math::
+
+        \\begin{array}{lcl}
+        \\mu &=& \\frac{1}{M} \\sum x_i\\\\
+        \\sigma^2 &=& \\frac{1}{M} \\left(\\sum x_i - \\mu\\right)^2\\\\
+        \\hat{x}_i &=& \\frac{x_i - \\mu}{\\sqrt{\\sigma^2 + \\epsilon }}\\\\
+        y_i &= & \\hat{x}_i \\gamma + \\beta.
+        \\end{array}
+
+    where :math:`x_i, y_i` are the inputs.
+    In testing, the mean and variance computed by moving average calculated during training are used.
+
+    Args:
+        inp (~nnabla.Variable): N-D array of input.
+        axes (:obj:`tuple` of :obj:`int`):
+            Mean and variance for each element in ``axes`` are calculated using
+            elements on the rest axes. For example, if an input is 4 dimensions,
+            and ``axes`` is ``[1]``,  batch mean is calculated as
+            ``np.mean(inp.d, axis=(0, 2, 3), keepdims=True)``
+            (using numpy expression as an example).
+        decay_rate (float): Decay rate of running mean and variance.
+        eps (float): Tiny value to avoid zero division by std.
+        batch_stat (bool): Use mini-batch statistics rather than running ones.
+        output_stat (bool): Output batch mean and variance.
+        fix_parameters (bool): When set to `True`, the beta and gamma will not be updated.
+        param_init (dict):
+            Parameter initializers can be set with a dict. A key of the dict must
+            be ``'beta'``, ``'gamma'``, ``'mean'`` or ``'var'``.
+            A value of the dict must be an :obj:`~nnabla.initializer.Initializer`
+            or a :obj:`numpy.ndarray`.
+            E.g. ``{'beta': ConstantIntializer(0), 'gamma': np.ones(gamma_shape) * 2}``.
+
+    Returns:
+        :class:`~nnabla.Variable`: N-D array.
+
+    References:
+
+        - Ioffe and Szegedy, Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift. https://arxiv.org/abs/1502.03167
+
+    The shape of parameters has the same number of dimensions with the input
+    data, and the shapes in ``axes`` has the same dimensions with the input, while the rest has ``1``.
+    If an input is 4-dim and ``axes=[1]``, the parameter shape will be
+    ``param_shape  = np.mean(inp.d, axis=(0, 2, 3), keepdims=True).shape``
+    (using numpy expression as an example).
+
+    """
+    
+    def __init__(self, n_features, axes=[1], decay_rate=0.9, eps=1e-5,
+                 batch_stat=True, output_stat=False, fix_parameters=False,
+                 param_init=None):
+        super(BatchNorm2d, self).__init__(n_features, 4, axes=axes, decay_rate=decay_rate, 
+                                          eps=1e-5, batch_stat=batch_stat, output_stat=output_stat, 
+                                          fix_parameters=fix_parameters,
+                                          param_init=param_init)
+
+class BatchNorm3d(BatchNormalization):
+    """
+    Batch normalization layer for 5d-Array or 5d-Variable. This is typically used together with `Conv3d`.
+
+    .. math::
+
+        \\begin{array}{lcl}
+        \\mu &=& \\frac{1}{M} \\sum x_i\\\\
+        \\sigma^2 &=& \\frac{1}{M} \\left(\\sum x_i - \\mu\\right)^2\\\\
+        \\hat{x}_i &=& \\frac{x_i - \\mu}{\\sqrt{\\sigma^2 + \\epsilon }}\\\\
+        y_i &= & \\hat{x}_i \\gamma + \\beta.
+        \\end{array}
+
+    where :math:`x_i, y_i` are the inputs.
+    In testing, the mean and variance computed by moving average calculated during training are used.
+
+    Args:
+        inp (~nnabla.Variable): N-D array of input.
+        axes (:obj:`tuple` of :obj:`int`):
+            Mean and variance for each element in ``axes`` are calculated using
+            elements on the rest axes. For example, if an input is 4 dimensions,
+            and ``axes`` is ``[1]``,  batch mean is calculated as
+            ``np.mean(inp.d, axis=(0, 2, 3), keepdims=True)``
+            (using numpy expression as an example).
+        decay_rate (float): Decay rate of running mean and variance.
+        eps (float): Tiny value to avoid zero division by std.
+        batch_stat (bool): Use mini-batch statistics rather than running ones.
+        output_stat (bool): Output batch mean and variance.
+        fix_parameters (bool): When set to `True`, the beta and gamma will not be updated.
+        param_init (dict):
+            Parameter initializers can be set with a dict. A key of the dict must
+            be ``'beta'``, ``'gamma'``, ``'mean'`` or ``'var'``.
+            A value of the dict must be an :obj:`~nnabla.initializer.Initializer`
+            or a :obj:`numpy.ndarray`.
+            E.g. ``{'beta': ConstantIntializer(0), 'gamma': np.ones(gamma_shape) * 2}``.
+
+    Returns:
+        :class:`~nnabla.Variable`: N-D array.
+
+    References:
+
+        - Ioffe and Szegedy, Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift. https://arxiv.org/abs/1502.03167
+
+    The shape of parameters has the same number of dimensions with the input
+    data, and the shapes in ``axes`` has the same dimensions with the input, while the rest has ``1``.
+    If an input is 4-dim and ``axes=[1]``, the parameter shape will be
+    ``param_shape  = np.mean(inp.d, axis=(0, 2, 3), keepdims=True).shape``
+    (using numpy expression as an example).
+
+    """
+    
+    def __init__(self, n_features, axes=[1], decay_rate=0.9, eps=1e-5,
+                 batch_stat=True, output_stat=False, fix_parameters=False,
+                 param_init=None):
+        super(BatchNorm3d, self).__init__(n_features, 5, axes=axes, decay_rate=decay_rate, 
+                                          eps=1e-5, batch_stat=batch_stat, output_stat=output_stat, 
+                                          fix_parameters=fix_parameters,
+                                          param_init=param_init)

--- a/python/src/nnabla/experimental/parametric_function_class/convolution.py
+++ b/python/src/nnabla/experimental/parametric_function_class/convolution.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as F
+from nnabla.parameter import get_parameter_or_create, get_parameter
+from nnabla.initializer import (
+    calc_uniform_lim_glorot,
+    ConstantInitializer, NormalInitializer, UniformInitializer)
+
+from .module import Module
+
+class Convolution(Module):
+    """N-D Convolution with a bias term.
+
+    For Dilated Convolution (a.k.a. Atrous Convolution), refer to:
+
+    - Chen et al., DeepLab: Semantic Image Segmentation with Deep Convolutional Nets, Atrous Convolution, and Fully Connected CRFs. https://arxiv.org/abs/1606.00915
+
+    - Yu et al., Multi-Scale Context Aggregation by Dilated Convolutions. https://arxiv.org/abs/1511.07122
+
+    Note:
+
+        Convolution is a computationally intensive operation that
+        should preferrably be run with the `cudnn` backend. NNabla
+        then uses CuDNN library functions to determine and cache the
+        fastest algorithm for the given set of convolution parameters,
+        which results in additional memory consumption which may pose
+        a problem for GPUs with insufficient memory size. In that
+        case, the `NNABLA_CUDNN_WORKSPACE_LIMIT` environment variable
+        can be used to restrict the choice of algorithms to those that
+        fit the given workspace memory limit, expressed in bytes. In
+        some cases it may also be desired to restrict the automatic
+        search to algorithms that produce deterministic (reproducable)
+        results. This can be requested by setting the the environment
+        variable `NNABLA_CUDNN_DETERMINISTIC` to a non-zero value.
+
+    Args:
+        inp (~nnabla.Variable): N-D array.
+        outmaps (int): Number of convolution kernels (which is equal to the number of output channels). For example, to apply convolution on an input with 16 types of filters, specify 16.
+        kernel (:obj:`tuple` of :obj:`int`): Convolution kernel size. For example, to apply convolution on an image with a 3 (height) by 5 (width) two-dimensional kernel, specify (3,5).
+        pad (:obj:`tuple` of :obj:`int`): Padding sizes for dimensions.
+        stride (:obj:`tuple` of :obj:`int`): Stride sizes for dimensions.
+        dilation (:obj:`tuple` of :obj:`int`): Dilation sizes for dimensions.
+        group (int): Number of groups of channels. This makes connections across channels more sparse by grouping connections along map direction.
+        w_init (:obj:`nnabla.initializer.BaseInitializer` or :obj:`numpy.ndarray`): Initializer for weight. By default, it is initialized with :obj:`nnabla.initializer.UniformInitializer` within the range determined by :obj:`nnabla.initializer.calc_uniform_lim_glorot`.  
+        b_init (:obj:`nnabla.initializer.BaseInitializer` or :obj:`numpy.ndarray`): Initializer for bias. By default, it is initialized with zeros if `with_bias` is `True`.
+        base_axis (int): Dimensions up to `base_axis` are treated as the sample dimensions.
+        fix_parameters (bool): When set to `True`, the weights and biases will not be updated.
+        rng (numpy.random.RandomState): Random generator for Initializer.
+        with_bias (bool): Specify whether to include the bias term.
+
+    Returns:
+        :class:`~nnabla.Variable`: N-D array. See :obj:`~nnabla.functions.convolution` for the output shape.
+
+    """
+    
+    def __init__(self, inmaps, outmaps, kernel,
+                pad=None, stride=None, dilation=None, group=1,
+                w_init=None, b_init=None,
+                base_axis=1, fix_parameters=False, rng=None, with_bias=True):
+        if w_init is None:
+            w_init = UniformInitializer(
+                calc_uniform_lim_glorot(inmaps, outmaps, tuple(kernel)), rng=rng)
+        if with_bias and b_init is None:
+            b_init = ConstantInitializer()
+        w_shape = (outmaps, inmaps // group) + tuple(kernel)        
+        w = nn.Variable.from_numpy_array(w_init(w_shape)).apply(need_grad=not fix_parameters)
+        b = None
+        if with_bias:
+            b_shape = (outmaps, )
+            b = nn.Variable.from_numpy_array(b_init(b_shape)).apply(need_grad=not fix_parameters)
+
+        self.W = w
+        self.b = b
+        self.base_axis = base_axis
+        self.pad = pad
+        self.stride = stride
+        self.dilation = dilation
+        self.group = group
+
+    def __call__(self, inp):
+        return F.convolution(inp, self.W, self.b, self.base_axis, 
+                             self.pad, self.stride, self.dilation, self.group)
+
+Conv1d = Convolution
+Conv2d = Convolution
+Conv3d = Convolution
+ConvNd = Convolution

--- a/python/src/nnabla/experimental/parametric_function_class/deconvolution.py
+++ b/python/src/nnabla/experimental/parametric_function_class/deconvolution.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as F
+from nnabla.parameter import get_parameter_or_create, get_parameter
+from nnabla.initializer import (
+    calc_uniform_lim_glorot,
+    ConstantInitializer, NormalInitializer, UniformInitializer)
+
+from .module import Module
+
+class Deconvolution(Module):
+    """
+    Deconvolution layer.
+
+    Args:
+        inp (~nnabla.Variable): N-D array.
+        outmaps (int): Number of deconvolution kernels (which is equal to the number of output channels). For example, to apply deconvolution on an input with 16 types of filters, specify 16.
+        kernel (:obj:`tuple` of :obj:`int`): Convolution kernel size. For example, to apply deconvolution on an image with a 3 (height) by 5 (width) two-dimensional kernel, specify (3,5).
+        pad (:obj:`tuple` of :obj:`int`): Padding sizes for dimensions.
+        stride (:obj:`tuple` of :obj:`int`): Stride sizes for dimensions.
+        dilation (:obj:`tuple` of :obj:`int`): Dilation sizes for dimensions.
+        group (int): Number of groups of channels. This makes connections across channels sparser by grouping connections along map direction.
+        w_init (:obj:`nnabla.initializer.BaseInitializer` or :obj:`numpy.ndarray`): Initializer for weight. By default, it is initialized with :obj:`nnabla.initializer.UniformInitializer` within the range determined by :obj:`nnabla.initializer.calc_uniform_lim_glorot`.  
+        b_init (:obj:`nnabla.initializer.BaseInitializer` or :obj:`numpy.ndarray`): Initializer for bias. By default, it is initialized with zeros if `with_bias` is `True`.
+        base_axis (int): Dimensions up to `base_axis` are treated as the sample dimensions.
+        fix_parameters (bool): When set to `True`, the weights and biases will not be updated.
+        rng (numpy.random.RandomState): Random generator for Initializer.
+        with_bias (bool): Specify whether to include the bias term.
+
+    Returns:
+        :class:`~nnabla.Variable`: N-D array. See :obj:`~nnabla.functions.deconvolution` for the output shape.
+
+    """
+    
+    def __init__(self, inmaps, outmaps, kernel,
+                pad=None, stride=None, dilation=None, group=1,
+                w_init=None, b_init=None,
+                base_axis=1, fix_parameters=False, rng=None, with_bias=True):
+        if w_init is None:
+            w_init = UniformInitializer(
+                calc_uniform_lim_glorot(inmaps, outmaps, tuple(kernel)), rng=rng)
+        if with_bias and b_init is None:
+            b_init = ConstantInitializer()
+        w_shape = (outmaps, inmaps // group) + tuple(kernel)        
+        w = nn.Variable.from_numpy_array(w_init(w_shape)).apply(need_grad=not fix_parameters)
+        b = None
+        if with_bias:
+            b_shape = (outmaps, )
+            b = nn.Variable.from_numpy_array(b_init(b_shape)).apply(need_grad=not fix_parameters)
+
+        self.W = w
+        self.b = b
+        self.base_axis = base_axis
+        self.pad = pad
+        self.stride = stride
+        self.dilation = dilation
+        self.group = group
+
+    def __call__(self, inp):
+        return F.deconvolution(inp, self.W, self.b, self.base_axis, 
+                             self.pad, self.stride, self.dilation, self.group)
+
+Deconv1d = Deconvolution
+Deconv2d = Deconvolution
+Deconv3d = Deconvolution
+DeconvNd = Deconvolution

--- a/python/src/nnabla/experimental/parametric_function_class/embed.py
+++ b/python/src/nnabla/experimental/parametric_function_class/embed.py
@@ -1,0 +1,50 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as F
+from nnabla.parameter import get_parameter_or_create, get_parameter
+from nnabla.initializer import (
+    calc_uniform_lim_glorot,
+    ConstantInitializer, NormalInitializer, UniformInitializer)
+
+from .module import Module
+
+class Embed(Module):
+    """ Embed.
+
+    Embed slices a matrix/tensor with indexing array/tensor. Weights are initialized with :obj:`nnabla.initializer.UniformInitializer` within the range of :math:`-\\sqrt{3}` and :math:`\\sqrt{3}`.
+
+    Args:
+        x(~nnabla.Variable): [Integer] Indices with shape :math:`(I_0, ..., I_N)`
+        n_inputs : number of possible inputs, words or vocabraries
+        n_features : number of embedding features
+        fix_parameters (bool): When set to `True`, the embedding weight matrix
+            will not be updated.
+
+    Returns:
+        ~nnabla.Variable: Output with shape :math:`(I_0, ..., I_N, W_1, ..., W_M)`
+    """
+    
+    def __init__(self, n_inputs, n_features, w_init=None, fix_parameters=False):
+        if w_init is None:
+            w_init = UniformInitializer((-np.sqrt(3.), np.sqrt(3)))
+        w_shape = (n_input, n_features)
+        w = nn.Variables.from_numpy_array(w_init()).apply(need_grad=not fix_parameters)
+        self.W = w
+
+    def __call__(self, inp):
+        return F.embed(inp, self.W)

--- a/python/src/nnabla/experimental/parametric_function_class/module.py
+++ b/python/src/nnabla/experimental/parametric_function_class/module.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+
+import nnabla as nn
+import nnabla.functions as F
+from nnabla.parameter import get_parameter_or_create, get_parameter
+from nnabla.initializer import (
+    calc_uniform_lim_glorot,
+    ConstantInitializer, NormalInitializer, UniformInitializer)
+
+from collections import OrderedDict
+
+class Module(object):
+    """Module mix-in for the parametric function classes.
+    """
+    
+    def __init__(self):
+        pass
+
+    def get_parameters(self, grad_only=True):
+        """Get parameters.
+        Args:
+            grad_only (bool, optional): Return parameters with `need_grad` option as `True`. 
+            If you set this option as `False`, All parameters are returned. Default is `True`.
+        Returns:
+            dict: The dictionary of parameter name (`str`) to Variable (:obj:`~nnabla.Variable`).
+        """
+        params = OrderedDict()
+
+        for v in self.get_modules():
+            if not isinstance(v, tuple):
+                continue
+            prefix, module = v
+            for k, v in module.__dict__.items():
+                if not isinstance(v, nn.Variable):
+                    continue
+                pname = k
+                name = "{}/{}".format(prefix, pname)
+                if grad_only and v.need_grad == False:
+                    continue
+                params[name] = v
+        return params
+    
+
+    def get_modules(self, memo=None, prefix=""):
+        """Get modules.
+
+        This function is internally used as the helper method for other methods.
+
+        Args: 
+            memo (set, optional): Module set in order to memorize to visit.
+            prefix (str, optional): Prefix to a specific parameter name.
+        
+        Yields:
+            `Module`: The module class.
+        """
+        if memo is None:
+            memo = set()
+            
+        if self not in memo:
+            memo.add(self)
+            yield prefix, self
+            for k, v in self.__dict__.items():
+                if not isinstance(v, Module):
+                    continue
+                name, module = k, v
+                submodule_prefix = "{}/{}".format(prefix, name) if prefix != "" else name
+                for m in module.get_modules(memo, submodule_prefix):
+                    yield m
+
+
+    def save_parameters(self, path, grad_only=False):
+        """Save all parameters into a file with the specified format.
+    
+        Currently hdf5 and protobuf formats are supported.
+    
+        Args:
+            path : path or file object
+            grad_only (bool, optional): Return parameters with `need_grad` option as `True`. 
+        """
+        params = self.get_parameters(grad_only=grad_only)
+        nn.save_parameters(path, params)
+
+
+    def load_parameters(self, path):
+        """Load parameters from a file with the specified format.
+        
+        Args:
+            path : path or file object
+        """
+        nn.load_parameters(path)
+        for v in self.get_modules():
+            if not isinstance(v, tuple):
+                continue
+            prefix, module = v
+            for k, v in module.__dict__.items():
+                if not isinstance(v, nn.Variable):
+                    continue
+                pname = k
+                name = "{}/{}".format(prefix, pname)
+                # Substitute
+                param0 = v
+                param1 = nn.parameter.pop_parameter(name)
+                if param0 is None:
+                    raise ValueError("Model does not have {} parameter.".format(name))
+                param0.d = param1.d.copy()
+                nn.logger.info("`{}` loaded.)".format(name))
+                
+                

--- a/python/src/nnabla/experimental/parametric_function_classes.py
+++ b/python/src/nnabla/experimental/parametric_function_classes.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .parametric_function_class.module import Module
+from .parametric_function_class.convolution import (Convolution, Conv1d, Conv2d, Conv3d, ConvNd)
+from .parametric_function_class.deconvolution import (Deconvolution, 
+                                                      Deconv1d, Deconv2d, Deconv3d, DeconvNd)
+from .parametric_function_class.affine import (Affine, Linear)
+from .parametric_function_class.embed import Embed
+from .parametric_function_class.batch_normalization import (BatchNormalization, 
+                                                            BatchNorm1d, BatchNorm2d, BatchNorm3d)
+            
+

--- a/python/src/nnabla/parameter.py
+++ b/python/src/nnabla/parameter.py
@@ -321,23 +321,23 @@ def load_parameters(path):
     logger.info("Parameter load ({}): {}".format(format, path))
 
 
-def save_parameters(path):
+def save_parameters(path, params=None):
     """Save all parameters into a file with the specified format.
 
     Currently hdf5 and protobuf formats are supported.
 
     Args:
       path : path or file object
+      params (dict, optional): Parameters to be saved. Dictionary is of a parameter name (:obj:`str`) to :obj:`~nnabla.Variable`.
     """
     _, ext = os.path.splitext(path)
-    params = get_parameters(grad_only=False)
+    params = get_parameters(grad_only=False) if params is None else params
     if ext == '.h5':
         # TODO temporary work around to suppress FutureWarning message.
         import warnings
         warnings.simplefilter('ignore', category=FutureWarning)
         import h5py
         with h5py.File(path, 'w') as hd:
-            params = get_parameters(grad_only=False)
             for i, (k, v) in enumerate(iteritems(params)):
                 hd[k] = v.d
                 hd[k].attrs['need_grad'] = v.need_grad


### PR DESCRIPTION
Currently, the following NNabla's parametric function classes are defined:

- Convolution (Conv1d, Conv2d, Conv3d, ConvNd)
- Deconvolution (Deconv1d, Deconv2d, Deconv3d, DeconvNd)
- Affine (Linear)
- Embed
- BatchNorm (BatchNorm1d, BatchNorm2d, BatchNorm3d)
