### PR TITLE
Spectral Normalization

### DIFF
--- a/doc/python/api/parametric_function.rst
+++ b/doc/python/api/parametric_function.rst
@@ -103,6 +103,7 @@ Here is the list of parametric functions.
 
     .. automethod:: __call__(x, w_init, b_init, fix_parameters)
 
+.. autofunction:: spectral_norm
 
 Parameter Initializer
 ---------------------

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -1729,7 +1729,8 @@ def mean_subtraction(inp, base_axis=1, update_running_mean=True, fix_parameters=
 @parametric_function_api("embed", [
     ('W', 'Embedding matrix', '(n_inputs, n_features)', True),
 ])
-def embed(inp, n_inputs, n_features, fix_parameters=False):
+def embed(inp, n_inputs, n_features, initializer=None,
+          fix_parameters=False, apply_w=None):
     """ Embed.
 
     Embed slices a matrix/tensor with indexing array/tensor. Weights are initialized with :obj:`nnabla.initializer.UniformInitializer` within the range of :math:`-\\sqrt{3}` and :math:`\\sqrt{3}`.
@@ -1740,12 +1741,17 @@ def embed(inp, n_inputs, n_features, fix_parameters=False):
         n_features : number of embedding features
         fix_parameters (bool): When set to `True`, the embedding weight matrix
             will not be updated.
+        apply_w (function): Lambda, function, or callable object applied to the weights.
 
     Returns:
         ~nnabla.Variable: Output with shape :math:`(I_0, ..., I_N, W_1, ..., W_M)`
     """
+    if not initializer:
+        initializer = UniformInitializer((-np.sqrt(3.), np.sqrt(3)))
     w = get_parameter_or_create("W", [n_inputs, n_features],
-                                UniformInitializer((-np.sqrt(3.), np.sqrt(3))), True, not fix_parameters)
+                                initializer, True, not fix_parameters)
+    if apply_w is not None:
+        w = apply_w(w)
     return F.embed(inp, w)
 
 

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -132,7 +132,8 @@ def {name}{signature}:
 def affine(inp, n_outmaps,
            base_axis=1,
            w_init=None, b_init=None,
-           fix_parameters=False, rng=None, with_bias=True):
+           fix_parameters=False, rng=None, with_bias=True,
+           apply_w=None, apply_b=None):
     """
     The affine layer, also known as the fully connected layer. Computes
 
@@ -151,6 +152,8 @@ def affine(inp, n_outmaps,
         fix_parameters (bool): When set to `True`, the weights and biases will not be updated.
         rng (numpy.random.RandomState): Random generator for Initializer.
         with_bias (bool): Specify whether to include the bias term.
+        apply_w (function): Lambda, function, or callable object applied to the weights.
+        apply_b (function): Lambda, function, or callable object applied to the bias.
 
     Returns:
         :class:`~nnabla.Variable`: :math:`(B + 1)`-D array. (:math:`M_0 \\times \ldots \\times M_{B-1} \\times L`)f
@@ -169,10 +172,14 @@ def affine(inp, n_outmaps,
     w = get_parameter_or_create(
         "W", [int(np.prod(inp.shape[base_axis:]))] + n_outmaps,
         w_init, True, not fix_parameters)
+    if apply_w is not None:
+        w = apply_w(w)
     b = None
     if with_bias:
         b = get_parameter_or_create(
             "b", n_outmaps, b_init, True, not fix_parameters)
+        if apply_b is not None:
+            b = apply_b(b)
     return F.affine(inp, w, b, base_axis)
 
 
@@ -559,7 +566,8 @@ def inq_affine(inp, n_outmaps, base_axis=1, num_bits=4,
 def convolution(inp, outmaps, kernel,
                 pad=None, stride=None, dilation=None, group=1,
                 w_init=None, b_init=None,
-                base_axis=1, fix_parameters=False, rng=None, with_bias=True):
+                base_axis=1, fix_parameters=False, rng=None, with_bias=True,
+                apply_w=None, apply_b=None):
     """N-D Convolution with a bias term.
 
     For Dilated Convolution (a.k.a. Atrous Convolution), refer to:
