### PR TITLE
Expose data pointer to python layer to some cases (e.g., for DALI)

### DIFF
--- a/include/nbla/nd_array.hpp
+++ b/include/nbla/nd_array.hpp
@@ -121,6 +121,15 @@ public:
    */
   NBLA_API shared_ptr<const Array> get_sp(dtypes dtype, const Context &ctx);
 
+  /** Get array's ptr.
+
+      @param[in] dtype Enum of data type.
+      @param[in] ctx Descriptor of array backend.
+      @param[in] write_only No synchronization happens.
+   */
+  NBLA_API unsigned long data_ptr(dtypes dtype, const Context &ctx,
+                                  bool write_only = false);
+
   /** Get mutable array with specified dtype and backend description.
 
       @param[in] dtype Enum of data type.

--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -85,6 +85,15 @@ public:
    */
   shared_ptr<const Array> get_sp(dtypes dtype, const Context &ctx);
 
+  /** Get array's ptr.
+
+      @param[in] dtype Enum of data type.
+      @param[in] ctx Descriptor of array backend.
+      @param[in] write_only No synchronization happens.
+   */
+  const void *data_ptr(dtypes dtype, const Context &ctx,
+                       bool write_only = false);
+
   /** Get dtype
   */
   inline dtypes dtype() const {

--- a/python/src/nnabla/_nd_array.pxd
+++ b/python/src/nnabla/_nd_array.pxd
@@ -54,6 +54,7 @@ cdef extern from "nbla/nd_array.hpp" namespace "nbla":
         void fill(double v) except+
         const CArray * get(dtypes dtype, const CContext & ctx) nogil except+
         shared_ptr[const CArray] get_sp(dtypes dtype, const CContext & ctx) nogil except+
+        unsigned long data_ptr(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except+
         CArray * cast(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
         ArrayPtr cast_sp(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
 

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -180,6 +180,34 @@ cdef class NdArray:
         """
         return tuple(self.arrp.shape())
 
+
+    def data_ptr(self, dtype, ctx=None):
+        """Get array's pointer.
+
+        The behavior is similar to `cast` method but returns the data pointer based on the `ctx`.
+        If the `ctx` is not specified, the default context obtained by `nn.get_current_context` is used.
+
+        Args: 
+            dtype (:obj:`numpy.dtype`):  Numpy Data type.
+            ctx (:obj:`nnabla.Context`, optional): Context descriptor.
+
+        Returns:
+            int: The data pointer.
+        
+        """
+        if ctx is not None:
+            ctx_ = ctx
+        else:
+            import nnabla as nn
+            ctx_ = nn.get_current_context()
+        cdef int type_num = np.dtype(dtype).num
+        cdef CContext cctx = <CContext ?> ctx_
+        cdef unsigned long ptr
+        with nogil:
+            ptr = <unsigned long> self.arrp.data_ptr(< dtypes > type_num, cctx, False)
+        return ptr
+
+
     @property
     def size(self):
         """Total size of the N-d array.

--- a/src/nbla/nd_array.cpp
+++ b/src/nbla/nd_array.cpp
@@ -85,6 +85,13 @@ const Array *NdArray::get(dtypes dtype, const Context &ctx) {
 shared_ptr<const Array> NdArray::get_sp(dtypes dtype, const Context &ctx) {
   return array_->get_sp(dtype, ctx);
 }
+
+unsigned long NdArray::data_ptr(dtypes dtype, const Context &ctx,
+                                bool write_only) {
+  return (unsigned long)reinterpret_cast<uintptr_t>(
+      array_->data_ptr(dtype, ctx, write_only));
+}
+
 Array *NdArray::cast(dtypes dtype, const Context &ctx, bool write_only) {
   return array_->cast(dtype, ctx, write_only);
 }

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -87,6 +87,12 @@ shared_ptr<const Array> SyncedArray::get_sp(dtypes dtype, const Context &ctx) {
   return std::const_pointer_cast<const Array>(array_[desc.key].first);
 }
 
+const void *SyncedArray::data_ptr(dtypes dtype, const Context &ctx,
+                                  bool write_only) {
+  cast_sp(dtype, ctx, write_only);
+  return array_[head_.key].first->const_pointer();
+}
+
 void SyncedArray::zero() {
   clear_all_array();
   zeroing_ = true;


### PR DESCRIPTION
Now you can access to the data pointer through `nn.NdArray` like

```python
x = F.constant(shape=[2,3])
ptr = x.data.data_ptr(np.float32, ctx)
```