### PR TITLE
fix docstrings for `data_iterator` and `data_source`

### DIFF
--- a/python/src/nnabla/utils/data_iterator.py
+++ b/python/src/nnabla/utils/data_iterator.py
@@ -38,9 +38,9 @@ from nnabla.logger import logger
 
 class DataIterator(object):
     '''DataIterator
-    Collect data from :ref:`data_source_design` and yields bunch of data.
+    Collect data from :ref:`data_source` and yields bunch of data.
 
-    Detailed documentation is available in :ref:`data_iterator_design`.
+    Detailed documentation is available in :ref:`data_iterator`.
 
     Args:
         data_source (:py:class:`DataSource <nnabla.utils.data_source.DataSource>`):

--- a/python/src/nnabla/utils/data_iterator.py
+++ b/python/src/nnabla/utils/data_iterator.py
@@ -38,9 +38,7 @@ from nnabla.logger import logger
 
 class DataIterator(object):
     '''DataIterator
-    Collect data from :ref:`data_source` and yields bunch of data.
-
-    Detailed documentation is available in :ref:`data_iterator`.
+    Collect data from `data_source` and yields bunch of data.
 
     Args:
         data_source (:py:class:`DataSource <nnabla.utils.data_source.DataSource>`):


### PR DESCRIPTION
The documentation/doc strings mention `data_source_design` and `data_iterator_design` which don't exist. I guess the following fix is what was intended instead.