@@ -598,6 +606,8 @@ def convolution(inp, outmaps, kernel,
         fix_parameters (bool): When set to `True`, the weights and biases will not be updated.
         rng (numpy.random.RandomState): Random generator for Initializer.
         with_bias (bool): Specify whether to include the bias term.
+        apply_w (function): Lambda, function, or callable object applied to the weights.
+        apply_b (function): Lambda, function, or callable object applied to the bias.
 
     Returns:
         :class:`~nnabla.Variable`: N-D array. See :obj:`~nnabla.functions.convolution` for the output shape.
@@ -611,10 +621,14 @@ def convolution(inp, outmaps, kernel,
     w = get_parameter_or_create(
         "W", (outmaps, inp.shape[base_axis] // group) + tuple(kernel),
         w_init, True, not fix_parameters)
+    if apply_w is not None:
+        w = apply_w(w)
     b = None
     if with_bias:
         b = get_parameter_or_create(
             "b", (outmaps,), b_init, True, not fix_parameters)
+        if apply_b is not None:
+            b = apply_b(b)
     return F.convolution(inp, w, b, base_axis, pad, stride, dilation, group)
 
 
@@ -1226,7 +1240,8 @@ def depthwise_convolution(inp, kernel, pad=None, stride=None, dilation=None,
 def deconvolution(inp, outmaps, kernel,
                   pad=None, stride=None, dilation=None, group=1,
                   w_init=None, b_init=None,
-                  base_axis=1, fix_parameters=False, rng=None, with_bias=True):
+                  base_axis=1, fix_parameters=False, rng=None, with_bias=True,
+                  apply_w=None, apply_b=None):
     """
     Deconvolution layer.
 
@@ -1244,6 +1259,8 @@ def deconvolution(inp, outmaps, kernel,
         fix_parameters (bool): When set to `True`, the weights and biases will not be updated.
         rng (numpy.random.RandomState): Random generator for Initializer.
         with_bias (bool): Specify whether to include the bias term.
+        apply_w (function): Lambda, function, or callable object applied to the weights.
+        apply_b (function): Lambda, function, or callable object applied to the bias.
 
     Returns:
         :class:`~nnabla.Variable`: N-D array. See :obj:`~nnabla.functions.deconvolution` for the output shape.
@@ -1257,10 +1274,14 @@ def deconvolution(inp, outmaps, kernel,
     w = get_parameter_or_create(
         "W", (inp.shape[base_axis], outmaps // group) + tuple(kernel),
         w_init, True, not fix_parameters)
+    if apply_w is not None:
+        w = apply_w(w)
     b = None
     if with_bias:
         b = get_parameter_or_create(
             "b", (outmaps,), b_init, True, not fix_parameters)
+        if apply_b is not None:
+            b = apply_b(b)
     return F.deconvolution(inp, w, b, base_axis, pad, stride, dilation, group)
 
 

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -2604,6 +2604,11 @@ def spectral_norm(w, dim=0, itr=1, eps=1e-12, test=False, u_init=None, fix_param
 
     """
 
+    assert (0 <= dim and dim < len(w.shape)), "`dim` must be `0 <= dim and dim < len(w.shape)`."
+    assert 0 < itr, "`itr` must be greater than 0."
+    assert 0 < eps, "`eps` must be greater than 0."
+
+
     if dim == len(w.shape) - 1:
         w_sn = _spectral_norm_outer_most_dim(w, dim=dim, itr=itr, eps=eps, test=test,
                                              u_init=u_init, fix_parameters=fix_parameters)
@@ -2671,7 +2676,7 @@ def _spectral_norm_outer_most_dim(w, dim, itr=1, eps=1e-12, test=False,
     W_sn = get_parameter_or_create(
         "W_sn", w.shape, ConstantInitializer(0), False, False)
     d0 = np.prod(w.shape[0:-1])  # In
-    d1 = np.prod(w.shape[-1])    # Out
+    d1 = w.shape[-1]             # Out
     w = F.reshape(w, [d0, d1], inplace=False)
     if u_init is None:
         u_init = NormalInitializer()

--- a/python/test/test_parametric_functions.py
+++ b/python/test/test_parametric_functions.py
@@ -284,4 +284,69 @@ def test_pf_batch_normalization_execution(g_rng, inshape, decay_rate, eps, batch
     assert not v.need_grad
 
 
+@pytest.mark.parametrize("w_shape, dim", [((32, 16, 3, 3), 0),  # convolution
+                                          ((16, 1), 1),         # affine
+                                          ((16, 32), 1),        # affine
+                                          ((8, 8, 16), 2),      # affine
+                                          ((8, 4, 16), 1),      # affine
+                                          ])
+@pytest.mark.parametrize("itr", [1, 2, 3])
+@pytest.mark.parametrize("test", [True, False])
+@pytest.mark.parametrize("u_init", [None, True])
+def test_pf_spectral_norm_execution(g_rng, w_shape, dim, itr, test, u_init):
+    nn.clear_parameters()
+
+    # python implementation
+    def spectral_norm_numpy(w, dim=0, itr=1, eps=1e-12, test=False, u_init_d=None):
+        if test:
+            return w
+        w_shape = w.shape
+        if dim != 0:
+            dims_transpose = [dim] + \
+                [i for i in range(len(w_shape)) if i != dim]
+            w = w.transpose(*dims_transpose)
+            w_shape = w.shape
+        d0, d1 = w_shape[0], np.prod(w_shape[1:])  # [Out, In]
+        w = w.reshape((d0, d1))
+        u = u_init_d
+        for i in range(itr):
+            v = np.dot(w.T, u)
+            v = v / np.sqrt(np.sum(v ** 2) + eps)
+            u = np.dot(w, v)
+            u = u / np.sqrt(np.sum(u ** 2) + eps)
+        sigma = np.dot(u.T, np.dot(w, v))
+        w_sn = w / sigma
+        w_sn = w_sn.reshape(w_shape)
+        if dim != 0:
+            dims_transpose = [i for i in range(1, dim + 1)] \
+                             + [0] + [i for i in range(dim + 1, len(w_shape))]
+            w_sn = w_sn.transpose(*dims_transpose)
+        return w_sn
+
+    # Setting
+    w = nn.Variable.from_numpy_array(g_rng.randn(*w_shape))
+    u_init = process_param_init(u_init, [w_shape[dim]], g_rng)
+
+    # Check execution
+    w_sn = PF.spectral_norm(w, dim, itr, test=test, u_init=u_init)
+    u_init_d = nn.get_parameters(grad_only=False)['spectral-norm/u'].d.copy() \
+        if u_init is None else u_init
+    if not test:
+        w_sn.forward()
+        w_sn.backward()
+    else:
+        w_sn = w
+
+    # Check values
+    w_sn_numpy = spectral_norm_numpy(
+        w.d, dim, itr, test=test, u_init_d=u_init_d)
+    assert np.allclose(w_sn_numpy, w_sn.d, atol=1e-2, rtol=1e-5)
+
+    # Check args (cannot since this is the functions composite)
+
+    # Check created parameters
+    assert len(nn.get_parameters(grad_only=False)) == 2
+    w_sn, u = [nn.get_parameters(grad_only=False)['spectral-norm/' + name]
+               for name in ['W_sn', 'u']]
+
 # TODO: Test all parametric functions.


### PR DESCRIPTION
Implementation of the [spectral normalization](https://arxiv.org/abs/1802.05957).

Now, we also added the `apply_w` and `apply_b` argument to the following functions
- convolution / deconvolution, 
- affine, 
- embed, 

which applies a function to a parameter variable.

Spectral normalization is applied to e.g., the convolution like 

```python
import nnabla as nn
import nnabla.parametric_functions as PF

b, c, h, w = 4, 64, 32, 32

# Spectrally normalized convolution
apply_w = lambda w: PF.spectral_norm(w, dim=0)
h = nn.Variable.from_numpy_array(np.random.randn(b, c, h, w))
h = PF.convolution(h, with_bias=False, apply_w=apply_w)
```


