### PR TITLE
Subpackage nnabla.models

### DIFF
--- a/doc/python/api.rst
+++ b/doc/python/api.rst
@@ -18,4 +18,5 @@ Python API Reference
     api/data_iterator
     api/utils
     api/ext
+    api/models
     api/experimental

--- a/doc/python/api/models.rst
+++ b/doc/python/api/models.rst
@@ -1,0 +1,9 @@
+Models
+======
+
+The ``nnabla.models`` package provides APIs that allow users to execute inference by or fine-tuning from pre-trained models.
+
+.. toctree::
+    :maxdepth: 1
+
+    models/imagenet.rst

--- a/doc/python/api/models.rst
+++ b/doc/python/api/models.rst
@@ -1,7 +1,7 @@
-Models
-======
+Pretrained Models
+=================
 
-The ``nnabla.models`` package provides APIs that allow users to execute inference by or fine-tuning from pre-trained models.
+The ``nnabla.models`` package provides APIs that allow users to execute state-of-the-art pre-trained models for inference and training in few lines of code.
 
 .. toctree::
     :maxdepth: 1

--- a/doc/python/api/models/imagenet.rst
+++ b/doc/python/api/models/imagenet.rst
@@ -67,3 +67,6 @@ List of models
 
 .. autoclass:: SENet
     :members:
+
+.. autoclass:: SqueezeNet
+    :members:

--- a/doc/python/api/models/imagenet.rst
+++ b/doc/python/api/models/imagenet.rst
@@ -1,0 +1,53 @@
+Pretrained models on ImageNet dataset
+=====================================
+
+.. automodule:: nnabla.models.imagenet
+
+This subpackage provides a variety of pre-trained state-of-the-art models which is trained on ImageNet_ dataset.
+
+.. _ImageNet: http://www.image-net.org/
+
+The pre-trained models can be used for both inference and training as following:
+
+.. code-block:: python
+
+    # Create ResNet-18 for inference
+    from nnabla.models.imagenet import ResNet
+    model = ResNet(18)
+    batch_size = 1
+    # model.input_shape returns (3, 224, 224) when ResNet-18
+    x = nn.Variable((batch_size,) + model.input_shape)
+    y = model(x, training=False)
+
+    # Execute inference
+    # Load input image as uint8 array with shape of (3, 224, 224)
+    from nnabla.utils.image_utils import imread
+    img = imread('example.jpg', size=model.input_shape[1:], channel_first=True)
+    x.d[0] = img
+    y.forward()
+    predicted_label = np.argmax(y.d[0])
+    print('Predicted label:', model.category_names[predicted_label])
+
+
+    # Create ResNet-18 for fine-tuning
+    batch_size=32
+    x = nn.Variable((batch_size,) + model.input_shape)
+    # * By training=True, it sets batch normalization mode for training
+    #   and gives trainable attributes to parameters.
+    # * By use_up_to='pool', it creats a network up to the output of
+    #   the final global average pooling.
+    pool = model(x, training=True, use_up_to='pool')
+
+    # Add a classification layer for another 10 category dataset
+    # and loss function
+    num_classes = 10
+    y = PF.affine(pool, num_classes, name='classifier10')
+    t = nn.Variable((batch_size, 1))
+    loss = F.sum(F.softmax_cross_entropy(y, t))
+
+    # Training...
+
+
+.. autoclass:: ResNet
+    :members:
+    :special-members:

--- a/doc/python/api/models/imagenet.rst
+++ b/doc/python/api/models/imagenet.rst
@@ -45,6 +45,21 @@ The pre-trained models can be used for both inference and training as following:
 
     # Training...
 
+Available models are summarized in the following table. Error rates are calculated using single center crop.
+
+
+.. csv-table:: Available ImageNet models
+    :header: "Name", "Class", "Top-1 error", "Top-5 error", "Trained by/with"
+
+    "ResNet-18", "ResNet", 30.28, 10.90, Neural Network Console
+    "ResNet-32", "ResNet", 26.72, 8.89, Neural Network Console
+    "ResNet-50", "ResNet", 24.59, 7.48, Neural Network Console
+    "ResNet-101", "ResNet", 23.81, 7.01, Neural Network Console
+    "ResNet-152", "ResNet", 23.48, 7.09, Neural Network Console
+    "MobileNetV2", "MobileNetV2", 29.94, 10.82, Neural Network Console
+    "SENet-154", "SENet", 22.04, 6.29, Neural Network Console
+    "SqueezeNet v1.1", "SqueezeNet", 41.23, 19.18, Neural Network Console
+
 
 Common interfaces
 -----------------

--- a/doc/python/api/models/imagenet.rst
+++ b/doc/python/api/models/imagenet.rst
@@ -64,3 +64,6 @@ List of models
 
 .. autoclass:: MobileNetV2
     :members:
+
+.. autoclass:: SENet
+    :members:

--- a/doc/python/api/models/imagenet.rst
+++ b/doc/python/api/models/imagenet.rst
@@ -1,7 +1,5 @@
-Pretrained models on ImageNet dataset
-=====================================
-
-.. automodule:: nnabla.models.imagenet
+ImageNet Models
+===============
 
 This subpackage provides a variety of pre-trained state-of-the-art models which is trained on ImageNet_ dataset.
 
@@ -48,6 +46,21 @@ The pre-trained models can be used for both inference and training as following:
     # Training...
 
 
+Common interfaces
+-----------------
+
+.. automodule:: nnabla.models.imagenet.base
+.. autoclass:: ImageNetBase
+    :members: input_shape, category_names
+    :special-members: __call__
+
+List of models
+--------------
+
+.. automodule:: nnabla.models.imagenet
+
 .. autoclass:: ResNet
     :members:
-    :special-members:
+
+.. autoclass:: MobileNetV2
+    :members:

--- a/doc/python/api/monitor.rst
+++ b/doc/python/api/monitor.rst
@@ -28,4 +28,4 @@ Utility functions
 
 .. autofunction:: plot_series
 
-.. autofunction:: plot_time_elaplsed
+.. autofunction:: plot_time_elapsed

--- a/doc/python/api/parametric_function.rst
+++ b/doc/python/api/parametric_function.rst
@@ -23,7 +23,8 @@ The parameters registered by :ref:`parametric-functions`
 can be managed using APIs listed in this section.
 
 
-.. autofunction:: parameter_scope(name)
+.. autofunction:: parameter_scope
+.. autofunction:: get_current_parameter_scope
 .. autofunction:: get_parameters
 .. autofunction:: clear_parameters
 .. autofunction:: save_parameters

--- a/doc/python/command_line_interface.rst
+++ b/doc/python/command_line_interface.rst
@@ -7,13 +7,13 @@ convert param and dataset, measure performance, file format converter and so on.
 .. code-block:: none
 
     usage: nnabla_cli [-h] [-m]
-                      {train,infer,forward,encode_param,decode_param,profile,conv_dataset,compare_with_cpu,create_image_classification_dataset,upload,create_tar,function_info,dump,nnb_template,convert,plot_series,plot_timer,version}
+                      {train,infer,forward,encode_param,decode_param,profile,conv_dataset,compare_with_cpu,create_image_classification_dataset,upload,create_tar,function_info,dump,nnb_template,convert,plot_series,plot_timer,draw_graph,version}
                       ...
     
-    Command line interface for NNabla(Version 1.0.9.dev1, Build 181025154033)
+    Command line interface for NNabla(Version 1.0.11.dev1, Build 181226024531)
     
     positional arguments:
-      {train,infer,forward,encode_param,decode_param,profile,conv_dataset,compare_with_cpu,create_image_classification_dataset,upload,create_tar,function_info,dump,nnb_template,convert,plot_series,plot_timer,version}
+      {train,infer,forward,encode_param,decode_param,profile,conv_dataset,compare_with_cpu,create_image_classification_dataset,upload,create_tar,function_info,dump,nnb_template,convert,plot_series,plot_timer,draw_graph,version}
         train               Training with NNP.
         infer               Do inference with NNP and binary data file input.
         forward             Do evaluation with NNP and test dataset.
@@ -32,6 +32,7 @@ convert param and dataset, measure performance, file format converter and so on.
         convert             File format converter.
         plot_series         Plot *.series.txt files.
         plot_timer          Plot *.timer.txt files.
+        draw_graph          Draw a graph in a NNP or nntxt file with graphviz.
         version             Print version and build number.
     
     optional arguments:
@@ -434,6 +435,37 @@ MonitorTimeElapsed
       -e, --elapsed         Plot total elapsed time. By default, it plots elapsed time per iteration.
       -u TIME_UNIT, --time-unit TIME_UNIT
                             Time unit chosen from {s|m|h|d}.
+
+Draw a graph from NNP or .nntxt files
+-------------------------------------
+
+**Note**:
+
+- This feature requires ``graphviz`` installed as a `Python package <https://graphviz.readthedocs.io/en/stable/manual.html#installation>`_. The ``graphviz`` Python is a interface to `graphviz library <https://www.graphviz.org/>`_ which is not installed by ``pip`` command. You have to install it using ``apt`` on Ubuntu for example.
+
+
+.. code-block:: none
+
+    usage: nnabla_cli draw_graph [-h] [-o OUTPUT_DIR] [-n NETWORK] [-f FORMAT]
+                                 input
+
+    Draw a graph in a NNP or nntxt file with graphviz.
+
+    Example:
+
+        nnabla_cli draw_graph -o output-folder path-to-nnp.nnp
+
+    positional arguments:
+      input                 Path to input nnp or nntxt.
+
+    optional arguments:
+      -h, --help            show this help message and exit
+      -o OUTPUT_DIR, --output-dir OUTPUT_DIR
+                            Output directory.
+      -n NETWORK, --network NETWORK
+                            Network names to be drawn.
+      -f FORMAT, --format FORMAT
+                            Graph saving format compatible with graphviz (`pdf`, `png`, ...).
 
 
 Development

--- a/docker/development/Dockerfile.onnx-test
+++ b/docker/development/Dockerfile.onnx-test
@@ -48,6 +48,7 @@ RUN apt-get update \
        unzip \
        wget \
        zip \
+       graphviz \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -119,6 +120,7 @@ RUN set -xe \
         tqdm \
         wheel \
     && pip install pyyaml onnx==1.3.0 future Cython autopep8 requests \
+        graphviz \
     && pip install cntk || true \
     && conda install -y -c pytorch pytorch-nightly-cpu \
     && rm -rf /opt/miniconda3/pkgs

--- a/python/setup.py
+++ b/python/setup.py
@@ -195,8 +195,11 @@ if __name__ == '__main__':
 
     shutil.copyfile(library_path, os.path.join(path_pkg, library_file_name))
     package_data = {"nnabla": [
-        library_file_name, 'nnabla.conf',
-                           'utils/converter/functions.pkl']}
+        library_file_name,
+        'nnabla.conf',
+        'utils/converter/functions.pkl',
+        'models/imagenet/category_names.txt',
+        ]}
 
     for root, dirs, files in os.walk(os.path.join(build_dir, 'bin')):
         for fn in files:
@@ -236,6 +239,8 @@ if __name__ == '__main__':
                 'nnabla.experimental.graph_converters',
                 'nnabla.experimental.parametric_function_class',
                 'nnabla.experimental.trainers',
+                'nnabla.models',
+                'nnabla.models.imagenet',
                 'nnabla.utils',
                 'nnabla.utils.cli',
                 'nnabla.utils.converter',

