### PR TITLE
Add Fused Batch Normalization

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -97,6 +97,9 @@ TanhShrink:
 Sinc:
   float: [float]
   half: [Half]
+FusedBatchNormalization:
+  float: [float]
+  half: [Half]
 BatchNormalization:
   float: [float]
   half: [Half]      

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -1169,6 +1169,63 @@ Neural Network Activation Functions:
     function_ids:
       Empty: 255
 Normalization:
+  FusedBatchNormalization:
+    snake_name: fused_batch_normalization
+    doc: |2
+
+      Batch normalization fused with add2 (adding a residual input) and activation.
+
+      This is an equivalent operation to the following,
+      but is more computationally efficient:
+
+      .. code-block:: python
+
+        h = nn.BatchNormalization(x, beta, gamma, mean, variance, *opts)
+        y = F.ReLU(h + z)
+    inputs:
+      x:
+        doc: N-D array of input.
+      beta:
+        doc: N-D array of beta which is learned.
+      gamma:
+        doc: N-D array of gamma which is learned.
+      mean:
+        doc: N-D array of running mean (modified during forward execution).
+      variance:
+        doc: N-D array of running variance (modified during forward execution).
+      z:
+        doc: N-D array of a residual input. By specifying None, the activation function
+          will follow immediately after BN operation.
+        optional: true
+    arguments:
+      axes:
+        doc: Axes mean and variance are taken.
+        type: repeated int64
+        default: (1,)
+      decay_rate:
+        doc: Decay rate of running mean and variance.
+        type: float
+        default: '0.9'
+      eps:
+        doc: Tiny value to avoid zero division by std.
+        type: float
+        default: 1e-05
+      batch_stat:
+        doc: Use mini-batch statistics rather than running ones.
+        type: bool
+        default: 'True'
+      nonlinearity:
+        doc: Activation chosen from ('relu').
+        type: string
+        available_values:
+        - relu
+        default: '''relu'''
+    outputs:
+      y:
+        doc: N-D array
+    c_runtime: not support
+    function_ids:
+      iIffBi: 270
   BatchNormalization:
     snake_name: batch_normalization
     doc: |2