--- a/python/src/nnabla/__init__.py
+++ b/python/src/nnabla/__init__.py
@@ -31,6 +31,7 @@ from ._version import (
 from .variable import Variable, Context
 from ._nd_array import NdArray
 from .parameter import (
+    get_current_parameter_scope,
     parameter_scope, get_parameters, clear_parameters,
     load_parameters, save_parameters)
 from .context import (

--- a/python/src/nnabla/models/__init__.py
+++ b/python/src/nnabla/models/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import

--- a/python/src/nnabla/models/imagenet/__init__.py
+++ b/python/src/nnabla/models/imagenet/__init__.py
@@ -14,3 +14,4 @@
 from __future__ import absolute_import
 from .resnet import ResNet
 from .mobilenet import MobileNetV2
+from .senet import SENet

--- a/python/src/nnabla/models/imagenet/__init__.py
+++ b/python/src/nnabla/models/imagenet/__init__.py
@@ -15,3 +15,4 @@ from __future__ import absolute_import
 from .resnet import ResNet
 from .mobilenet import MobileNetV2
 from .senet import SENet
+from .squeezenet import SqueezeNet

--- a/python/src/nnabla/models/imagenet/__init__.py
+++ b/python/src/nnabla/models/imagenet/__init__.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+from .resnet import ResNet

--- a/python/src/nnabla/models/imagenet/__init__.py
+++ b/python/src/nnabla/models/imagenet/__init__.py
@@ -13,3 +13,4 @@
 # limitations under the License.
 from __future__ import absolute_import
 from .resnet import ResNet
+from .mobilenet import MobileNetV2

--- a/python/src/nnabla/models/imagenet/base.py
+++ b/python/src/nnabla/models/imagenet/base.py
@@ -1,0 +1,39 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+import os
+
+
+class ImageNetBase(object):
+
+    @property
+    def category_names(self):
+        '''
+        Returns category names of 1000 ImageNet classes.
+        '''
+        if hasattr(self, '_category_names'):
+            return self._category_names
+        with open(os.path.join(os.path.dirname(__file__), 'category_names.txt'), 'r') as fd:
+            self._category_names = fd.read().splitlines()
+        return self._category_names
+
+    @property
+    def input_shape(self):
+        '''
+        Should returns default image size (channel, height, width) as a tuple.
+        '''
+        return self._input_shape()
+
+    def _input_shape(self):
+        raise NotImplementedError('input size is not implemented')

--- a/python/src/nnabla/models/imagenet/base.py
+++ b/python/src/nnabla/models/imagenet/base.py
@@ -13,9 +13,17 @@
 # limitations under the License.
 from __future__ import absolute_import
 import os
+from nnabla.utils.nnp_graph import NnpLoader, NnpNetworkPass
+
+from ..utils import *
 
 
 class ImageNetBase(object):
+
+    '''
+    Most of ImageNet pretrained models are inherited from this class
+    so that it provides some common interfaces.
+    '''
 
     @property
     def category_names(self):
@@ -37,3 +45,48 @@ class ImageNetBase(object):
 
     def _input_shape(self):
         raise NotImplementedError('input size is not implemented')
+
+    def _load_nnp(self, rel_name, rel_url):
+        '''
+            Args:
+                rel_name: relative path to where donwloaded nnp is saved.
+                rel_url: relative url path to where nnp is downloaded from.
+
+            '''
+        from nnabla.utils.download import download
+        path_nnp = os.path.join(
+                get_model_home(), 'imagenet/{}'.format(rel_name))
+        url = os.path.join(get_model_url_base(),
+                           'imagenet/{}'.format(rel_url))
+        logger.info('Downloading {} from {}'.format(rel_name, url))
+        download(url, path_nnp, open_file=False, allow_overwrite=False)
+        print('Loading {}.'.format(path_nnp))
+        self.nnp = NnpLoader(path_nnp)
+
+    def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
+        '''
+        Create a network (computation graph) from a loaded model.
+
+        Args:
+
+            input_var (Variable, optional):
+                If given, input variable is replaced with the given variable and a network is constructed on top of the variable. Otherwise, a variable with batch size as 1 and a default shape from ``self.input_shape``.
+
+            use_up_to (str):
+                Network is constructed up to a variable specified by a string. A list of string-variable correspondences in a model is described in documentation for each model class.
+
+            training (bool):
+                This option enables additional training (fine-tuning, transfer learning etc.) for the constructed network. If True, the ``batch_stat`` option in batch normalization is turned ``True``, and ``need_grad`` attribute in trainable variables (conv weights and gamma and beta of bn etc.) is turned ``True``. The default is ``False``.
+
+            force_global_pooling (bool):
+                Regardless the input image size, the final average pooling before classification layer will be automatically transformed to a global average pooling. The default is ``False``.
+
+            check_global_pooling (bool):
+                If ``True``, and if the stride configuration of the final average pooling is not for global pooling, it raises an exception. The default is ``True``. Use ``False`` when user want to do the pooling with the trained stride ``(7, 7)`` regardless the input spatial size.
+
+            returns_net (bool):
+                When ``True``, it returns a :obj:`~nnabla.utils.nnp_graph.NnpNetwork` object. Otherwise, It only returns the last variable of the constructed network. The default is ``False``.
+            verbose (bool, or int):
+                Verbose level. With ``0``, it says nothing during network construction.
+        '''
+        raise NotImplementedError()

--- a/python/src/nnabla/models/imagenet/category_names.txt
+++ b/python/src/nnabla/models/imagenet/category_names.txt
@@ -1,0 +1,1000 @@
+tench, Tinca tinca
+goldfish, Carassius auratus
+great white shark, white shark, man-eater, man-eating shark, Carcharodon carcharias
+tiger shark, Galeocerdo cuvieri
+hammerhead, hammerhead shark
+electric ray, crampfish, numbfish, torpedo
+stingray
+cock
+hen
+ostrich, Struthio camelus
+brambling, Fringilla montifringilla
+goldfinch, Carduelis carduelis
+house finch, linnet, Carpodacus mexicanus
+junco, snowbird
+indigo bunting, indigo finch, indigo bird, Passerina cyanea
+robin, American robin, Turdus migratorius
+bulbul
+jay
+magpie
+chickadee
+water ouzel, dipper
+kite
+bald eagle, American eagle, Haliaeetus leucocephalus
+vulture
+great grey owl, great gray owl, Strix nebulosa
+European fire salamander, Salamandra salamandra
+common newt, Triturus vulgaris
+eft
+spotted salamander, Ambystoma maculatum
+axolotl, mud puppy, Ambystoma mexicanum
+bullfrog, Rana catesbeiana
+tree frog, tree-frog
+tailed frog, bell toad, ribbed toad, tailed toad, Ascaphus trui
+loggerhead, loggerhead turtle, Caretta caretta
+leatherback turtle, leatherback, leathery turtle, Dermochelys coriacea
+mud turtle
+terrapin
+box turtle, box tortoise
+banded gecko
+common iguana, iguana, Iguana iguana
+American chameleon, anole, Anolis carolinensis
+whiptail, whiptail lizard
+agama
+frilled lizard, Chlamydosaurus kingi
+alligator lizard
+Gila monster, Heloderma suspectum
+green lizard, Lacerta viridis
+African chameleon, Chamaeleo chamaeleon
+Komodo dragon, Komodo lizard, dragon lizard, giant lizard, Varanus komodoensis
+African crocodile, Nile crocodile, Crocodylus niloticus
+American alligator, Alligator mississipiensis
+triceratops
+thunder snake, worm snake, Carphophis amoenus
+ringneck snake, ring-necked snake, ring snake
+hognose snake, puff adder, sand viper
+green snake, grass snake
+king snake, kingsnake
+garter snake, grass snake
+water snake
+vine snake
+night snake, Hypsiglena torquata
+boa constrictor, Constrictor constrictor
+rock python, rock snake, Python sebae
+Indian cobra, Naja naja
+green mamba
+sea snake
+horned viper, cerastes, sand viper, horned asp, Cerastes cornutus
+diamondback, diamondback rattlesnake, Crotalus adamanteus
+sidewinder, horned rattlesnake, Crotalus cerastes
+trilobite
+harvestman, daddy longlegs, Phalangium opilio
+scorpion
+black and gold garden spider, Argiope aurantia
+barn spider, Araneus cavaticus
+garden spider, Aranea diademata
+black widow, Latrodectus mactans
+tarantula
+wolf spider, hunting spider
+tick
+centipede
+black grouse
+ptarmigan
+ruffed grouse, partridge, Bonasa umbellus
+prairie chicken, prairie grouse, prairie fowl
+peacock
+quail
+partridge
+African grey, African gray, Psittacus erithacus
+macaw
+sulphur-crested cockatoo, Kakatoe galerita, Cacatua galerita
+lorikeet
+coucal
+bee eater
+hornbill
+hummingbird
+jacamar
+toucan
+drake
+red-breasted merganser, Mergus serrator
+goose
+black swan, Cygnus atratus
+tusker
+echidna, spiny anteater, anteater
+platypus, duckbill, duckbilled platypus, duck-billed platypus, Ornithorhynchus anatinus
+wallaby, brush kangaroo
+koala, koala bear, kangaroo bear, native bear, Phascolarctos cinereus
+wombat
+jellyfish
+sea anemone, anemone
+brain coral
+flatworm, platyhelminth
+nematode, nematode worm, roundworm
+conch
+snail
+slug
+sea slug, nudibranch
+chiton, coat-of-mail shell, sea cradle, polyplacophore
+chambered nautilus, pearly nautilus, nautilus
+Dungeness crab, Cancer magister
+rock crab, Cancer irroratus
+fiddler crab
+king crab, Alaska crab, Alaskan king crab, Alaska king crab, Paralithodes camtschatica
+American lobster, Northern lobster, Maine lobster, Homarus americanus
+spiny lobster, langouste, rock lobster, crawfish, crayfish, sea crawfish
+crayfish, crawfish, crawdad, crawdaddy
+hermit crab
+isopod
+white stork, Ciconia ciconia
+black stork, Ciconia nigra
+spoonbill
+flamingo
+little blue heron, Egretta caerulea
+American egret, great white heron, Egretta albus
+bittern
+crane
+limpkin, Aramus pictus
+European gallinule, Porphyrio porphyrio
+American coot, marsh hen, mud hen, water hen, Fulica americana
+bustard
+ruddy turnstone, Arenaria interpres
+red-backed sandpiper, dunlin, Erolia alpina
+redshank, Tringa totanus
+dowitcher
+oystercatcher, oyster catcher
+pelican
+king penguin, Aptenodytes patagonica
+albatross, mollymawk
+grey whale, gray whale, devilfish, Eschrichtius gibbosus, Eschrichtius robustus
+killer whale, killer, orca, grampus, sea wolf, Orcinus orca
+dugong, Dugong dugon
+sea lion
+Chihuahua
+Japanese spaniel
+Maltese dog, Maltese terrier, Maltese
+Pekinese, Pekingese, Peke
+Shih-Tzu
+Blenheim spaniel
+papillon
+toy terrier
+Rhodesian ridgeback
+Afghan hound, Afghan
+basset, basset hound
+beagle
+bloodhound, sleuthhound
+bluetick
+black-and-tan coonhound
+Walker hound, Walker foxhound
+English foxhound
+redbone
+borzoi, Russian wolfhound
+Irish wolfhound
+Italian greyhound
+whippet
+Ibizan hound, Ibizan Podenco
+Norwegian elkhound, elkhound
+otterhound, otter hound
+Saluki, gazelle hound
+Scottish deerhound, deerhound
+Weimaraner
+Staffordshire bullterrier, Staffordshire bull terrier
+American Staffordshire terrier, Staffordshire terrier, American pit bull terrier, pit bull terrier
+Bedlington terrier
+Border terrier
+Kerry blue terrier
+Irish terrier
+Norfolk terrier
+Norwich terrier
+Yorkshire terrier
+wire-haired fox terrier
+Lakeland terrier
+Sealyham terrier, Sealyham
+Airedale, Airedale terrier
+cairn, cairn terrier
+Australian terrier
+Dandie Dinmont, Dandie Dinmont terrier
+Boston bull, Boston terrier
+miniature schnauzer
+giant schnauzer
+standard schnauzer
+Scotch terrier, Scottish terrier, Scottie
+Tibetan terrier, chrysanthemum dog
+silky terrier, Sydney silky
+soft-coated wheaten terrier
+West Highland white terrier
+Lhasa, Lhasa apso
+flat-coated retriever
+curly-coated retriever
+golden retriever
+Labrador retriever
+Chesapeake Bay retriever
+German short-haired pointer
+vizsla, Hungarian pointer
+English setter
+Irish setter, red setter
+Gordon setter
+Brittany spaniel
+clumber, clumber spaniel
+English springer, English springer spaniel
+Welsh springer spaniel
+cocker spaniel, English cocker spaniel, cocker
+Sussex spaniel
+Irish water spaniel
+kuvasz
+schipperke
+groenendael
+malinois
+briard
+kelpie
+komondor
+Old English sheepdog, bobtail
+Shetland sheepdog, Shetland sheep dog, Shetland
+collie
+Border collie
+Bouvier des Flandres, Bouviers des Flandres
+Rottweiler
+German shepherd, German shepherd dog, German police dog, alsatian
+Doberman, Doberman pinscher
+miniature pinscher
+Greater Swiss Mountain dog
+Bernese mountain dog
+Appenzeller
+EntleBucher
+boxer
+bull mastiff
+Tibetan mastiff
+French bulldog
+Great Dane
+Saint Bernard, St Bernard
+Eskimo dog, husky
+malamute, malemute, Alaskan malamute
+Siberian husky
+dalmatian, coach dog, carriage dog
+affenpinscher, monkey pinscher, monkey dog
+basenji
+pug, pug-dog
+Leonberg
+Newfoundland, Newfoundland dog
+Great Pyrenees
+Samoyed, Samoyede
+Pomeranian
+chow, chow chow
+keeshond
+Brabancon griffon
+Pembroke, Pembroke Welsh corgi
+Cardigan, Cardigan Welsh corgi
+toy poodle
+miniature poodle
+standard poodle
+Mexican hairless
+timber wolf, grey wolf, gray wolf, Canis lupus
+white wolf, Arctic wolf, Canis lupus tundrarum
+red wolf, maned wolf, Canis rufus, Canis niger
+coyote, prairie wolf, brush wolf, Canis latrans
+dingo, warrigal, warragal, Canis dingo
+dhole, Cuon alpinus
+African hunting dog, hyena dog, Cape hunting dog, Lycaon pictus
+hyena, hyaena
+red fox, Vulpes vulpes
+kit fox, Vulpes macrotis
+Arctic fox, white fox, Alopex lagopus
+grey fox, gray fox, Urocyon cinereoargenteus
+tabby, tabby cat
+tiger cat
+Persian cat
+Siamese cat, Siamese
+Egyptian cat
+cougar, puma, catamount, mountain lion, painter, panther, Felis concolor
+lynx, catamount
+leopard, Panthera pardus
+snow leopard, ounce, Panthera uncia
+jaguar, panther, Panthera onca, Felis onca
+lion, king of beasts, Panthera leo
+tiger, Panthera tigris
+cheetah, chetah, Acinonyx jubatus
+brown bear, bruin, Ursus arctos
+American black bear, black bear, Ursus americanus, Euarctos americanus
+ice bear, polar bear, Ursus Maritimus, Thalarctos maritimus
+sloth bear, Melursus ursinus, Ursus ursinus
+mongoose
+meerkat, mierkat
+tiger beetle
+ladybug, ladybeetle, lady beetle, ladybird, ladybird beetle
+ground beetle, carabid beetle
+long-horned beetle, longicorn, longicorn beetle
+leaf beetle, chrysomelid
+dung beetle
+rhinoceros beetle
+weevil
+fly
+bee
+ant, emmet, pismire
+grasshopper, hopper
+cricket
+walking stick, walkingstick, stick insect
+cockroach, roach
+mantis, mantid
+cicada, cicala
+leafhopper
+lacewing, lacewing fly
+dragonfly, darning needle, devil's darning needle, sewing needle, snake feeder, snake doctor, mosquito hawk, skeeter hawk
+damselfly
+admiral
+ringlet, ringlet butterfly
+monarch, monarch butterfly, milkweed butterfly, Danaus plexippus
+cabbage butterfly
+sulphur butterfly, sulfur butterfly
+lycaenid, lycaenid butterfly
+starfish, sea star
+sea urchin
+sea cucumber, holothurian
+wood rabbit, cottontail, cottontail rabbit
+hare
+Angora, Angora rabbit
+hamster
+porcupine, hedgehog
+fox squirrel, eastern fox squirrel, Sciurus niger
+marmot
+beaver
+guinea pig, Cavia cobaya
+sorrel
+zebra
+hog, pig, grunter, squealer, Sus scrofa
+wild boar, boar, Sus scrofa
+warthog
+hippopotamus, hippo, river horse, Hippopotamus amphibius
+ox
+water buffalo, water ox, Asiatic buffalo, Bubalus bubalis
+bison
+ram, tup
+bighorn, bighorn sheep, cimarron, Rocky Mountain bighorn, Rocky Mountain sheep, Ovis canadensis
+ibex, Capra ibex
+hartebeest
+impala, Aepyceros melampus
+gazelle
+Arabian camel, dromedary, Camelus dromedarius
+llama
+weasel
+mink
+polecat, fitch, foulmart, foumart, Mustela putorius
+black-footed ferret, ferret, Mustela nigripes
+otter
+skunk, polecat, wood pussy
+badger
+armadillo
+three-toed sloth, ai, Bradypus tridactylus
+orangutan, orang, orangutang, Pongo pygmaeus
+gorilla, Gorilla gorilla
+chimpanzee, chimp, Pan troglodytes
+gibbon, Hylobates lar
+siamang, Hylobates syndactylus, Symphalangus syndactylus
+guenon, guenon monkey
+patas, hussar monkey, Erythrocebus patas
+baboon
+macaque
+langur
+colobus, colobus monkey
+proboscis monkey, Nasalis larvatus
+marmoset
+capuchin, ringtail, Cebus capucinus
+howler monkey, howler
+titi, titi monkey
+spider monkey, Ateles geoffroyi
+squirrel monkey, Saimiri sciureus
+Madagascar cat, ring-tailed lemur, Lemur catta
+indri, indris, Indri indri, Indri brevicaudatus
+Indian elephant, Elephas maximus
+African elephant, Loxodonta africana
+lesser panda, red panda, panda, bear cat, cat bear, Ailurus fulgens
+giant panda, panda, panda bear, coon bear, Ailuropoda melanoleuca
+barracouta, snoek
+eel
+coho, cohoe, coho salmon, blue jack, silver salmon, Oncorhynchus kisutch
+rock beauty, Holocanthus tricolor
+anemone fish
+sturgeon
+gar, garfish, garpike, billfish, Lepisosteus osseus
+lionfish
+puffer, pufferfish, blowfish, globefish
+abacus
+abaya
+academic gown, academic robe, judge's robe
+accordion, piano accordion, squeeze box
+acoustic guitar
+aircraft carrier, carrier, flattop, attack aircraft carrier
+airliner
+airship, dirigible
+altar
+ambulance
+amphibian, amphibious vehicle
+analog clock
+apiary, bee house
+apron
+ashcan, trash can, garbage can, wastebin, ash bin, ash-bin, ashbin, dustbin, trash barrel, trash bin
+assault rifle, assault gun
+backpack, back pack, knapsack, packsack, rucksack, haversack
+bakery, bakeshop, bakehouse
+balance beam, beam
+balloon
+ballpoint, ballpoint pen, ballpen, Biro
+Band Aid
+banjo
+bannister, banister, balustrade, balusters, handrail
+barbell
+barber chair
+barbershop
+barn
+barometer
+barrel, cask
+barrow, garden cart, lawn cart, wheelbarrow
+baseball
+basketball
+bassinet
+bassoon
+bathing cap, swimming cap
+bath towel
+bathtub, bathing tub, bath, tub
+beach wagon, station wagon, wagon, estate car, beach waggon, station waggon, waggon
+beacon, lighthouse, beacon light, pharos
+beaker
+bearskin, busby, shako
+beer bottle
+beer glass
+bell cote, bell cot
+bib
+bicycle-built-for-two, tandem bicycle, tandem
+bikini, two-piece
+binder, ring-binder
+binoculars, field glasses, opera glasses
+birdhouse
+boathouse
+bobsled, bobsleigh, bob
+bolo tie, bolo, bola tie, bola
+bonnet, poke bonnet
+bookcase
+bookshop, bookstore, bookstall
+bottlecap
+bow
+bow tie, bow-tie, bowtie
+brass, memorial tablet, plaque
+brassiere, bra, bandeau
+breakwater, groin, groyne, mole, bulwark, seawall, jetty
+breastplate, aegis, egis
+broom
+bucket, pail
+buckle
+bulletproof vest
+bullet train, bullet
+butcher shop, meat market
+cab, hack, taxi, taxicab
+caldron, cauldron
+candle, taper, wax light
+cannon
+canoe
+can opener, tin opener
+cardigan
+car mirror
+carousel, carrousel, merry-go-round, roundabout, whirligig
+carpenter's kit, tool kit
+carton
+car wheel
+cash machine, cash dispenser, automated teller machine, automatic teller machine, automated teller, automatic teller, ATM
+cassette
+cassette player
+castle
+catamaran
+CD player
+cello, violoncello
+cellular telephone, cellular phone, cellphone, cell, mobile phone
+chain
+chainlink fence
+chain mail, ring mail, mail, chain armor, chain armour, ring armor, ring armour
+chain saw, chainsaw
+chest
+chiffonier, commode
+chime, bell, gong
+china cabinet, china closet
+Christmas stocking
+church, church building
+cinema, movie theater, movie theatre, movie house, picture palace
+cleaver, meat cleaver, chopper
+cliff dwelling
+cloak
+clog, geta, patten, sabot
+cocktail shaker
+coffee mug
+coffeepot
+coil, spiral, volute, whorl, helix
+combination lock
+computer keyboard, keypad
+confectionery, confectionary, candy store
+container ship, containership, container vessel
+convertible
+corkscrew, bottle screw
+cornet, horn, trumpet, trump
+cowboy boot
+cowboy hat, ten-gallon hat
+cradle
+crane
+crash helmet
+crate
+crib, cot
+Crock Pot
+croquet ball
+crutch
+cuirass
+dam, dike, dyke
+desk
+desktop computer
+dial telephone, dial phone
+diaper, nappy, napkin
+digital clock
+digital watch
+dining table, board
+dishrag, dishcloth
+dishwasher, dish washer, dishwashing machine
+disk brake, disc brake
+dock, dockage, docking facility
+dogsled, dog sled, dog sleigh
+dome
+doormat, welcome mat
+drilling platform, offshore rig
+drum, membranophone, tympan
+drumstick
+dumbbell
+Dutch oven
+electric fan, blower
+electric guitar
+electric locomotive
+entertainment center
+envelope
+espresso maker
+face powder
+feather boa, boa
+file, file cabinet, filing cabinet
+fireboat
+fire engine, fire truck
+fire screen, fireguard
+flagpole, flagstaff
+flute, transverse flute
+folding chair
+football helmet
+forklift
+fountain
+fountain pen
+four-poster
+freight car
+French horn, horn
+frying pan, frypan, skillet
+fur coat
+garbage truck, dustcart
+gasmask, respirator, gas helmet
+gas pump, gasoline pump, petrol pump, island dispenser
+goblet
+go-kart
+golf ball
+golfcart, golf cart
+gondola
+gong, tam-tam
+gown
+grand piano, grand
+greenhouse, nursery, glasshouse
+grille, radiator grille
+grocery store, grocery, food market, market
+guillotine
+hair slide
+hair spray
+half track
+hammer
+hamper
+hand blower, blow dryer, blow drier, hair dryer, hair drier
+hand-held computer, hand-held microcomputer
+handkerchief, hankie, hanky, hankey
+hard disc, hard disk, fixed disk
+harmonica, mouth organ, harp, mouth harp
+harp
+harvester, reaper
+hatchet
+holster
+home theater, home theatre
+honeycomb
+hook, claw
+hoopskirt, crinoline
+horizontal bar, high bar
+horse cart, horse-cart
+hourglass
+iPod
+iron, smoothing iron
+jack-o'-lantern
+jean, blue jean, denim
+jeep, landrover
+jersey, T-shirt, tee shirt
+jigsaw puzzle
+jinrikisha, ricksha, rickshaw
+joystick
+kimono
+knee pad
+knot
+lab coat, laboratory coat
+ladle
+lampshade, lamp shade
+laptop, laptop computer
+lawn mower, mower
+lens cap, lens cover
+letter opener, paper knife, paperknife
+library
+lifeboat
+lighter, light, igniter, ignitor
+limousine, limo
+liner, ocean liner
+lipstick, lip rouge
+Loafer
+lotion
+loudspeaker, speaker, speaker unit, loudspeaker system, speaker system
+loupe, jeweler's loupe
+lumbermill, sawmill
+magnetic compass
+mailbag, postbag
+mailbox, letter box
+maillot
+maillot, tank suit
+manhole cover
+maraca
+marimba, xylophone
+mask
+matchstick
+maypole
+maze, labyrinth
+measuring cup
+medicine chest, medicine cabinet
+megalith, megalithic structure
+microphone, mike
+microwave, microwave oven
+military uniform
+milk can
+minibus
+miniskirt, mini
+minivan
+missile
+mitten
+mixing bowl
+mobile home, manufactured home
+Model T
+modem
+monastery
+monitor
+moped
+mortar
+mortarboard
+mosque
+mosquito net
+motor scooter, scooter
+mountain bike, all-terrain bike, off-roader
+mountain tent
+mouse, computer mouse
+mousetrap
+moving van
+muzzle
+nail
+neck brace
+necklace
+nipple
+notebook, notebook computer
+obelisk
+oboe, hautboy, hautbois
+ocarina, sweet potato
+odometer, hodometer, mileometer, milometer
+oil filter
+organ, pipe organ
+oscilloscope, scope, cathode-ray oscilloscope, CRO
+overskirt
+oxcart
+oxygen mask
+packet
+paddle, boat paddle
+paddlewheel, paddle wheel
+padlock
+paintbrush
+pajama, pyjama, pj's, jammies
+palace
+panpipe, pandean pipe, syrinx
+paper towel
+parachute, chute
+parallel bars, bars
+park bench
+parking meter
+passenger car, coach, carriage
+patio, terrace
+pay-phone, pay-station
+pedestal, plinth, footstall
+pencil box, pencil case
+pencil sharpener
+perfume, essence
+Petri dish
+photocopier
+pick, plectrum, plectron
+pickelhaube
+picket fence, paling
+pickup, pickup truck
+pier
+piggy bank, penny bank
+pill bottle
+pillow
+ping-pong ball
+pinwheel
+pirate, pirate ship
+pitcher, ewer
+plane, carpenter's plane, woodworking plane
+planetarium
+plastic bag
+plate rack
+plow, plough
+plunger, plumber's helper
+Polaroid camera, Polaroid Land camera
+pole
+police van, police wagon, paddy wagon, patrol wagon, wagon, black Maria
+poncho
+pool table, billiard table, snooker table
+pop bottle, soda bottle
+pot, flowerpot
+potter's wheel
+power drill
+prayer rug, prayer mat
+printer
+prison, prison house
+projectile, missile
+projector
+puck, hockey puck
+punching bag, punch bag, punching ball, punchball
+purse
+quill, quill pen
+quilt, comforter, comfort, puff
+racer, race car, racing car
+racket, racquet
+radiator
+radio, wireless
+radio telescope, radio reflector
+rain barrel
+recreational vehicle, RV, R.V.
+reel
+reflex camera
+refrigerator, icebox
+remote control, remote
+restaurant, eating house, eating place, eatery
+revolver, six-gun, six-shooter
+rifle
+rocking chair, rocker
+rotisserie
+rubber eraser, rubber, pencil eraser
+rugby ball
+rule, ruler
+running shoe
+safe
+safety pin
+saltshaker, salt shaker
+sandal
+sarong
+sax, saxophone
+scabbard
+scale, weighing machine
+school bus
+schooner
+scoreboard
+screen, CRT screen
+screw
+screwdriver
+seat belt, seatbelt
+sewing machine
+shield, buckler
+shoe shop, shoe-shop, shoe store
+shoji
+shopping basket
+shopping cart
+shovel
+shower cap
+shower curtain
+ski
+ski mask
+sleeping bag
+slide rule, slipstick
+sliding door
+slot, one-armed bandit
+snorkel
+snowmobile
+snowplow, snowplough
+soap dispenser
+soccer ball
+sock
+solar dish, solar collector, solar furnace
+sombrero
+soup bowl
+space bar
+space heater
+space shuttle
+spatula
+speedboat
+spider web, spider's web
+spindle
+sports car, sport car
+spotlight, spot
+stage
+steam locomotive
+steel arch bridge
+steel drum
+stethoscope
+stole
+stone wall
+stopwatch, stop watch
+stove
+strainer
+streetcar, tram, tramcar, trolley, trolley car
+stretcher
+studio couch, day bed
+stupa, tope
+submarine, pigboat, sub, U-boat
+suit, suit of clothes
+sundial
+sunglass
+sunglasses, dark glasses, shades
+sunscreen, sunblock, sun blocker
+suspension bridge
+swab, swob, mop
+sweatshirt
+swimming trunks, bathing trunks
+swing
+switch, electric switch, electrical switch
+syringe
+table lamp
+tank, army tank, armored combat vehicle, armoured combat vehicle
+tape player
+teapot
+teddy, teddy bear
+television, television system
+tennis ball
+thatch, thatched roof
+theater curtain, theatre curtain
+thimble
+thresher, thrasher, threshing machine
+throne
+tile roof
+toaster
+tobacco shop, tobacconist shop, tobacconist
+toilet seat
+torch
+totem pole
+tow truck, tow car, wrecker
+toyshop
+tractor
+trailer truck, tractor trailer, trucking rig, rig, articulated lorry, semi
+tray
+trench coat
+tricycle, trike, velocipede
+trimaran
+tripod
+triumphal arch
+trolleybus, trolley coach, trackless trolley
+trombone
+tub, vat
+turnstile
+typewriter keyboard
+umbrella
+unicycle, monocycle
+upright, upright piano
+vacuum, vacuum cleaner
+vase
+vault
+velvet
+vending machine
+vestment
+viaduct
+violin, fiddle
+volleyball
+waffle iron
+wall clock
+wallet, billfold, notecase, pocketbook
+wardrobe, closet, press
+warplane, military plane
+washbasin, handbasin, washbowl, lavabo, wash-hand basin
+washer, automatic washer, washing machine
+water bottle
+water jug
+water tower
+whiskey jug
+whistle
+wig
+window screen
+window shade
+Windsor tie
+wine bottle
+wing
+wok
+wooden spoon
+wool, woolen, woollen
+worm fence, snake fence, snake-rail fence, Virginia fence
+wreck
+yawl
+yurt
+web site, website, internet site, site
+comic book
+crossword puzzle, crossword
+street sign
+traffic light, traffic signal, stoplight
+book jacket, dust cover, dust jacket, dust wrapper
+menu
+plate
+guacamole
+consomme
+hot pot, hotpot
+trifle
+ice cream, icecream
+ice lolly, lolly, lollipop, popsicle
+French loaf
+bagel, beigel
+pretzel
+cheeseburger
+hotdog, hot dog, red hot
+mashed potato
+head cabbage
+broccoli
+cauliflower
+zucchini, courgette
+spaghetti squash
+acorn squash
+butternut squash
+cucumber, cuke
+artichoke, globe artichoke
+bell pepper
+cardoon
+mushroom
+Granny Smith
+strawberry
+orange
+lemon
+fig
+pineapple, ananas
+banana
+jackfruit, jak, jack
+custard apple
+pomegranate
+hay
+carbonara
+chocolate sauce, chocolate syrup
+dough
+meat loaf, meatloaf
+pizza, pizza pie
+potpie
+burrito
+red wine
+espresso
+cup
+eggnog
+alp
+bubble
+cliff, drop, drop-off
+coral reef
+geyser
+lakeside, lakeshore
+promontory, headland, head, foreland
+sandbar, sand bar
+seashore, coast, seacoast, sea-coast
+valley, vale
+volcano
+ballplayer, baseball player
+groom, bridegroom
+scuba diver
+rapeseed
+daisy
+yellow lady's slipper, yellow lady-slipper, Cypripedium calceolus, Cypripedium parviflorum
+corn
+acorn
+hip, rose hip, rosehip
+buckeye, horse chestnut, conker
+coral fungus
+agaric
+gyromitra
+stinkhorn, carrion fungus
+earthstar
+hen-of-the-woods, hen of the woods, Polyporus frondosus, Grifola frondosa
+bolete
+ear, spike, capitulum
+toilet tissue, toilet paper, bathroom tissue

--- a/python/src/nnabla/models/imagenet/mobilenet.py
+++ b/python/src/nnabla/models/imagenet/mobilenet.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+import nnabla as nn
+from nnabla.utils.download import download
+from nnabla.utils.nnp_graph import NnpLoader, NnpNetworkPass
+
+from nnabla import logger
+
+from ..utils import *
+from .base import ImageNetBase
+
+
+class MobileNetV2(ImageNetBase):
+    '''
+    MobileNetV2 architecture.
+
+    The following is a list of string that can be specified to ``use_up_to`` option in ``__call__`` method;
+
+    * ``'classifier'`` (default): The output of the final affine layer for classification.
+    * ``'pool'``: The output of the final global average pooling.
+    * ``'lastconv'``: The input of the final global average pooling without ReLU activation..
+    * ``'lastconv+relu'``: Network up to ``'lastconv'`` followed by ReLU activation.
+
+    References:
+        * `Sandelr et al., MobileNetV2: Inverted Residuals and Linear Bottlenecks.
+          <https://arxiv.org/abs/1801.04381>`_
+
+    '''
+
+    def __init__(self):
+        path_nnp = os.path.join(
+            get_model_home(), 'imagenet/MobileNet-v2.nnp')
+        url = os.path.join(get_model_url_base(),
+                           'imagenet/MobileNet-v2/MobileNet-v2.nnp')
+        logger.info('Downloading MobileNetV2 from {}'.format(url))
+        download(url, path_nnp, open_file=False, allow_overwrite=False)
+        print('Loading {}.'.format(path_nnp))
+        self.nnp = NnpLoader(path_nnp)
+
+    def _input_shape(self):
+        return (3, 224, 224)
+
+    def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
+        r'''
+
+        Args:
+            input_var (Variable, optional):
+                If given, input variable is replaced with the given variable and a network is constructed on top of the variable. Otherwise, a variable with a default shape ``(1, 3, 224, 224)`` is used.
+
+            use_up_to (str):
+                Network is constructed up to a variable specified by a string as following.
+
+                * ``'classifier'`` (default): The output of the final affine layer for classification.
+                * ``'pool'``: The output of the final global average pooling.
+                * ``'lastconv'``: The input of the final global average pooling without ReLU activation..
+                * ``'lastconv+relu'``: Network up to ``'lastconv'`` followed by ReLU activation.
+
+
+            training (bool):
+                This option enables additional training (fine-tuning, transfer learning etc.) for the constructed network. If True, the ``batch_stat`` option in batch normalization is turned ``True``, and ``need_grad`` attribute in trainable variables (conv weights and gamma and beta of bn etc.) is turned ``True``. The default is ``False``.
+
+            force_global_pooling (bool):
+                Regardless the input image size, the final average pooling before classification layer will be automatically transformed to a global average pooling. The default is ``False``.
+
+            check_global_pooling (bool):
+                If ``True``, and if the stride configuration of the final average pooling is not for global pooling, it raises an exception. The default is ``True``. Use ``False`` when user want to do the pooling with the trained stride ``(7, 7)`` regardless the input spatial size.
+
+            returns_net (bool):
+                When ``True``, it returns a :obj:`~nnabla.utils.nnp_graph.NnpNetwork` object. Otherwise, It only returns the last variable of the constructed network. The default is ``False``.
+            verbose (bool, or int):
+                Verbose level. With ``0``, it says nothing during network construction.
+
+        '''
+
+        # Use up to
+        set_use_up_to = set(
+            ['classifier', 'pool', 'lastconv', 'lastconv+relu'])
+        assert use_up_to in set_use_up_to, "use_up_to must be chosen from {}. Given {}.".format(
+            set_use_up_to, use_up_to)
+
+        fix_parameters = not training
+        bn_batch_stat = training
+        default_shape = (1,) + self.input_shape
+        if input_var is None:
+            input_var = nn.Variable(default_shape)
+        assert input_var.ndim == 4, "input_var must be 4 dimensions. Given {}.".format(
+            input_var.ndim)
+        assert input_var.shape[1] == 3, "input_var.shape[1] must be 3 (RGB). Given {}.".format(
+            input_var.shape[1])
+
+        callback = NnpNetworkPass(verbose)
+        callback.drop_function('ImageAugmentationX')
+        callback.set_variable('ImageAugmentationX', input_var)
+        if force_global_pooling:
+            callback.force_average_pooling_global('AveragePooling')
+        elif check_global_pooling:
+            callback.check_average_pooling_global('AveragePooling')
+        callback.set_batch_normalization_batch_stat_all(bn_batch_stat)
+
+        if use_up_to == 'classifier':
+            callback.use_up_to('Reshape')
+        elif use_up_to == 'pool':
+            callback.use_up_to('AveragePooling')
+        elif use_up_to == 'lastconv':
+            callback.use_up_to('BatchNormalization_2')
+        elif use_up_to == 'lastconv+relu':
+            callback.use_up_to('ReLU_2')
+        else:
+            raise NotImplementedError()
+        if fix_parameters:
+            callback.fix_parameters()
+        batch_size = input_var.shape[0]
+        net = self.nnp.get_network(
+            'Training', batch_size=batch_size, callback=callback)
+        if returns_net:
+            return net
+        return list(net.outputs.values())[0]

--- a/python/src/nnabla/models/imagenet/mobilenet.py
+++ b/python/src/nnabla/models/imagenet/mobilenet.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 from __future__ import absolute_import
 import nnabla as nn
-from nnabla.utils.download import download
-from nnabla.utils.nnp_graph import NnpLoader, NnpNetworkPass
+from nnabla.utils.nnp_graph import NnpNetworkPass
 
 from nnabla import logger
 
-from ..utils import *
 from .base import ImageNetBase
 
 
@@ -40,49 +38,12 @@ class MobileNetV2(ImageNetBase):
     '''
 
     def __init__(self):
-        path_nnp = os.path.join(
-            get_model_home(), 'imagenet/MobileNet-v2.nnp')
-        url = os.path.join(get_model_url_base(),
-                           'imagenet/MobileNet-v2/MobileNet-v2.nnp')
-        logger.info('Downloading MobileNetV2 from {}'.format(url))
-        download(url, path_nnp, open_file=False, allow_overwrite=False)
-        print('Loading {}.'.format(path_nnp))
-        self.nnp = NnpLoader(path_nnp)
+        self._load_nnp('MobileNet-v2.nnp', 'MobileNet-v2/MobileNet-v2.nnp')
 
     def _input_shape(self):
         return (3, 224, 224)
 
     def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
-        r'''
-
-        Args:
-            input_var (Variable, optional):
-                If given, input variable is replaced with the given variable and a network is constructed on top of the variable. Otherwise, a variable with a default shape ``(1, 3, 224, 224)`` is used.
-
-            use_up_to (str):
-                Network is constructed up to a variable specified by a string as following.
-
-                * ``'classifier'`` (default): The output of the final affine layer for classification.
-                * ``'pool'``: The output of the final global average pooling.
-                * ``'lastconv'``: The input of the final global average pooling without ReLU activation..
-                * ``'lastconv+relu'``: Network up to ``'lastconv'`` followed by ReLU activation.
-
-
-            training (bool):
-                This option enables additional training (fine-tuning, transfer learning etc.) for the constructed network. If True, the ``batch_stat`` option in batch normalization is turned ``True``, and ``need_grad`` attribute in trainable variables (conv weights and gamma and beta of bn etc.) is turned ``True``. The default is ``False``.
-
-            force_global_pooling (bool):
-                Regardless the input image size, the final average pooling before classification layer will be automatically transformed to a global average pooling. The default is ``False``.
-
-            check_global_pooling (bool):
-                If ``True``, and if the stride configuration of the final average pooling is not for global pooling, it raises an exception. The default is ``True``. Use ``False`` when user want to do the pooling with the trained stride ``(7, 7)`` regardless the input spatial size.
-
-            returns_net (bool):
-                When ``True``, it returns a :obj:`~nnabla.utils.nnp_graph.NnpNetwork` object. Otherwise, It only returns the last variable of the constructed network. The default is ``False``.
-            verbose (bool, or int):
-                Verbose level. With ``0``, it says nothing during network construction.
-
-        '''
 
         # Use up to
         set_use_up_to = set(

--- a/python/src/nnabla/models/imagenet/resnet.py
+++ b/python/src/nnabla/models/imagenet/resnet.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+import nnabla as nn
+from nnabla.utils.download import download
+from nnabla.utils.nnp_graph import NnpLoader, NnpNetworkPass
+
+from nnabla import logger
+
+from ..utils import *
+from .base import ImageNetBase
+
+
+class ResNet(ImageNetBase):
+
+    '''
+    ResNet architectures for 18, 34, 50, 101, and 152 of number of layers.
+
+    Args:
+        num_layers (int): Number of layers chosen from 18, 34, 50, 101, and 152.
+
+    References:
+        * `He et al, Deep Residual Learning for Image Recognition.
+          <https://arxiv.org/abs/1512.03385>`_
+
+    '''
+
+    def __init__(self, num_layers=18):
+        set_num_layers = set((18, 34, 50, 101, 152))
+        assert num_layers in set_num_layers, "num_layers must be chosen from {}".format(
+            set_num_layers)
+        path_nnp = os.path.join(
+            get_model_home(), 'imagenet/Resnet-{}.nnp'.format(num_layers))
+        url = os.path.join(get_model_url_base(),
+                           'imagenet/Resnet-{0}/Resnet-{0}.nnp'.format(num_layers))
+        logger.info('Downloading ResNet{} from {}'.format(num_layers, url))
+        download(url, path_nnp, open_file=False, allow_overwrite=False)
+        print('Loading {}.'.format(path_nnp))
+        self.nnp = NnpLoader(path_nnp)
+        self.num_layers = num_layers
+
+    def _input_shape(self):
+        return (3, 224, 224)
+
+    def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
+        r'''
+
+        Args:
+            input_var (Variable, optional):
+                If given, input variable is replaced with the given variable and a network is constructed on top of the variable. Otherwise, a variable with a default shape ``(1, 3, 224, 224)`` is used.
+
+            use_up_to (str):
+                Network is constructed up to a variable specified by a string as following.
+
+                * ``'classifier'`` (default): The output of the final affine layer for classification.
+                * ``'pool'``: The output of the final global average pooling.
+                * ``'block4'``: The input of the final global average pooling without ReLU activation..
+                * ``'block4+relu'``: Network up to ``'block'`` followed by ReLU activation.
+
+
+            training (bool):
+                This option enables additional training (fine-tuning, transfer learning etc.) for the constructed network. If True, the ``batch_stat`` option in batch normalization is turned ``True``, and ``need_grad`` attribute in trainable variables (conv weights and gamma and beta of bn etc.) is turned ``True``. The default is ``False``.
+
+            force_global_pooling (bool):
+                Regardless the input image size, the final average pooling before classification layer will be automatically transformed to a global average pooling. The default is ``False``.
+
+            check_global_pooling (bool):
+                If ``True``, and if the stride configuration of the final average pooling is not for global pooling, it raises an exception. The default is ``True``. Use ``False`` when user want to do the pooling with the trained stride ``(7, 7)`` regardless the input spatial size.
+
+            returns_net (bool):
+                When ``True``, it returns a :obj:`~nnabla.utils.nnp_graph.NnpNetwork` object. Otherwise, It only returns the last variable of the constructed network. The default is ``False``.
+            verbose (bool, or int):
+                Verbose level. With ``0``, it says nothing during network construction.
+
+        '''
+        assert use_from is None, 'This should not be set because it is for forward compatibility.'
+
+        set_use_up_to = set(['classifier', 'pool', 'block4', 'block4+relu'])
+
+        assert use_up_to in set_use_up_to, "use_up_to must be chosen from {}. Given {}.".format(
+            set_use_up_to, use_up_to)
+        fix_parameters = not training
+        bn_batch_stat = training
+        default_shape = (1,) + self.input_shape
+        if input_var is None:
+            input_var = nn.Variable(default_shape)
+        assert input_var.ndim == 4, "input_var must be 4 dimensions. Given {}.".format(
+            input_var.ndim)
+        assert input_var.shape[1] == 3, "input_var.shape[1] must be 3 (RGB). Given {}.".format(
+            input_var.shape[1])
+
+        callback = NnpNetworkPass(verbose)
+
+        callback.remove_and_rewire('ImageAugmentationX')
+        callback.set_variable('InputX', input_var)
+        if force_global_pooling:
+            callback.force_average_pooling_global('AveragePooling')
+        elif check_global_pooling:
+            callback.check_average_pooling_global('AveragePooling')
+        callback.set_batch_normalization_batch_stat_all(bn_batch_stat)
+
+        if use_up_to == 'classifier':
+            callback.use_up_to('Affine')
+        elif use_up_to == 'pool':
+            callback.use_up_to('AveragePooling')
+        elif use_up_to.startswith('block4'):
+            callback.use_up_to('Add2_7_RepeatStart_4[{}]'.format(
+                0 if self.num_layers == 18 else 1))
+        elif use_up_to.startswith('block4+relu'):
+            callback.use_up_to('ReLU_25_RepeatStart_4[{}]'.format(
+                0 if self.num_layers == 18 else 1))
+        else:
+            raise NotImplementedError()
+
+        if fix_parameters:
+            callback.fix_parameters()
+        batch_size = input_var.shape[0]
+        net = self.nnp.get_network(
+            'Training', batch_size=batch_size, callback=callback)
+        if returns_net:
+            return net
+        return list(net.outputs.values())[0]

--- a/python/src/nnabla/models/imagenet/resnet.py
+++ b/python/src/nnabla/models/imagenet/resnet.py
@@ -13,12 +13,10 @@
 # limitations under the License.
 from __future__ import absolute_import
 import nnabla as nn
-from nnabla.utils.download import download
-from nnabla.utils.nnp_graph import NnpLoader, NnpNetworkPass
+from nnabla.utils.nnp_graph import NnpNetworkPass
 
 from nnabla import logger
 
-from ..utils import *
 from .base import ImageNetBase
 
 
@@ -30,6 +28,13 @@ class ResNet(ImageNetBase):
     Args:
         num_layers (int): Number of layers chosen from 18, 34, 50, 101, and 152.
 
+    The following is a list of string that can be specified to ``use_up_to`` option in ``__call__`` method;
+
+    * ``'classifier'`` (default): The output of the final affine layer for classification.
+    * ``'pool'``: The output of the final global average pooling.
+    * ``'lastconv'``: The input of the final global average pooling without ReLU activation..
+    * ``'lastconv+relu'``: Network up to ``'lastconv'`` followed by ReLU activation.
+
     References:
         * `He et al, Deep Residual Learning for Image Recognition.
           <https://arxiv.org/abs/1512.03385>`_
@@ -37,56 +42,26 @@ class ResNet(ImageNetBase):
     '''
 
     def __init__(self, num_layers=18):
+
+        # Check validity of num_layers
         set_num_layers = set((18, 34, 50, 101, 152))
         assert num_layers in set_num_layers, "num_layers must be chosen from {}".format(
             set_num_layers)
-        path_nnp = os.path.join(
-            get_model_home(), 'imagenet/Resnet-{}.nnp'.format(num_layers))
-        url = os.path.join(get_model_url_base(),
-                           'imagenet/Resnet-{0}/Resnet-{0}.nnp'.format(num_layers))
-        logger.info('Downloading ResNet{} from {}'.format(num_layers, url))
-        download(url, path_nnp, open_file=False, allow_overwrite=False)
-        print('Loading {}.'.format(path_nnp))
-        self.nnp = NnpLoader(path_nnp)
         self.num_layers = num_layers
+
+        # Load nnp
+        self._load_nnp('Resnet-{}.nnp'.format(num_layers),
+                       'Resnet-{0}/Resnet-{0}.nnp'.format(num_layers))
 
     def _input_shape(self):
         return (3, 224, 224)
 
     def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
-        r'''
 
-        Args:
-            input_var (Variable, optional):
-                If given, input variable is replaced with the given variable and a network is constructed on top of the variable. Otherwise, a variable with a default shape ``(1, 3, 224, 224)`` is used.
-
-            use_up_to (str):
-                Network is constructed up to a variable specified by a string as following.
-
-                * ``'classifier'`` (default): The output of the final affine layer for classification.
-                * ``'pool'``: The output of the final global average pooling.
-                * ``'block4'``: The input of the final global average pooling without ReLU activation..
-                * ``'block4+relu'``: Network up to ``'block'`` followed by ReLU activation.
-
-
-            training (bool):
-                This option enables additional training (fine-tuning, transfer learning etc.) for the constructed network. If True, the ``batch_stat`` option in batch normalization is turned ``True``, and ``need_grad`` attribute in trainable variables (conv weights and gamma and beta of bn etc.) is turned ``True``. The default is ``False``.
-
-            force_global_pooling (bool):
-                Regardless the input image size, the final average pooling before classification layer will be automatically transformed to a global average pooling. The default is ``False``.
-
-            check_global_pooling (bool):
-                If ``True``, and if the stride configuration of the final average pooling is not for global pooling, it raises an exception. The default is ``True``. Use ``False`` when user want to do the pooling with the trained stride ``(7, 7)`` regardless the input spatial size.
-
-            returns_net (bool):
-                When ``True``, it returns a :obj:`~nnabla.utils.nnp_graph.NnpNetwork` object. Otherwise, It only returns the last variable of the constructed network. The default is ``False``.
-            verbose (bool, or int):
-                Verbose level. With ``0``, it says nothing during network construction.
-
-        '''
         assert use_from is None, 'This should not be set because it is for forward compatibility.'
 
-        set_use_up_to = set(['classifier', 'pool', 'block4', 'block4+relu'])
+        set_use_up_to = set(
+            ['classifier', 'pool', 'lastconv', 'lastconv+relu'])
 
         assert use_up_to in set_use_up_to, "use_up_to must be chosen from {}. Given {}.".format(
             set_use_up_to, use_up_to)
@@ -114,10 +89,10 @@ class ResNet(ImageNetBase):
             callback.use_up_to('Affine')
         elif use_up_to == 'pool':
             callback.use_up_to('AveragePooling')
-        elif use_up_to.startswith('block4'):
+        elif use_up_to.startswith('lastconv'):
             callback.use_up_to('Add2_7_RepeatStart_4[{}]'.format(
                 0 if self.num_layers == 18 else 1))
-        elif use_up_to.startswith('block4+relu'):
+        elif use_up_to.startswith('lastconv+relu'):
             callback.use_up_to('ReLU_25_RepeatStart_4[{}]'.format(
                 0 if self.num_layers == 18 else 1))
         else:

--- a/python/src/nnabla/models/imagenet/resnet.py
+++ b/python/src/nnabla/models/imagenet/resnet.py
@@ -41,6 +41,13 @@ class ResNet(ImageNetBase):
 
     '''
 
+    _KEY_VARIABLE = {
+        'classifier': 'Affine',
+        'pool': 'AveragePooling',
+        'lastconv': 'Add2_7_RepeatStart_4[{index}]',
+        'lastconv+relu': 'ReLU_25_RepeatStart_4[{index}]',
+        }
+
     def __init__(self, num_layers=18):
 
         # Check validity of num_layers
@@ -59,46 +66,17 @@ class ResNet(ImageNetBase):
     def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
 
         assert use_from is None, 'This should not be set because it is for forward compatibility.'
-
-        set_use_up_to = set(
-            ['classifier', 'pool', 'lastconv', 'lastconv+relu'])
-
-        assert use_up_to in set_use_up_to, "use_up_to must be chosen from {}. Given {}.".format(
-            set_use_up_to, use_up_to)
-        fix_parameters = not training
-        bn_batch_stat = training
-        default_shape = (1,) + self.input_shape
-        if input_var is None:
-            input_var = nn.Variable(default_shape)
-        assert input_var.ndim == 4, "input_var must be 4 dimensions. Given {}.".format(
-            input_var.ndim)
-        assert input_var.shape[1] == 3, "input_var.shape[1] must be 3 (RGB). Given {}.".format(
-            input_var.shape[1])
+        input_var = self.get_input_var(input_var)
 
         callback = NnpNetworkPass(verbose)
-
         callback.remove_and_rewire('ImageAugmentationX')
         callback.set_variable('InputX', input_var)
-        if force_global_pooling:
-            callback.force_average_pooling_global('AveragePooling')
-        elif check_global_pooling:
-            callback.check_average_pooling_global('AveragePooling')
-        callback.set_batch_normalization_batch_stat_all(bn_batch_stat)
-
-        if use_up_to == 'classifier':
-            callback.use_up_to('Affine')
-        elif use_up_to == 'pool':
-            callback.use_up_to('AveragePooling')
-        elif use_up_to.startswith('lastconv'):
-            callback.use_up_to('Add2_7_RepeatStart_4[{}]'.format(
-                0 if self.num_layers == 18 else 1))
-        elif use_up_to.startswith('lastconv+relu'):
-            callback.use_up_to('ReLU_25_RepeatStart_4[{}]'.format(
-                0 if self.num_layers == 18 else 1))
-        else:
-            raise NotImplementedError()
-
-        if fix_parameters:
+        self.configure_global_average_pooling(
+            callback, force_global_pooling, check_global_pooling, 'AveragePooling')
+        callback.set_batch_normalization_batch_stat_all(training)
+        index = 0 if self.num_layers == 18 else 1
+        self.use_up_to(use_up_to, callback, index=index)
+        if not training:
             callback.fix_parameters()
         batch_size = input_var.shape[0]
         net = self.nnp.get_network(

--- a/python/src/nnabla/models/imagenet/senet.py
+++ b/python/src/nnabla/models/imagenet/senet.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import nnabla as nn
+from nnabla.utils.nnp_graph import NnpNetworkPass
+
+from nnabla import logger
+
+from .base import ImageNetBase
+
+
+class SENet(ImageNetBase):
+    '''
+    SENet-154 model which integrates SE blocks with a modified ResNeXt architecture.
+
+    The following is a list of string that can be specified to ``use_up_to`` option in ``__call__`` method;
+
+    * ``'classifier'`` (default): The output of the final affine layer for classification.
+    * ``'pool'``: The output of the final global average pooling.
+    * ``'lastconv'``: The input of the final global average pooling without ReLU activation..
+    * ``'lastconv+relu'``: Network up to ``'lastconv'`` followed by ReLU activation.
+
+    References:
+
+        * `Hu et al., Squeeze-and-Excitation Networks.
+          <https://arxiv.org/abs/1709.01507>`_
+
+    '''
+
+    def __init__(self):
+        self._load_nnp('SENet-154.nnp', 'SENet-154/SENet-154.nnp')
+
+    def _input_shape(self):
+        return (3, 224, 224)
+
+    def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
+        # Use up to
+        set_use_up_to = set(
+            ['classifier', 'pool', 'lastconv', 'lastconv+relu'])
+        assert use_up_to in set_use_up_to, "use_up_to must be chosen from {}. Given {}.".format(
+            set_use_up_to, use_up_to)
+
+        fix_parameters = not training
+        bn_batch_stat = training
+        default_shape = (1, 3, 224, 224)
+        if input_var is None:
+            input_var = nn.Variable(default_shape)
+        assert input_var.ndim == 4, "input_var must be 4 dimensions. Given {}.".format(
+            input_var.ndim)
+        assert input_var.shape[1] == 3, "input_var.shape[1] must be 3 (RGB). Given {}.".format(
+            input_var.shape[1])
+
+        callback = NnpNetworkPass(verbose)
+
+        callback.remove_and_rewire('ImageAugmentationX')
+        if not training:
+            callback.remove_and_rewire('Dropout')
+        callback.set_variable('ImageAugmentationX', input_var)
+        if force_global_pooling:
+            callback.force_average_pooling_global('AveragePooling')
+        elif check_global_pooling:
+            callback.check_average_pooling_global('AveragePooling')
+        callback.set_batch_normalization_batch_stat_all(bn_batch_stat)
+
+        if use_up_to == 'classifier':
+            callback.use_up_to('Affine')
+        elif use_up_to == 'pool':
+            callback.use_up_to('AveragePooling')
+        elif use_up_to == 'lastconv':
+            callback.use_up_to('Add2_7_RepeatStart_4[1]')
+        elif use_up_to == 'lastconv+relu':
+            callback.use_up_to('ReLU_25_RepeatStart_4[1]')
+        else:
+            raise NotImplementedError()
+        if fix_parameters:
+            callback.fix_parameters()
+        batch_size = input_var.shape[0]
+        net = self.nnp.get_network(
+            'Training', batch_size=batch_size, callback=callback)
+        if returns_net:
+            return net
+        return list(net.outputs.values())[0]

--- a/python/src/nnabla/models/imagenet/squeezenet.py
+++ b/python/src/nnabla/models/imagenet/squeezenet.py
@@ -40,6 +40,12 @@ class SqueezeNet(ImageNetBase):
         * `DeepScale/SqueezeNet on GitHub <https://github.com/DeepScale/SqueezeNet>`_
 
     '''
+    _KEY_VARIABLE = {
+        'classifier': 'SqueezeNet/Reshape',
+        'pool': 'SqueezeNet/AveragePooling',
+        'lastconv': 'SqueezeNet/Convolution_2',
+        'lastconv+relu': 'SqueezeNet/ReLU_2',
+        }
 
     def __init__(self):
         self._load_nnp('SqueezeNet-1.1.nnp',
@@ -50,47 +56,17 @@ class SqueezeNet(ImageNetBase):
 
     def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
 
-        # Use up to
-        set_use_up_to = set(
-            ['classifier', 'pool', 'lastconv', 'lastconv+relu'])
-
-        assert use_up_to in set_use_up_to, "use_up_to must be chosen from {}. Given {}.".format(
-            set_use_up_to, use_up_to)
-
-        fix_parameters = not training
-        bn_batch_stat = training
-        default_shape = (1,) + self.input_shape
-        if input_var is None:
-            input_var = nn.Variable(default_shape)
-        assert input_var.ndim == 4, "input_var must be 4 dimensions. Given {}.".format(
-            input_var.ndim)
-        assert input_var.shape[1] == 3, "input_var.shape[1] must be 3 (RGB). Given {}.".format(
-            input_var.shape[1])
+        input_var = self.get_input_var(input_var)
 
         callback = NnpNetworkPass(verbose)
-
         callback.remove_and_rewire('ImageAugmentationX')
-        callback.set_variable('ImageAugmentationX', input_var)
+        callback.set_variable('TrainingInput', input_var)
+        self.configure_global_average_pooling(
+            callback, force_global_pooling, check_global_pooling, 'SqueezeNet/AveragePooling')
+        callback.set_batch_normalization_batch_stat_all(training)
+        self.use_up_to(use_up_to, callback)
         if not training:
             callback.remove_and_rewire('SqueezeNet/Dropout')
-        if force_global_pooling:
-            callback.force_average_pooling_global('SqueezeNet/AveragePooling')
-        elif check_global_pooling:
-            callback.check_average_pooling_global('SqueezeNet/AveragePooling')
-        callback.set_batch_normalization_batch_stat_all(bn_batch_stat)
-
-        if use_up_to == 'classifier':
-            callback.use_up_to('SqueezeNet/Reshape')
-        elif use_up_to == 'pool':
-            callback.use_up_to('SqueezeNet/AveragePooling')
-        elif use_up_to == 'lastconv':
-            callback.use_up_to('SqueezeNet/Convolution_2')
-        elif use_up_to == 'lastconv+relu':
-            callback.use_up_to('SqueezeNet/ReLU_2')
-        else:
-            raise NotImplementedError()
-
-        if fix_parameters:
             callback.fix_parameters()
         batch_size = input_var.shape[0]
         net = self.nnp.get_network(

--- a/python/src/nnabla/models/imagenet/squeezenet.py
+++ b/python/src/nnabla/models/imagenet/squeezenet.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+import nnabla as nn
+from nnabla.utils.nnp_graph import NnpNetworkPass
+
+from nnabla import logger
+
+from .base import ImageNetBase
+
+
+class SqueezeNet(ImageNetBase):
+    '''
+    SqueezeNet v1.1 model.
+
+    The following is a list of string that can be specified to ``use_up_to`` option in ``__call__`` method;
+
+    * ``'classifier'`` (default): The output of the final affine layer for classification.
+    * ``'pool'``: The output of the final global average pooling.
+    * ``'lastconv'``: The input of the final global average pooling without ReLU activation..
+    * ``'lastconv+relu'``: Network up to ``'lastconv'`` followed by ReLU activation.
+
+    References:
+
+        * `Iandra et al., SqueezeNet: AlexNet-level accuracy with 50x fewer parameters and <0.5MB model size.
+          <https://arxiv.org/abs/1602.07360>`_
+        * `DeepScale/SqueezeNet on GitHub <https://github.com/DeepScale/SqueezeNet>`_
+
+    '''
+
+    def __init__(self):
+        self._load_nnp('SqueezeNet-1.1.nnp',
+                       'SqueezeNet-1.1/SqueezeNet-1.1.nnp')
+
+    def _input_shape(self):
+        return (3, 227, 227)
+
+    def __call__(self, input_var=None, use_from=None, use_up_to='classifier', training=False, force_global_pooling=False, check_global_pooling=True, returns_net=False, verbose=0):
+
+        # Use up to
+        set_use_up_to = set(
+            ['classifier', 'pool', 'lastconv', 'lastconv+relu'])
+
+        assert use_up_to in set_use_up_to, "use_up_to must be chosen from {}. Given {}.".format(
+            set_use_up_to, use_up_to)
+
+        fix_parameters = not training
+        bn_batch_stat = training
+        default_shape = (1,) + self.input_shape
+        if input_var is None:
+            input_var = nn.Variable(default_shape)
+        assert input_var.ndim == 4, "input_var must be 4 dimensions. Given {}.".format(
+            input_var.ndim)
+        assert input_var.shape[1] == 3, "input_var.shape[1] must be 3 (RGB). Given {}.".format(
+            input_var.shape[1])
+
+        callback = NnpNetworkPass(verbose)
+
+        callback.remove_and_rewire('ImageAugmentationX')
+        callback.set_variable('ImageAugmentationX', input_var)
+        if not training:
+            callback.remove_and_rewire('SqueezeNet/Dropout')
+        if force_global_pooling:
+            callback.force_average_pooling_global('SqueezeNet/AveragePooling')
+        elif check_global_pooling:
+            callback.check_average_pooling_global('SqueezeNet/AveragePooling')
+        callback.set_batch_normalization_batch_stat_all(bn_batch_stat)
+
+        if use_up_to == 'classifier':
+            callback.use_up_to('SqueezeNet/Reshape')
+        elif use_up_to == 'pool':
+            callback.use_up_to('SqueezeNet/AveragePooling')
+        elif use_up_to == 'lastconv':
+            callback.use_up_to('SqueezeNet/Convolution_2')
+        elif use_up_to == 'lastconv+relu':
+            callback.use_up_to('SqueezeNet/ReLU_2')
+        else:
+            raise NotImplementedError()
+
+        if fix_parameters:
+            callback.fix_parameters()
+        batch_size = input_var.shape[0]
+        net = self.nnp.get_network(
+            'Training', batch_size=batch_size, callback=callback)
+        if returns_net:
+            return net
+        return list(net.outputs.values())[0]

--- a/python/src/nnabla/models/utils.py
+++ b/python/src/nnabla/models/utils.py
@@ -17,6 +17,8 @@ import os
 from nnabla import logger
 from nnabla.utils.download import download, get_data_home
 
+from ..utils import *
+
 
 def get_model_home():
     '''

--- a/python/src/nnabla/models/utils.py
+++ b/python/src/nnabla/models/utils.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import
+import os
+
+from nnabla import logger
+from nnabla.utils.download import download, get_data_home
+
+
+def get_model_home():
+    '''
+    Returns a root folder path for downloading models.
+    '''
+    d = os.path.join(get_data_home(), 'nnp_models')
+    if not os.path.isdir(d):
+        os.makedirs(d)
+    return d
+
+
+def get_model_url_base_from_env():
+    '''
+    Returns a value of environment variable ``NNABLA_MODELS_URL_BASE`` if set,
+    otherwise returns ``None``.
+    '''
+    return os.environ.get('NNABLA_MODELS_URL_BASE', None)
+
+
+def get_model_url_base():
+    '''
+    Returns a root folder for models.
+    '''
+    url_base = get_model_url_base_from_env()
+    if url_base is not None:
+        logger.info('NNBLA_MODELS_URL_BASE is set as {}.'.format(url_base))
+    else:
+        url_base = 'https://nnabla.org/pretrained-models/nnp_models/'
+    return url_base

--- a/python/src/nnabla/parameter.py
+++ b/python/src/nnabla/parameter.py
@@ -35,11 +35,27 @@ current_scope = OrderedDict()
 root_scope = current_scope
 
 
+def get_current_parameter_scope():
+    '''Returns current parameter scope.
+    '''
+    global current_scope
+    return current_scope
+
+
 @contextmanager
-def parameter_scope(name):
+def parameter_scope(name, scope=None):
     """
     Grouping parameters registered by parametric functions
     listed in :mod:`nnabla.parametric_functions`.
+
+    Args:
+
+        name (str): Parameter scope name.
+
+        scope (OrderedDict, optional):
+            Specifiy current parameter scope as a local dictionary.
+            The default value is ``None``. In this case,
+            the current parameter scope maintained in global is used.
 
     Example:
 
@@ -95,18 +111,25 @@ def parameter_scope(name):
         raise ValueError(
             'Invalid argument of parameter_scope("{}").'.format(name))
     prev_scope = current_scope
-    scope = current_scope
+    if scope is None:
+        scope = current_scope
+    else:
+        if not isinstance(scope, dict):
+            raise ValueError(
+                'Scope must be a dictionary. {} is given.'.format(type(scope)))
     for name in names:
         parent_scope = scope
-        # Creates a new scope dict if it doesn't exist.
-        # `dict.get` returns default value (OrderedDict())
-        # if scope contains `name`
-        scope = scope.get(name, OrderedDict())
-        assert isinstance(scope, dict)
-        parent_scope[name] = scope
+        # When name is empty, the given scope is used as a current scope.
+        if name:
+            # Creates a new scope dict if it doesn't exist.
+            # `dict.get` returns default value (OrderedDict())
+            # if scope contains `name`
+            scope = scope.get(name, OrderedDict())
+            assert isinstance(scope, dict)
+            parent_scope[name] = scope
     current_scope = scope
     try:
-        yield
+        yield current_scope
     finally:
         current_scope = prev_scope
 

--- a/python/src/nnabla/utils/cli/cli.py
+++ b/python/src/nnabla/utils/cli/cli.py
@@ -97,6 +97,9 @@ def cli_main():
     add_plot_series_command(subparsers)
     add_plot_timer_command(subparsers)
 
+    from nnabla.utils.cli.draw_graph import add_draw_graph_command
+    add_draw_graph_command(subparsers)
+
     # Version
     subparser = subparsers.add_parser(
         'version', help='Print version and build number.')

--- a/python/src/nnabla/utils/cli/draw_graph.py
+++ b/python/src/nnabla/utils/cli/draw_graph.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def draw_graph_command(args):
+    import os
+    from nnabla.logger import logger
+    from nnabla.utils import nnp_graph
+    import nnabla.functions as F
+    from nnabla.experimental.viewers import SimpleGraph
+
+    logger.info('Loading: %s' % args.input)
+    nnp = nnp_graph.NnpLoader(args.input)
+    names = nnp.get_network_names()
+    logger.info('Available networks: %s' % repr(names))
+
+    if not args.network:
+        logger.info('Drawing all networks as `--network` option is not passed.')
+        draw_networks = names
+    else:
+        draw_networks = []
+        for n in args.network:
+            assert n in names, "Specified a network `%s` that doesn't exist." % n
+            draw_networks.append(n)
+
+    if not os.path.isdir(args.output_dir):
+        os.makedirs(args.output_dir)
+
+    logger.info("Save drawn network(s) into `%s`." % args.output_dir)
+
+    for n in draw_networks:
+        logger.info("Drawing: %s" % n)
+        graph = nnp.get_network(n)
+        if not graph.outputs:
+            logger.info("No output in `%s`. Skipping." % n)
+            continue
+        elif len(graph.outputs) > 1:
+            out = F.sink(*graph.outputs.values())
+        else:
+            out = list(graph.outputs.values())[0]
+
+        sg = SimpleGraph(format=args.format)
+        sg.save(out, os.path.join(args.output_dir,
+                                  n.replace(' ', '_')), cleanup=True)
+
+    return True
+
+
+def add_draw_graph_command(subparsers):
+    desc = '''Draw a graph in a NNP or nntxt file with graphviz.
+
+Example:
+
+    nnabla_cli draw_graph -o output-folder path-to-nnp.nnp'''
+
+    from argparse import RawTextHelpFormatter
+    # Train
+    subparser = subparsers.add_parser(
+        'draw_graph',
+        formatter_class=RawTextHelpFormatter,
+        description=desc,
+        help='Draw a graph in a NNP or nntxt file with graphviz.')
+    subparser.add_argument('input', type=str,
+                           help='Path to input nnp or nntxt.')
+    subparser.add_argument(
+        '-o', '--output-dir', type=str, default='draw_out', help='Output directory.')
+    subparser.add_argument('-n', '--network', action='append',
+                           help='Network names to be drawn.')
+    subparser.add_argument('-f', '--format', default='png',
+                           help='Graph saving format compatible with graphviz (`pdf`, `png`, ...).')
+    subparser.set_defaults(func=draw_graph_command)
+    return subparser

--- a/python/src/nnabla/utils/cli/plot.py
+++ b/python/src/nnabla/utils/cli/plot.py
@@ -18,6 +18,7 @@ import copy
 def plot_series_command(args):
     import nnabla.monitor as M
     plot_any_command(args, M.plot_series)
+    return True
 
 
 def plot_timer_command(args):
@@ -38,6 +39,7 @@ def plot_timer_command(args):
                 format_unit[args.time_unit])
     plot_any_command(args, M.plot_time_elapsed, dict(
         elapsed=args.elapsed, unit=args.time_unit))
+    return True
 
 
 def plot_any_command(args, plot_func, plot_func_kwargs=None):

--- a/python/src/nnabla/utils/converter/onnx/exporter.py
+++ b/python/src/nnabla/utils/converter/onnx/exporter.py
@@ -257,11 +257,14 @@ class OnnxExporter:
         try:
             opset = int(opset)
             if opset <= 6:
-                self.nnabla_function_type_to_onnx_optype = opver_impl_map.get("6")
+                self.nnabla_function_type_to_onnx_optype = opver_impl_map.get(
+                    "6")
             else:
-                self.nnabla_function_type_to_onnx_optype = opver_impl_map.get(str(opset), table_op_set_9_x)
+                self.nnabla_function_type_to_onnx_optype = opver_impl_map.get(
+                    str(opset), table_op_set_9_x)
         except:
-            self.nnabla_function_type_to_onnx_optype = opver_impl_map.get(opset, table_op_set_9_x)
+            self.nnabla_function_type_to_onnx_optype = opver_impl_map.get(
+                opset, table_op_set_9_x)
 
     def _add_param(self, param_name, dtype, shape, raw_data):
         init = self._model_proto.graph.initializer.add()
@@ -519,7 +522,8 @@ class OnnxExporter:
         return [n]
 
     def Unpooling_9(self, func):
-        scales = list(map(lambda f: float(f), [1.0, 1.0] + func.unpooling_param.kernel.dim[:]))
+        scales = list(
+            map(lambda f: float(f), [1.0, 1.0] + func.unpooling_param.kernel.dim[:]))
         n = onnx.helper.make_node(
             'Upsample',
             func.input,
@@ -547,7 +551,6 @@ class OnnxExporter:
             name=func.name
         )
         return [n]
-
 
     def Unpooling_6(self, func):
         if len(func.unpooling_param.kernel.dim) != 2:
@@ -848,7 +851,6 @@ class OnnxExporter:
 
         return nl
 
-
     def Stack(self, func):
         nl = []
         outputs = []
@@ -944,7 +946,8 @@ class OnnxExporter:
                 d = list(np.transpose(w_data).astype(np.float32).flatten())
                 del param.data[:]
                 param.data.extend(d)
-                self._parameters_state[func.input[1]] = state | ParameterState.TRANSPOSED
+                self._parameters_state[func.input[1]
+                                       ] = state | ParameterState.TRANSPOSED
             transB = 1
         else:
             w_shape = list(self._var_dict[func.input[1]].dim[:])

--- a/python/src/nnabla/utils/data_source_loader.py
+++ b/python/src/nnabla/utils/data_source_loader.py
@@ -17,12 +17,13 @@ Contents loader functions for DataSource.
 
 '''
 
+from __future__ import absolute_import
+
 from six.moves import map
 from shutil import rmtree
 from six import BytesIO
 from six import StringIO
 from six.moves.urllib.parse import urljoin
-from tqdm import tqdm
 import contextlib
 import csv
 
@@ -39,6 +40,9 @@ import tempfile
 
 from nnabla.utils.image_utils import imresize, imread
 from nnabla.logger import logger
+
+# Expose for backward compatibility
+from .download import download, get_data_home
 
 pypng_available = False
 try:
@@ -385,63 +389,3 @@ def _download_hook(t):
         t.update((b - last_b[0]) * bsize)
         last_b[0] = b
     return inner
-
-
-def get_data_home():
-    import os
-    d = os.path.expanduser('~/nnabla_data')
-    if d == '/nnabla_data':
-        d = './nnabla_data'
-    try:
-        os.makedirs(d)
-    except OSError:
-        pass  # python2 does not support exists_ok arg
-    return d
-
-
-def download(url, output_file=None, open_file=True, allow_overwrite=False):
-    '''Download a file from URL.
-
-    Args:
-        url (str): URL.
-        output_file (str, optional): If given, the downloaded file is written to the given path.
-        open_file (bool): If True, it returns an opened file stream of the downloaded file.
-        allow_overwrite (bool): If True, it overwrites an existing file.
-
-    Returns:
-        Returns file object if open_file is True, otherwise None.
-
-    '''
-    filename = url.split('/')[-1]
-    if output_file is None:
-        cache = os.path.join(get_data_home(), filename)
-    else:
-        cache = output_file
-    if os.path.exists(cache) and not allow_overwrite:
-        logger.info("> {} already exists.".format(cache))
-        logger.info("> If you have any issue when using this file, ")
-        logger.info("> manually remove the file and try download again.")
-    else:
-        r = request.urlopen(url)
-        try:
-            if six.PY2:
-                content_length = int(r.info().dict['content-length'])
-            elif six.PY3:
-                content_length = int(r.info()['Content-Length'])
-        except:
-            content_length = 0
-        unit = 1000000
-        content = b''
-        with tqdm(total=content_length, desc=filename) as t:
-            while True:
-                data = r.read(unit)
-                l = len(data)
-                t.update(l)
-                if l == 0:
-                    break
-                content += data
-        with open(cache, 'wb') as f:
-            f.write(content)
-    if not open_file:
-        return
-    return open(cache, 'rb')

--- a/python/src/nnabla/utils/download.py
+++ b/python/src/nnabla/utils/download.py
@@ -65,7 +65,7 @@ def download(url, output_file=None, open_file=True, allow_overwrite=False):
             content_length = 0
         unit = 1000000
         content = b''
-        with tqdm(total=content_length, desc=filename) as t:
+        with tqdm(total=content_length, desc=filename, unit='B', unit_scale=True, unit_divisor=1024) as t:
             while True:
                 data = r.read(unit)
                 l = len(data)

--- a/python/src/nnabla/utils/download.py
+++ b/python/src/nnabla/utils/download.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from nnabla.logger import logger
+
+import six.moves.urllib.request as request
+import six
+from tqdm import tqdm
+import os
+
+
+def get_data_home():
+    d = os.path.expanduser('~/nnabla_data')
+    if d == '/nnabla_data':
+        d = './nnabla_data'
+    try:
+        os.makedirs(d)
+    except OSError:
+        pass  # python2 does not support exists_ok arg
+    return d
+
+
+def download(url, output_file=None, open_file=True, allow_overwrite=False):
+    '''Download a file from URL.
+
+    Args:
+        url (str): URL.
+        output_file (str, optional): If given, the downloaded file is written to the given path.
+        open_file (bool): If True, it returns an opened file stream of the downloaded file.
+        allow_overwrite (bool): If True, it overwrites an existing file.
+
+    Returns:
+        Returns file object if open_file is True, otherwise None.
+
+    '''
+    filename = url.split('/')[-1]
+    if output_file is None:
+        cache = os.path.join(get_data_home(), filename)
+    else:
+        cache = output_file
+    if os.path.exists(cache) and not allow_overwrite:
+        logger.info("> {} already exists.".format(cache))
+        logger.info("> If you have any issue when using this file, ")
+        logger.info("> manually remove the file and try download again.")
+    else:
+        r = request.urlopen(url)
+        try:
+            if six.PY2:
+                content_length = int(r.info().dict['content-length'])
+            elif six.PY3:
+                content_length = int(r.info()['Content-Length'])
+        except:
+            content_length = 0
+        unit = 1000000
+        content = b''
+        with tqdm(total=content_length, desc=filename) as t:
+            while True:
+                data = r.read(unit)
+                l = len(data)
+                t.update(l)
+                if l == 0:
+                    break
+                content += data
+        with open(cache, 'wb') as f:
+            f.write(content)
+    if not open_file:
+        return
+    return open(cache, 'rb')

--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -225,11 +225,13 @@ class NnpNetwork(object):
                             list(nn.get_parameters(grad_only=False).keys()))))
             assert shape == param.shape
             v.variable = param
+            param.name = name
             return param
 
         # Create a new one and returns.
         var = nn.Variable(shape)
         v.variable = var
+        var.name = name
         return var
 
     def _create_inputs(self, inputs):
@@ -250,6 +252,8 @@ class NnpNetwork(object):
 
         for o, ovar in zip(f.outputs, outputs):
             o.variable = ovar
+            ovar.name = o.proto.name
+
     def __init__(self, network_proto, batch_size=None, rng=None, callbacks=None):
 
         if batch_size is None:

--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -250,14 +250,20 @@ class NnpNetwork(object):
             f.inputs = inputs
             f.outputs = outputs
 
-        # get outputs
-        inputs = [v for v in variables.values() if v.parent is None]
+        # Filter isolated variables
+        variables = {k: v for k, v in variables.items(
+        ) if v.parent is not None or v.num_referrers > 0}
+
+        # Get outputs
         outputs = [v for v in variables.values() if v.num_referrers == 0]
 
+        # Build computation graph
         visit_forward(outputs, self._create_function)
 
         # Get input variables
         self.variables = {v.proto.name: v.variable for v in variables.values()}
+        inputs = [v for v in variables.values(
+        ) if v.parent is None and v.proto.type != "Parameter"]
         self.inputs = {i.proto.name: i.variable for i in inputs}
         self.outputs = {o.proto.name: o.variable for o in outputs}
 

--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -105,7 +105,7 @@ def _create_function(inputs, f, batch_size):
     return function_instance
 
 
-class VariableProto:
+class VariableProto(object):
 
     def __init__(self, v):
         self.proto = v
@@ -155,7 +155,7 @@ class VariableProto:
         self.parent.outputs = new_outputs
 
 
-class FunctionProto:
+class FunctionProto(object):
     def __init__(self, proto):
         self.proto = proto
         self._inputs = []

--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -243,7 +243,8 @@ class NnpNetwork(object):
 
         function_instance = _create_function(inputs, f.proto, self.batch_size)
 
-        outputs = function_instance(*inputs)
+        outputs = function_instance(
+            *inputs, n_outputs=len(f.outputs), auto_forward=False)
         if not isinstance(outputs, tuple):
             outputs = (outputs,)
 

--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import print_function
+
+from collections import OrderedDict
 import os
 import weakref
 import numpy as np
@@ -19,7 +22,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.function as F
 from nnabla.utils import nnabla_pb2
-from nnabla.parameter import get_parameter
+from nnabla.parameter import get_parameter, set_parameter
 from nnabla.utils.load_function import _create_function_instance
 from nnabla.utils.load import (
     _create_variable,
@@ -107,22 +110,49 @@ class VariableProto:
     def __init__(self, v):
         self.proto = v
         self.parent = None
-        self._referrers = []
+        self._referrers = {}
         self.variable = None
+        self.need_grad = None
+        self.stop = False
+
+    @property
+    def name(self):
+        return self.proto.name
 
     def add_referrer(self, f):
         assert isinstance(f, FunctionProto)
-        self._referrers.append(weakref.ref(f))
+        self._referrers[f.name] = weakref.ref(f)
 
     @property
     def referrers(self):
-        referrers = [r() for r in self.referrers]
-        assert all([r is not None for r in referrers])
+        referrers = {k: r()
+                     for k, r in self._referrers.items() if r() is not None}
         return referrers
 
     @property
     def num_referrers(self):
         return len(self._referrers)
+
+    def delete_referrer(self, f):
+        del self._referrers[f.name]
+
+    def rewire_on(self, var):
+        parent = var.parent
+        if self.parent is not None:
+            self.parent.disable()
+        self.parent = parent
+        var.parent = None
+
+        # Replace var with self for var.parent.outputs
+        if parent is None:
+            return
+        new_outputs = []
+        for o in parent.outputs:
+            new = o
+            if o is var:
+                new = self
+            new_outputs.append(new)
+        self.parent.outputs = new_outputs
 
 
 class FunctionProto:
@@ -131,6 +161,11 @@ class FunctionProto:
         self._inputs = []
         self._outputs = []
         self.function = None
+        self._disabled = False
+
+    @property
+    def name(self):
+        return self.proto.name
 
     @property
     def inputs(self):
@@ -157,19 +192,42 @@ class FunctionProto:
         for o in outputs:
             o.parent = self
 
+    def disable(self):
+        self._disabled = True
+        for i in self.inputs:
+            i.delete_referrer(self)  # Forget me.
+        for o in self.outputs:
+            o.parent = None  # Forget me.
+        self._inputs = []
+        self._outputs = []
+
+    @property
+    def disabled(self):
+        return self._disabled
+
 
 def visit_forward(variables, callback, fclosed=None):
     if fclosed is None:
         fclosed = set()
+    stop = False
     for v in variables:
+        stop |= v.stop
         f = v.parent
         if f is None:
             continue
         if f in fclosed:
             continue
         fclosed.add(f)
-        visit_forward(f.inputs, callback, fclosed)
+        stop_f = visit_forward(f.inputs, callback, fclosed)
+        # Send stop signal to child function if any of predecessors of
+        # `variables` has the stop attribute.
+        stop |= stop_f
+        if stop_f:
+            # callback.verbose('Skip {} by stop signal.'.format(f.name))
+            f.disable()
+            continue
         callback(f)
+    return stop
 
 
 class NnpNetwork(object):
@@ -190,7 +248,12 @@ class NnpNetwork(object):
 
     '''
 
-    def _get_variable_or_create(self, v):
+    def _get_variable_or_create(self, v, callback, current_scope):
+
+        if v.variable is not None:
+            return v.variable
+
+        v = callback._apply_generate_variable(v)
 
         if v.variable is not None:
             return v.variable
@@ -213,6 +276,10 @@ class NnpNetwork(object):
                         name))
                     tmp = _create_variable(pvar, name, shape, self.rng)
                     param = tmp.variable_instance
+                    set_parameter(name, param)
+                # Always copy param to current scope even if it already exists.
+                with nn.parameter_scope('', current_scope):
+                    set_parameter(name, param)
             except:
                 import sys
                 import traceback
@@ -224,6 +291,7 @@ class NnpNetwork(object):
                         '\n'.join(
                             list(nn.get_parameters(grad_only=False).keys()))))
             assert shape == param.shape
+            param = param.get_unlinked_variable(need_grad=v.need_grad)
             v.variable = param
             param.name = name
             return param
@@ -234,15 +302,20 @@ class NnpNetwork(object):
         var.name = name
         return var
 
-    def _create_inputs(self, inputs):
+    def _create_inputs(self, inputs, callback, current_scope):
         input_vars = []
         for i in inputs:
-            input_vars.append(self._get_variable_or_create(i))
+            input_vars.append(self._get_variable_or_create(
+                i, callback, current_scope))
         return input_vars
 
-    def _create_function(self, f):
-        inputs = self._create_inputs(f.inputs)
+    def _create_function(self, f, callback, current_scope):
+        callback.verbose2('Creating function {}: {} --> {}.'.format(f.name,
+                                                                    [i.name for i in f.inputs], [i.name for i in f.outputs]))
 
+        f = callback._apply_generate_function_by_type(f)
+        f = callback._apply_generate_function_by_name(f)
+        inputs = self._create_inputs(f.inputs, callback, current_scope)
         function_instance = _create_function(inputs, f.proto, self.batch_size)
 
         outputs = function_instance(
@@ -252,9 +325,36 @@ class NnpNetwork(object):
 
         for o, ovar in zip(f.outputs, outputs):
             o.variable = ovar
-            ovar.name = o.proto.name
+            ovar.name = o.name
 
-    def __init__(self, network_proto, batch_size=None, rng=None, callbacks=None):
+    def _filter_variables(self, variables):
+        # Filter isolated variables
+        variables = {k: v for k, v in variables.items(
+        ) if v.parent is not None or v.num_referrers > 0}
+        return variables
+
+    def _get_inputs(self, variables):
+        inputs = [v for v in variables.values(
+        ) if v.parent is None and v.proto.type != "Parameter"]
+        return inputs
+
+    def _get_outputs(self, variables):
+        # Get outputs
+        outputs = [v for v in variables.values() if v.num_referrers == 0]
+        return outputs
+
+    def _functions_in_forward_order(self, variables):
+        variables = self._filter_variables(variables)
+        outputs = self._get_outputs(variables)
+        function_order = []
+
+        def _function_order(f):
+            function_order.append(f)
+        visit_forward(outputs, _function_order)
+        for f in function_order:
+            yield f
+
+    def __init__(self, network_proto, scope, batch_size=None, rng=None, callback=None):
 
         if batch_size is None:
             batch_size = network_proto.batch_size
@@ -262,6 +362,9 @@ class NnpNetwork(object):
         if rng is None:
             rng = np.random.RandomState(1223)
         self.rng = rng
+
+        if callback is None:
+            callback = NnpNetworkPass()  # No pass
 
         # Variable proto messages as a dictionary with name as a key
         variables = {v.name: VariableProto(v) for v in network_proto.variable}
@@ -273,22 +376,35 @@ class NnpNetwork(object):
             f.inputs = inputs
             f.outputs = outputs
 
-        # Filter isolated variables
-        variables = {k: v for k, v in variables.items(
-        ) if v.parent is not None or v.num_referrers > 0}
+        # Apply function passes
+        for f in self._functions_in_forward_order(variables):
+            if f.disabled:
+                continue
+            callback._apply_function_pass_by_type(f, variables)
+            callback._apply_function_pass_by_name(f, variables)
 
-        # Get outputs
-        outputs = [v for v in variables.values() if v.num_referrers == 0]
+        # Apply stop-at.
+        for f in self._functions_in_forward_order(variables):
+            # callback.verbose2('Applying stop-at for inputs of {}.'.format(f.name))
+            callback._apply_use_up_to(f.inputs)
 
         # Build computation graph
-        visit_forward(outputs, self._create_function)
+        num_ops = 0
+        current_scope = nn.get_current_parameter_scope()
+        with nn.parameter_scope('', scope):
+            for f in self._functions_in_forward_order(variables):
+                self._create_function(f, callback, current_scope)
+                num_ops += 1
+        callback.verbose2('Created {} functions.'.format(num_ops))
+
+        variables = self._filter_variables(variables)
+        inputs = self._get_inputs(variables)
+        outputs = self._get_outputs(variables)
 
         # Get input variables
-        self.variables = {v.proto.name: v.variable for v in variables.values()}
-        inputs = [v for v in variables.values(
-        ) if v.parent is None and v.proto.type != "Parameter"]
-        self.inputs = {i.proto.name: i.variable for i in inputs}
-        self.outputs = {o.proto.name: o.variable for o in outputs}
+        self.variables = {v.name: v.variable for v in variables.values()}
+        self.inputs = {i.name: i.variable for i in inputs}
+        self.outputs = {o.name: o.variable for o in outputs}
 
 
 class NnpLoader(object):
@@ -315,11 +431,21 @@ class NnpLoader(object):
 
     '''
 
-    def __init__(self, filepath):
+    def __init__(self, filepath, scope=None):
+        # OrderedDict maintains loaded parameters from nnp files.
+        # The loaded parameters will be copied to the current
+        # scope when get_network is called.
+        if scope is None:
+            scope = OrderedDict()
+        self._params = scope
+
         _, ext = os.path.splitext(filepath)
 
         if ext == ".nnp":
-            proto = _load_nnp_to_proto(filepath)
+            # Load parameters to self._params rather than
+            # loading to global current scope.
+            with nn.parameter_scope('', self._params):
+                proto = _load_nnp_to_proto(filepath)
         elif ext in ('.nntxt', '.prototxt'):
             proto = _load_nntxt_to_proto(filepath)
         else:
@@ -334,10 +460,176 @@ class NnpLoader(object):
         '''
         return list(self.network_dict.keys())
 
-    def get_network(self, name, batch_size=None, callbacks=None):
+    def get_network(self, name, batch_size=None, callback=None):
         '''Create a variable graph given  network by name
 
         Returns: NnpNetwork
 
         '''
-        return NnpNetwork(self.network_dict[name], batch_size, callbacks)
+        network_proto = nnabla_pb2.Network()
+        network_proto.CopyFrom(self.network_dict[name])
+        return NnpNetwork(network_proto, self._params, batch_size, callback=callback)
+
+
+class NnpNetworkPass(object):
+
+    def _no_verbose(self, *a, **kw):
+        pass
+
+    def _verbose(self, *a, **kw):
+        print(*a, **kw)
+
+    def __init__(self, verbose=0):
+        self._variable_callbacks = {}
+        self._function_callbacks_by_name = {}
+        self._function_callbacks_by_type = {}
+        self._passes_by_name = {}
+        self._passes_by_type = {}
+        self._fix_parameters = False
+        self._use_up_to_variables = set()
+
+        self.verbose = self._no_verbose
+        self.verbose2 = self._no_verbose
+        if verbose:
+            self.verbose = self._verbose
+        if verbose > 1:
+            self.verbose2 = self._verbose
+
+    def on_function_pass_by_name(self, name):
+        def _on_function_pass_by_name(callback):
+            def _callback(f, variables):
+                return callback(f, variables)
+            self._passes_by_name[name] = _callback
+            return _callback
+        return _on_function_pass_by_name
+
+    def on_function_pass_by_type(self, name):
+        def _on_function_pass_by_type(callback):
+            def _callback(f, variables):
+                return callback(f, variables)
+            self._passes_by_name[name] = _callback
+            return _callback
+        return _on_function_pass_by_type
+
+    def on_generate_variable(self, name):
+        def _on_generate_variable(callback):
+            def _callback(v):
+                return callback(v)
+            self._variable_callbacks[name] = _callback
+            return _callback
+        return _on_generate_variable
+
+    def on_generate_function_by_name(self, name):
+        def _on_generate_function_by_name(callback):
+            def _callback(v):
+                return callback(v)
+            self._function_callbacks_by_name[name] = _callback
+            return _callback
+        return _on_generate_function_by_name
+
+    def on_generate_function_by_type(self, name):
+        def _on_generate_function_by_type(callback):
+            def _callback(v):
+                return callback(v)
+            self._function_callbacks_by_type[name] = _callback
+            return _callback
+        return _on_generate_function_by_type
+
+    def drop_function(self, *names):
+        def callback(f, variables):
+            self.verbose('Pass: Deleting {}.'.format(f.name))
+            f.disable()
+
+        for name in names:
+            self.on_function_pass_by_name(name)(callback)
+
+    def fix_parameters(self):
+        self._fix_parameters = True
+
+    def use_up_to(self, *names):
+        self._use_up_to_variables.update(set(names))
+
+    def remove_and_rewire(self, name, i=0, o=0):
+        @self.on_function_pass_by_name(name)
+        def on_dr(f, variables):
+            fi = f.inputs[i]
+            fo = f.outputs[o]
+            self.verbose('Removing {} and rewire input={} and output={}.'.format(
+                f.name, fi.name, fo.name))
+            fo.rewire_on(fi)
+
+    def set_variable(self, name, input_var):
+        @self.on_generate_variable(name)
+        def on_input_x(v):
+            self.verbose('Replace {} by {}.'.format(name, input_var))
+            v.proto.shape.dim[:] = input_var.shape
+            v.variable = input_var
+            return v
+
+    def force_average_pooling_global(self, name):
+        @self.on_generate_function_by_name(name)
+        def on_avgpool(f):
+            pool_shape = f.inputs[0].variable.shape[2:]
+            self.verbose('Change strides of {} to {}.'.format(
+                f.name, pool_shape))
+            p = f.proto.average_pooling_param
+            p.kernel.dim[:] = pool_shape
+            p.stride.dim[:] = pool_shape
+            return f
+
+    def check_average_pooling_global(self, name):
+        @self.on_generate_function_by_name(name)
+        def on_avgpool_check(f):
+            pool_shape = f.inputs[0].variable.shape[2:]
+            self.verbose('Change strides of {} to {}.'.format(
+                f.name, pool_shape))
+            p = f.proto.average_pooling_param
+            if tuple(p.kernel.dim[:]) != pool_shape:
+                raise ValueError('Stride configuration of average pooling is not for global pooling. Given Image shape: {} Kernel: {} Stride: {}.'.format(
+                    pool_shape, p.kernel.dim[:], p.stride.dim[:]))
+            if tuple(p.stride.dim[:]) != pool_shape:
+                raise ValueError('Stride configuration of average pooling is not for global pooling. Given Image shape: {} Kernel: {} Stride: {}.'.format(
+                    pool_shape, p.kernel.dim[:], p.stride.dim[:]))
+            return f
+
+    def set_batch_normalization_batch_stat_all(self, batch_stat):
+        @self.on_generate_function_by_type('BatchNormalization')
+        def on_bn(f):
+            self.verbose('Setting batch_stat={} at {}.'.format(
+                batch_stat, f.name))
+            p = f.proto.batch_normalization_param
+            p.batch_stat = batch_stat
+            return f
+
+    def _apply_function_pass_by_name(self, f, variables):
+        if f.name not in self._passes_by_name:
+            return f
+        return self._passes_by_name[f.name](f, variables)
+
+    def _apply_function_pass_by_type(self, f, variables):
+        if f.proto.type not in self._passes_by_type:
+            return f
+        return self._passes_by_type[f.proto.type](f, variables)
+
+    def _apply_generate_variable(self, v):
+        if v.name in self._variable_callbacks:
+            v = self._variable_callbacks[v.name](v)
+        if self._fix_parameters:
+            v.need_grad = False
+        return v
+
+    def _apply_generate_function_by_name(self, f):
+        if f.name not in self._function_callbacks_by_name:
+            return f
+        return self._function_callbacks_by_name[f.name](f)
+
+    def _apply_generate_function_by_type(self, f):
+        if f.proto.type not in self._function_callbacks_by_type:
+            return f
+        return self._function_callbacks_by_type[f.proto.type](f)
+
+    def _apply_use_up_to(self, variables):
+        for v in variables:
+            if v.name in self._use_up_to_variables:
+                self.verbose('Stopping at {}.'.format(v.name))
+                v.stop = True

--- a/python/test/experimental/test_viewers.py
+++ b/python/test/experimental/test_viewers.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+
+
+def test_simple_graph(tmpdir):
+    try:
+        from graphviz import Digraph
+    except:
+        pytest.skip('Skip because graphviz is not installed.')
+    from nnabla.experimental.viewers import SimpleGraph
+    sg = SimpleGraph()
+
+    nn.clear_parameters()
+    x = nn.Variable((2, 3, 4, 4))
+    with nn.parameter_scope('c1'):
+        h = PF.convolution(x, 8, (3, 3), pad=(1, 1))
+        h = F.relu(PF.batch_normalization(h))
+    with nn.parameter_scope('f1'):
+        y = PF.affine(h, 10)
+    g = sg.create_graphviz_digraph(y)
+    assert isinstance(g, Digraph)
+    tmpdir.ensure(dir=True)
+    # fpath = tmpdir.join('graph').strpath
+    fpath = 'tmp-draw'
+    sg.save(y, fpath, format='png')

--- a/python/test/models/test_imagenet.py
+++ b/python/test/models/test_imagenet.py
@@ -83,6 +83,8 @@ def test_nnabla_models_resnet(num_layers, image_size, batch_size, training, seed
     reason='models are tested only when NNBLA_MODELS_URL_BASE is specified as an envvar')
 @pytest.mark.parametrize('model_class, up_to_list', [
     ('MobileNetV2', ['classifier', 'pool', 'lastconv', 'lastconv+relu']),
+    ('SENet', ['classifier', 'pool', 'lastconv', 'lastconv+relu']),
+    ('SqueezeNet', ['classifier', 'pool', 'lastconv', 'lastconv+relu']),
     ])
 @pytest.mark.parametrize('image_size_factor', [1, 2])
 @pytest.mark.parametrize('batch_size', [1, 5])
@@ -116,10 +118,12 @@ def test_nnabla_models_imagenet_etc(model_class, up_to_list, image_size_factor, 
                       check_global_pooling=check_global_pooling)
             y.forward()
 
-        if image_size_factor != 1 and use_up_to in ('classifier', 'pool'):
+        # Need special care for SENet because it contains global average
+        # pooling in various points in a network.
+        if image_size_factor != 1 and (model_class == 'SENet' or use_up_to in ('classifier', 'pool')):
             with pytest.raises(ValueError):
                 _execute()
-            if use_up_to == 'pool':
+            if use_up_to == 'pool' and model_class != 'SENet':
                 check_global_pooling = False
                 _execute()
             force_global_pooling = True

--- a/python/test/models/test_imagenet.py
+++ b/python/test/models/test_imagenet.py
@@ -22,27 +22,39 @@ import numpy as np
 from nnabla.models.utils import get_model_url_base_from_env
 
 
+def _check_trainable_parameters(y):
+
+    def _check_trainable_inputs(f):
+        for i in f.inputs:
+            if i.need_grad:
+                return True
+        return False
+
+    return y.visit_check(_check_trainable_inputs)
+
+
 @pytest.mark.skipif(
     get_model_url_base_from_env() is None,
     reason='models are tested only when NNBLA_MODELS_URL_BASE is specified as an envvar')
 @pytest.mark.parametrize('num_layers', [18, 34, 50, 101, 152])
 @pytest.mark.parametrize('image_size', [224, 448])
 @pytest.mark.parametrize('batch_size', [1, 5])
+@pytest.mark.parametrize('training', [False, True])
 @pytest.mark.parametrize('seed', [1223])
-def test_nnabla_models_resnet(num_layers, image_size, batch_size, seed):
+def test_nnabla_models_resnet(num_layers, image_size, batch_size, training, seed):
     from nnabla.models.imagenet import ResNet
     nn.clear_parameters()
     rng = np.random.RandomState(seed)
     model = ResNet(num_layers)
     x = nn.Variable.from_numpy_array(rng.randint(
         0, 256, size=(batch_size, 3, image_size, image_size)))
-    for use_up_to in ('classifier', 'pool', 'block4', 'block4+relu'):
+    for use_up_to in ('classifier', 'pool', 'lastconv', 'lastconv+relu'):
         check_global_pooling = True
         force_global_pooling = False
         returns_net = False
 
         def _execute():
-            y = model(x, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
+            y = model(x, training=training, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
                       check_global_pooling=check_global_pooling)
             y.forward()
 
@@ -54,8 +66,71 @@ def test_nnabla_models_resnet(num_layers, image_size, batch_size, seed):
                 _execute()
             force_global_pooling = True
         _execute()
-        net = model(x, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
+        net = model(x, training=training, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
                     check_global_pooling=check_global_pooling, returns_net=True)
         assert isinstance(net, NnpNetwork)
         assert len(net.inputs.values()) == 1
         assert len(net.outputs.values()) == 1
+        y = list(net.outputs.values())[0]
+        if training:
+            assert _check_trainable_parameters(y)
+        else:
+            assert not _check_trainable_parameters(y)
+
+
+@pytest.mark.skipif(
+    get_model_url_base_from_env() is None,
+    reason='models are tested only when NNBLA_MODELS_URL_BASE is specified as an envvar')
+@pytest.mark.parametrize('model_class, up_to_list', [
+    ('MobileNetV2', ['classifier', 'pool', 'lastconv', 'lastconv+relu']),
+    ])
+@pytest.mark.parametrize('image_size_factor', [1, 2])
+@pytest.mark.parametrize('batch_size', [1, 5])
+@pytest.mark.parametrize('training', [False, True])
+@pytest.mark.parametrize('seed', [1223])
+def test_nnabla_models_imagenet_etc(model_class, up_to_list, image_size_factor, batch_size, training, seed):
+    nn.clear_parameters()
+    rng = np.random.RandomState(seed)
+
+    # Load model
+    from nnabla.models import imagenet
+    Model = getattr(imagenet, model_class)
+    model = Model()
+
+    # Determine input shape and create input variable
+    input_shape = list(model.input_shape)
+    input_shape[1] *= image_size_factor
+    input_shape[2] *= image_size_factor
+    input_shape = tuple(input_shape)
+    x = nn.Variable.from_numpy_array(rng.randint(
+        0, 256, size=(batch_size,) + input_shape))
+
+    # Test cases for all intermediate outputs
+    for use_up_to in up_to_list:
+        check_global_pooling = True
+        force_global_pooling = False
+        returns_net = False
+
+        def _execute():
+            y = model(x, training=training, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
+                      check_global_pooling=check_global_pooling)
+            y.forward()
+
+        if image_size_factor != 1 and use_up_to in ('classifier', 'pool'):
+            with pytest.raises(ValueError):
+                _execute()
+            if use_up_to == 'pool':
+                check_global_pooling = False
+                _execute()
+            force_global_pooling = True
+        _execute()
+        net = model(x, training=training, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
+                    check_global_pooling=check_global_pooling, returns_net=True)
+        assert isinstance(net, NnpNetwork)
+        assert len(net.inputs.values()) == 1
+        assert len(net.outputs.values()) == 1
+        y = list(net.outputs.values())[0]
+        if training:
+            assert _check_trainable_parameters(y)
+        else:
+            assert not _check_trainable_parameters(y)

--- a/python/test/models/test_imagenet.py
+++ b/python/test/models/test_imagenet.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from __future__ import absolute_import
+import pytest
+from nnabla.utils.nnp_graph import NnpNetwork
+import nnabla as nn
+import numpy as np
+
+from nnabla.models.utils import get_model_url_base_from_env
+
+
+@pytest.mark.skipif(
+    get_model_url_base_from_env() is None,
+    reason='models are tested only when NNBLA_MODELS_URL_BASE is specified as an envvar')
+@pytest.mark.parametrize('num_layers', [18, 34, 50, 101, 152])
+@pytest.mark.parametrize('image_size', [224, 448])
+@pytest.mark.parametrize('batch_size', [1, 5])
+@pytest.mark.parametrize('seed', [1223])
+def test_nnabla_models_resnet(num_layers, image_size, batch_size, seed):
+    from nnabla.models.imagenet import ResNet
+    nn.clear_parameters()
+    rng = np.random.RandomState(seed)
+    model = ResNet(num_layers)
+    x = nn.Variable.from_numpy_array(rng.randint(
+        0, 256, size=(batch_size, 3, image_size, image_size)))
+    for use_up_to in ('classifier', 'pool', 'block4', 'block4+relu'):
+        check_global_pooling = True
+        force_global_pooling = False
+        returns_net = False
+
+        def _execute():
+            y = model(x, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
+                      check_global_pooling=check_global_pooling)
+            y.forward()
+
+        if image_size == 448 and use_up_to in ('classifier', 'pool'):
+            with pytest.raises(ValueError):
+                _execute()
+            if use_up_to == 'pool':
+                check_global_pooling = False
+                _execute()
+            force_global_pooling = True
+        _execute()
+        net = model(x, use_up_to=use_up_to, force_global_pooling=force_global_pooling,
+                    check_global_pooling=check_global_pooling, returns_net=True)
+        assert isinstance(net, NnpNetwork)
+        assert len(net.inputs.values()) == 1
+        assert len(net.outputs.values()) == 1


### PR DESCRIPTION
This adds `nnabla.models` API which allows users to use SotA pretrained models for both inference and training.

ImageNet pretrained models are added. Lineup so far is as following;

* ResNet-18,34,50,101,152
* MobileNetV2
* SqueezeNet
* SENet-154

We'll add more very soon.