--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -1,0 +1,127 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+#include <nbla/function/add2.hpp>
+#include <nbla/function/batch_normalization.hpp>
+#include <nbla/function/relu.hpp>
+
+#include <vector>
+
+namespace nbla {
+
+using std::vector;
+
+NBLA_REGISTER_FUNCTION_HEADER(FusedBatchNormalization, const vector<int> &,
+                              float, float, bool, const string &);
+
+/** Batch normalization fused with add2 (adding a residual input) and
+activation.
+
+This is an equivalent operation to the following (in Python), but is more
+computationally efficient:
+@code{.py}
+h = F.BatchNormalization(x, beta, gamma, mean, variance, *opts)
+y = F.ReLU(h + z)
+@endcode
+
+Inputs:
+- N-D array of input.
+- N-D array of beta which is learned.
+- N-D array of gamma which is learned.
+- N-D array of running mean (modified during forward execution).
+- N-D array of running variance (modified during forward execution).
+- N-D array of N-D array of a residual input (optional). If not passed, the
+  activation function will follow immediately after BN operation.
+
+Outputs (1 or 3):
+- N-D array.
+- (Optional) N-D array of batch mean.
+- (Optional) N-D array of batch variance.
+
+@tparam T Data type for computation.
+
+@param axes Axes mean and variance are taken.
+@param decay_rate Decay rate of running mean and variance.
+@param eps Tiny value to avoid zero division by std.
+@param batch_stat Use mini-batch statistics rather than running ones.
+@param nonlinearity Activation chosen from ("relu").
+
+@sa Ioffe and Szegedy, Batch Normalization: Accelerating Deep Network Training
+by Reducing Internal Covariate Shift. https://arxiv.org/abs/1502.03167
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class FusedBatchNormalization
+    : public BaseFunction<const vector<int> &, float, float, bool,
+                          const string &> {
+protected:
+  vector<int> axes_;
+  float decay_rate_;
+  float eps_;
+  bool batch_stat_;
+  string nonlinearity_;
+
+  // Not ideal, but BN backward relies on forward results internally stored.
+  shared_ptr<Function> bn_;
+
+public:
+  FusedBatchNormalization(const Context &ctx, const vector<int> axes,
+                          float decay_rate, float eps, bool batch_stat,
+                          const string &nonlinearity)
+
+      : BaseFunction<const vector<int> &, float, float, bool, const string &>(
+            ctx, axes, decay_rate, eps, batch_stat, nonlinearity),
+        axes_(axes), decay_rate_(decay_rate), eps_(eps),
+        batch_stat_(batch_stat), nonlinearity_(nonlinearity) {}
+  virtual ~FusedBatchNormalization() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_FusedBatchNormalization(
+        this->ctx_, this->axes_, this->decay_rate_, this->eps_,
+        this->batch_stat_, this->nonlinearity_);
+  }
+  virtual int min_inputs() { return 5; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>(),
+                          get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual string name() { return "FusedBatchNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const {
+    // Gradient computation always requires output mean and var.
+    return o > 0;
+  }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+} // namespace nbla

--- a/python/test/function/test_fused_batch_normalization.py
+++ b/python/test/function/test_fused_batch_normalization.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from six.moves import range
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('FusedBatchNormalization')
+cpu_context = nn.Context(["cpu:float"])
+
+
+def ref_fused_batch_normalization(x, beta, gamma, rmean, rvar, z, axes, decay_rate,
+                                  eps, batch_stat, nonlinearity, output_stat):
+    with nn.context_scope(cpu_context):
+        xvar = nn.Variable.from_numpy_array(x)
+        betavar = nn.Variable.from_numpy_array(beta)
+        gammavar = nn.Variable.from_numpy_array(gamma)
+        rmeanvar = nn.Variable.from_numpy_array(rmean)
+        rvarvar = nn.Variable.from_numpy_array(rvar)
+        if z is not None:
+            zvar = nn.Variable.from_numpy_array(z)
+        with nn.auto_forward():
+            bn = F.batch_normalization(xvar, betavar, gammavar, rmeanvar, rvarvar,
+                                       axes, decay_rate, eps, batch_stat, output_stat)
+            if z is None:
+                if output_stat:
+                    y = bn[0]
+                else:
+                    y = bn
+            else:
+                if output_stat:
+                    y = F.add2(bn[0], zvar)
+                else:
+                    y = F.add2(bn, zvar)
+            y = F.relu(y)
+        rmean[:] = rmeanvar.d
+        rvar[:] = rvarvar.d
+        if output_stat:
+            return y.d, bn[1].d, bn[2].d
+        else:
+            return y.d
+
+
+def ref_grad_fused_batch_normalization(x, beta, gamma, rmean, rvar, z, dy, axes, decay_rate,
+                                       eps, batch_stat, nonlinearity, output_stat):
+    with nn.context_scope(cpu_context):
+        xvar = nn.Variable.from_numpy_array(x, need_grad=True)
+        xvar.g = 0
+        betavar = nn.Variable.from_numpy_array(beta, need_grad=True)
+        betavar.g = 0
+        gammavar = nn.Variable.from_numpy_array(gamma, need_grad=True)
+        gammavar.g = 0
+        rmeanvar = nn.Variable.from_numpy_array(rmean)
+        rmeanvar.g = 0
+        rvarvar = nn.Variable.from_numpy_array(rvar)
+        rvarvar.g = 0
+        zvar = None
+        if z is not None:
+            zvar = nn.Variable.from_numpy_array(z, need_grad=True)
+            zvar.g = 0
+        with nn.auto_forward():
+            bn = F.batch_normalization(xvar, betavar, gammavar, rmeanvar, rvarvar,
+                                       axes, decay_rate, eps, batch_stat, output_stat)
+            if z is None:
+                if output_stat:
+                    y1 = bn[0]
+                else:
+                    y1 = bn
+            else:
+                if output_stat:
+                    y1 = F.add2(bn[0], zvar)
+                else:
+                    y1 = F.add2(bn, zvar)
+            y = F.relu(y1)
+        y.g = dy
+        y.backward(dy)
+        concat = [xvar.g.flatten(), betavar.g.flatten(), gammavar.g.flatten()]
+        if z is not None:
+            concat.append(zvar.g.flatten())
+        return np.concatenate(concat)
+
+
+def create_inputs(rng, axis, add):
+    x = rng.randn(2, 3, 5, 4).astype(np.float32) * 2
+    shape_stat = [1 for _ in range(x.ndim)]
+    if add:
+        # Note: The last dimension must be a multiple of 4
+        # if we want to test cudnn BN persistent mode.
+        z = rng.randn(2, 3, 5, 4).astype(np.float32) * 2
+    else:
+        z = None
+
+    shape_stat[axis] = x.shape[axis]
+    beta = rng.randn(*shape_stat).astype(np.float32)
+    gamma = rng.randn(*shape_stat).astype(np.float32)
+    rmean = np.zeros(shape_stat, dtype=np.float32)
+    rvar = np.zeros(shape_stat, dtype=np.float32)
+    return x, beta, gamma, rmean, rvar, z
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("axis", [0, 3])
+@pytest.mark.parametrize("decay_rate", [0.9])
+@pytest.mark.parametrize("eps", [1e-5])
+@pytest.mark.parametrize("nonlinearity", ['relu'])
+@pytest.mark.parametrize("output_stat", [False])  # [True, False])
+@pytest.mark.parametrize("add", [True, False])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+def test_fused_batch_normalization_forward_backward(seed, axis, decay_rate, eps,
+                                                    nonlinearity,
+                                                    output_stat, add,
+                                                    ctx, func_name):
+    from nbla_test_utils import function_tester
+    rng = np.random.RandomState(seed)
+    inputs = list(create_inputs(rng, axis, add))
+    axes = [axis]
+    batch_stat = True
+    function_tester(rng, F.fused_batch_normalization, ref_fused_batch_normalization,
+                    inputs,
+                    ref_grad=ref_grad_fused_batch_normalization,
+                    func_args=[axes, decay_rate, eps,
+                               batch_stat, nonlinearity, output_stat],
+                    backward=[True, True, True, False, False, add],
+                    ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2)
+
+    # Check if running mean and var works.
+    vinputs = []
+    for i in inputs:
+        if i is None:
+            vinputs.append(None)
+            continue
+        vinputs.append(nn.Variable.from_numpy_array(i, need_grad=True))
+    for i in range(5):
+        inputs[0] = rng.randn(*inputs[0].shape)
+        vinputs[0].d[...] = inputs[0]
+        ref_y = ref_fused_batch_normalization(
+            *(inputs + [axes, decay_rate, eps, batch_stat, nonlinearity, output_stat]))
+        with nn.context_scope(ctx), nn.auto_forward():
+            y = F.fused_batch_normalization(
+                *(vinputs + [axes, decay_rate, eps, batch_stat, nonlinearity, output_stat]))
+        assert np.allclose(vinputs[3].d, inputs[3])
+        assert np.allclose(vinputs[4].d, inputs[4], atol=1e-3)
+
+    # Check if global stat mode works
+    batch_stat = False
+    if output_stat:
+        return
+    ref_y = ref_fused_batch_normalization(
+        *(inputs + [axes, decay_rate, eps, batch_stat, nonlinearity, output_stat]))
+    with nn.context_scope(ctx), nn.auto_forward():
+        y = F.fused_batch_normalization(
+            *(vinputs + [axes, decay_rate, eps, batch_stat, nonlinearity, output_stat]))
+    assert np.allclose(ref_y, y.d, atol=1e-6)

--- a/python/test/test_parametric_functions.py
+++ b/python/test/test_parametric_functions.py
@@ -284,6 +284,122 @@ def test_pf_batch_normalization_execution(g_rng, inshape, decay_rate, eps, batch
     assert not v.need_grad
 
 
+@pytest.mark.parametrize("inshape, decay_rate, eps, axes", [
+    ((1, 2, 1, 4), 0.9, 1e-5, [3]),
+    ((8, 8), 0.99, 1e-3, [1]),
+])
+@pytest.mark.parametrize('batch_stat, output_stat', [(False, False), (True, False), (True, True)])
+@pytest.mark.parametrize("nonlinearity", ['relu'])
+@pytest.mark.parametrize('param_init', [None, True])
+@pytest.mark.parametrize("fix_parameters", [False, True])
+@pytest.mark.parametrize("with_z", [False, True])
+@pytest.mark.parametrize("rng", [None, True])
+def test_pf_fused_batch_normalization_execution(
+        g_rng, inshape, axes, decay_rate, eps, batch_stat, nonlinearity,
+        output_stat, param_init, fix_parameters, with_z, rng):
+
+    p_shape = [1 for _ in inshape]
+    for i in range(len(axes)):
+        p_shape[axes[i]] = inshape[axes[i]]
+    p_shape = tuple(p_shape)
+
+    if param_init:
+        beta_init = np.ones(p_shape) * 1
+        gamma_init = np.ones(p_shape) * 2
+        mean_init = np.ones(p_shape) * 0.5
+        var_init = np.ones(p_shape) * 1.5
+        param_init = dict(
+            beta=beta_init,
+            gamma=gamma_init,
+            mean=mean_init,
+            var=var_init)
+    rng = process_rng(rng)
+
+    x = nn.Variable.from_numpy_array(g_rng.randn(*inshape))
+    z = None
+    if with_z:
+        z = nn.Variable.from_numpy_array(g_rng.randn(*inshape))
+
+    kw = {}
+    insert_if_not_none(kw, 'z', z)
+    insert_if_not_default(kw, 'axes', axes, [1])
+    insert_if_not_default(kw, 'decay_rate', decay_rate, 0.9)
+    insert_if_not_default(kw, 'eps', eps, 1e-5)
+    insert_if_not_default(kw, 'batch_stat', batch_stat, True)
+    insert_if_not_default(kw, 'nonlinearity', nonlinearity, 'relu')
+    insert_if_not_default(kw, 'output_stat', output_stat, False)
+    insert_if_not_default(kw, 'fix_parameters', fix_parameters, False)
+    insert_if_not_none(kw, 'param_init', param_init)
+
+    # Check creation
+    y = PF.fused_batch_normalization(x, **kw)
+
+    # Check parameter values before execution
+    h = y[0] if output_stat else y
+    if with_z:
+        _, b, g, m, v, _ = h.parent.inputs
+    else:
+        _, b, g, m, v = h.parent.inputs
+    if param_init:
+        assert np.allclose(b.d, beta_init)
+        assert np.allclose(g.d, gamma_init)
+        assert np.allclose(m.d, mean_init)
+        assert np.allclose(v.d, var_init)
+    else:
+        assert np.allclose(b.d, 0)
+        assert np.allclose(g.d, 1)
+        assert np.allclose(m.d, 0)
+        assert np.allclose(v.d, 1)
+
+    # Check execution
+    if output_stat:
+        forward_backward_all(*y)
+    else:
+        y.forward()
+        # TODO: Enable when implemented
+        if batch_stat:
+            y.backward()
+
+    # Check values
+    # TODO
+
+    # Check args
+    assert h.parent.info.type_name == 'FusedBatchNormalization'
+    args = h.parent.info.args
+    assert args['axes'] == axes
+    assert np.isclose(args['decay_rate'], decay_rate)
+    assert np.isclose(args['eps'], eps)
+    assert args['batch_stat'] == batch_stat
+    assert args['nonlinearity'] == nonlinearity
+
+    # Check created parameters
+    assert h.parent.inputs[0] == x
+    num_inputs = 5
+    if with_z:
+        num_inputs = 6
+        h.parent.inputs[5] == z
+    assert len(h.parent.inputs) == num_inputs
+    assert len(nn.get_parameters()) == 2
+    assert len(nn.get_parameters(grad_only=False)) == 4
+    beta, gamma, mean, var = [nn.get_parameters(grad_only=False)['bn/' + name]
+                              for name in ['beta', 'gamma', 'mean', 'var']]
+    assert beta.shape == p_shape
+    assert gamma.shape == p_shape
+    assert mean.shape == p_shape
+    assert var.shape == p_shape
+
+    assert beta.need_grad
+    assert gamma.need_grad
+    assert not mean.need_grad
+    assert not var.need_grad
+
+    _, b, g, m, v = h.parent.inputs[:5]
+    assert b.need_grad == (not fix_parameters)
+    assert g.need_grad == (not fix_parameters)
+    assert not m.need_grad
+    assert not v.need_grad
+
+
 @pytest.mark.parametrize("w_shape, dim", [((32, 16, 3, 3), 0),  # convolution
                                           ((16, 1), 1),         # affine
                                           ((16, 32), 1),        # affine

--- a/src/nbla/function/generic/fused_batch_normalization.cpp
+++ b/src/nbla/function/generic/fused_batch_normalization.cpp
@@ -1,0 +1,102 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/function/fused_batch_normalization.hpp>
+#include <nbla/variable.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <numeric>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(FusedBatchNormalization, const vector<int> &,
+                              float, float, bool, const string &);
+
+template <class T>
+void FusedBatchNormalization<T>::setup_impl(const Variables &inputs,
+                                            const Variables &outputs) {
+  NBLA_CHECK(nonlinearity_ == "relu", error_code::not_implemented,
+             "Currently \"relu\" is only supported as a nonlinearity.");
+  Variables inputs_bn(inputs.begin(), inputs.begin() + 5);
+  bn_ = create_BatchNormalization(this->ctx_, axes_, decay_rate_, eps_,
+                                  batch_stat_);
+  bn_->setup(inputs_bn, outputs);
+}
+
+template <class T>
+void FusedBatchNormalization<T>::forward_impl(const Variables &inputs,
+                                              const Variables &outputs) {
+
+  NBLA_CHECK(bn_, error_code::value, "setup is not called.");
+  // Naive non-fused implementation by layer composition.
+  // 1. Perform BatchNormalization
+  Variables inputs_bn(inputs.begin(), inputs.begin() + 5);
+  bn_->forward(inputs_bn, outputs);
+
+  // 2. Perform Add2
+  // NOTE: Output buffer are re-used by inplacing.
+  if (inputs.size() == 6) {
+    auto add2 = create_Add2(this->ctx_, true);
+    add2->setup(Variables{outputs[0], inputs[5]}, Variables{outputs[0]});
+    add2->forward(Variables{outputs[0], inputs[5]}, Variables{outputs[0]});
+  }
+
+  // 3. Perform ReLU
+  // NOTE: Output buffer are re-used by inplacing.
+  auto relu = create_ReLU(this->ctx_, true);
+  relu->setup(Variables{outputs[0]}, Variables{outputs[0]});
+  relu->forward(Variables{outputs[0]}, Variables{outputs[0]});
+}
+
+template <class T>
+void FusedBatchNormalization<T>::backward_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &propagate_down, const vector<bool> &accum) {
+  NBLA_CHECK(bn_, error_code::value, "setup is not called.");
+
+  // Naive non-fused implementation by layer composition.
+  // 1. Perform ReLU backward
+  // NOTE: Output buffer are re-used by inplacing.
+  bool prop_down_add2 = (inputs.size() == 6 && propagate_down[5]);
+  bool prop_down_bn =
+      std::accumulate(propagate_down.begin(), propagate_down.begin() + 3, false,
+                      std::logical_or<bool>());
+
+  bool accum_relu = false; // Whatever because inout are inplaced.
+  auto relu = create_ReLU(this->ctx_, true);
+  relu->setup(Variables{outputs[0]}, Variables{outputs[0]}); // Inplace
+  relu->backward(Variables{outputs[0]}, Variables{outputs[0]},
+                 {prop_down_add2 || prop_down_bn}, {accum_relu});
+
+  // 2. Perform Add2 backward
+  // NOTE: Output buffer are re-used by inplacing.
+  if (prop_down_add2) {
+    auto add2 = create_Add2(this->ctx_, true);
+    bool accum_bn = false; // Whatever since it's inplaced.
+    add2->setup(Variables{outputs[0], inputs[5]}, Variables{outputs[0]});
+    add2->backward(Variables{outputs[0], inputs[5]}, Variables{outputs[0]},
+                   {prop_down_bn, prop_down_add2}, {accum_bn, accum[5]});
+  }
+
+  // 3. Perform BN backward
+  Variables inputs_bn(inputs.begin(), inputs.begin() + 5);
+  vector<bool> prop_down_bn_inputs(propagate_down.begin(),
+                                   propagate_down.begin() + 5);
+  vector<bool> accum_bn_inputs(accum.begin(), accum.begin() + 5);
+  bn_->backward(inputs_bn, outputs, prop_down_bn_inputs, accum_bn_inputs);
+}
+} // namespace nbla


### PR DESCRIPTION
The PR sony/nnabla-ext-cuda#154 adds CUDA implementation.
A fused operation of batch normalization + add2 + activation is added. This reduces memory usage and execution time especially in CUDA backend.

Depends on #436. 