### PR TITLE
Add LogSoftmax and disable fp16 Softmax

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -54,7 +54,10 @@ LeakyReLU:
   half: [Half]
 Softmax:
   float: [float]
-  half: [Half]
+#   half: [Half]
+LogSoftmax:
+  float: [float]
+#   half: [Half]
 ELU:
   float: [float]
   half: [Half]
@@ -371,7 +374,7 @@ BinaryCrossEntropy:
   half: [Half]
 SoftmaxCrossEntropy:
   float: [float, int]
-  half: [Half, int]
+#   half: [Half, int]
 CategoricalCrossEntropy:
   float: [float, int]
   half: [Half, int]

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -812,7 +812,7 @@ Neural Network Activation Functions:
       .. math::
           y_i = \frac{\exp(x_i)}{\sum_j \exp(x_j)}
 
-      along the dimension specified by `axis`, where :math:`y_i` is the input and :math:`x_i` is the output.
+      along the dimension specified by `axis`, where :math:`x_i` is the input and :math:`y_i` is the output.
     inputs:
       x:
         doc: N-D array. Typically indicates a score.
@@ -827,6 +827,46 @@ Neural Network Activation Functions:
     function_ids:
       i: 16
     c_runtime: support
+  LogSoftmax:
+    snake_name: log_softmax
+    doc: |2
+
+      Fused operation of Softmax normalization followed by log, which is defined as
+
+      .. math::
+          y_i = \log \frac{\exp(x_i)}{\sum_j \exp(x_j)},
+
+      where :math:`y_i` is the input and :math:`x_i` is the output at i-th channel.
+      An advantage of this fusion is reducing the numerical instability due to the log application.
+
+      The original definition can be rewritten as
+
+      .. math::
+          y_i = x_i - \max_j(x_j) - \log\left\(\sum_j \exp(x_j - \max_k(x_k))\right\).
+
+      It is more stable as a log is always applied to a value :math:`\ge e`, while a log can be evaluated for 0 in the non-fused operation.
+
+      Also, backward gradient computation is more stable than the original one as it doesn't perform division by x due to a gradient of log. The definition is as following.
+
+      .. math::
+          dx_i = dy_i - y_i * \sum_j dy_j
+
+      where :math:`dx_i` and :math:`dy_i` denote gradients of loss
+      wrt :math:`x_i` and :math:`y_i` respectively.
+    inputs:
+      x:
+        doc: N-D array. Typically indicates a score.
+    arguments:
+      axis:
+        doc: Axis normalization is taken.
+        type: int64
+        default: len(x.shape) - 1
+    outputs:
+      y:
+        doc: N-D array with the same shape as x
+    c_runtime: not support
+    function_ids:
+      i: 269
   ELU:
     snake_name: elu
     doc: |2

--- a/include/nbla/function/log_softmax.hpp
+++ b/include/nbla/function/log_softmax.hpp
@@ -1,0 +1,75 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_LOG_SOFTMAX_HPP
+#define NBLA_FUNCTION_LOG_SOFTMAX_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(LogSoftmax, int);
+
+/** Softmax normalization defined as
+@f[
+y_i = x_i - \log\left\(\sum_j exp(x_j)\right\)
+@f]
+along dimension specified by axis.
+
+Inputs:
+- N-D array.
+
+Outputs:
+- N-D array with the same shape as input.
+
+@tparam T Data type for computation.
+@param axis Axis normalization is taken.
+\ingroup FunctionImplGrp
+ */
+template <typename T> class LogSoftmax : public BaseFunction<int> {
+protected:
+  int axis_;
+  int size0_, size1_, size2_;
+
+public:
+  LogSoftmax(const Context &ctx, int axis)
+      : BaseFunction(ctx, axis), axis_(axis) {}
+  virtual ~LogSoftmax() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_LogSoftmax(ctx_, axis_);
+  }
+  virtual int min_inputs() { return 1; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "LogSoftmax"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return true; }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/function/softmax_cross_entropy.hpp
+++ b/include/nbla/function/softmax_cross_entropy.hpp
@@ -60,8 +60,8 @@ class SoftmaxCrossEntropy : public BaseFunction<int> {
 protected:
   int axis_;
   int size0_, size1_, size2_;
-  shared_ptr<Function> softmax_;
-  Variable softmax_output_;
+  shared_ptr<Function> log_softmax_;
+  Variable log_softmax_output_;
 
 public:
   SoftmaxCrossEntropy(const Context &ctx, int axis)

--- a/python/test/function/test_softmax.py
+++ b/python/test/function/test_softmax.py
@@ -18,8 +18,6 @@ import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
 
-ctxs = list_context('Softmax')
-
 
 def ref_softmax(x, axis):
     x = x - x.max(axis, keepdims=True)
@@ -27,12 +25,29 @@ def ref_softmax(x, axis):
     return x
 
 
+def ref_log_softmax(x, axis):
+    x = x - x.max(axis, keepdims=True)
+    x = x - np.log(np.exp(x).sum(axis, keepdims=True))
+    return x
+
+
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("axis", [0, 1, 2])
-@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("ctx, func_name", list_context('Softmax'))
 def test_softmax_forward_backward(seed, axis, ctx, func_name):
     from nbla_test_utils import function_tester
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     function_tester(rng, F.softmax, ref_softmax, inputs, func_args=[axis],
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("ctx, func_name", list_context('LogSoftmax'))
+def test_log_softmax_forward_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32)]
+    function_tester(rng, F.log_softmax, ref_log_softmax, inputs, func_args=[axis],
+                    ctx=ctx, func_name=func_name, atol_b=1e-2)

--- a/src/nbla/function/generic/log_softmax.cpp
+++ b/src/nbla/function/generic/log_softmax.cpp
@@ -1,0 +1,108 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/log_softmax.hpp>
+#include <nbla/variable.hpp>
+
+// TODO: remove the following headers if not used.
+#include <iostream>
+#include <typeinfo>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(LogSoftmax, int);
+
+template <typename T>
+void LogSoftmax<T>::setup_impl(const Variables &inputs,
+                               const Variables &outputs) {
+  Shape_t in_shape = inputs[0]->shape();
+  NBLA_CHECK(axis_ < in_shape.size(), error_code::value,
+             "axis must be less than ndim of inputs[0]. "
+             "axis: %d >= ndim of inputs[0]: %d.",
+             axis_, in_shape.size());
+  outputs[0]->reshape(in_shape, true);
+  Size_t size = inputs[0]->size();
+  Size_t size_axis = inputs[0]->size(axis_);
+  size0_ = size / size_axis;          // Batch size.
+  size1_ = inputs[0]->shape()[axis_]; // Size of specified axis.
+  size2_ = size / size0_ / size1_;    // Size of rest.
+}
+
+template <typename T>
+void LogSoftmax<T>::forward_impl(const Variables &inputs,
+                                 const Variables &outputs) {
+  typedef typename force_float<T>::type AccumType;
+  // Setting up variables
+  const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
+  for (int i0 = 0; i0 < size0_; ++i0) {
+    for (int i2 = 0; i2 < size2_; ++i2) {
+      const int j = i0 * size1_ * size2_ + i2;
+      // compute maximum
+      T max_x = x[j];
+      for (int i1 = 0; i1 < size1_; ++i1) {
+        const int k = i1 * size2_ + j;
+        max_x = (max_x >= x[k]) ? max_x : x[k];
+      }
+      // Compute exponential and sum
+      AccumType exp_sum = 0;
+      for (int i1 = 0; i1 < size1_; ++i1) {
+        const int k = i1 * size2_ + j;
+        const T tmp = x[k] - max_x;
+        y[k] = tmp;
+        exp_sum += std::exp(tmp);
+      }
+      // Compute softmax
+      for (int i1 = 0; i1 < size1_; ++i1) {
+        const int k = i1 * size2_ + j;
+        y[k] -= std::log(exp_sum);
+      }
+    }
+  }
+}
+
+template <typename T>
+void LogSoftmax<T>::backward_impl(const Variables &inputs,
+                                  const Variables &outputs,
+                                  const vector<bool> &propagate_down,
+                                  const vector<bool> &accum) {
+  typedef typename force_float<T>::type AccumType;
+  if (!propagate_down[0]) {
+    return;
+  }
+  // Setting up variables
+  const T *y = outputs[0]->get_data_pointer<T>(this->ctx_);
+  const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
+  T *dx = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
+
+  for (int i0 = 0; i0 < size0_; ++i0) {
+    for (int i2 = 0; i2 < size2_; ++i2) {
+      const int j = i0 * size1_ * size2_ + i2;
+      // compute sum of dy * y
+      AccumType dy_sum = 0;
+      for (int i1 = 0; i1 < size1_; ++i1) {
+        const int k = i1 * size2_ + j;
+        dy_sum += dy[k];
+      }
+      // Compute backward
+      for (int i1 = 0; i1 < size1_; ++i1) {
+        const int k = i1 * size2_ + j;
+        dx[k] = (accum[0] ? dx[k] : (T)0) + dy[k] - std::exp(y[k]) * dy_sum;
+      }
+    }
+  }
+}
+}

--- a/src/nbla/function/generic/softmax.cpp
+++ b/src/nbla/function/generic/softmax.cpp
@@ -45,6 +45,7 @@ void Softmax<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 template <class T>
 void Softmax<T>::forward_impl(const Variables &inputs,
                               const Variables &outputs) {
+  typedef typename force_float<T>::type AccumType;
   // Setting up variables
   const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -58,7 +59,7 @@ void Softmax<T>::forward_impl(const Variables &inputs,
         max_x = (max_x >= x[k]) ? max_x : x[k];
       }
       // Compute exponential and sum
-      T exp_sum = 0;
+      AccumType exp_sum = 0;
       for (int i1 = 0; i1 < size1_; ++i1) {
         const int k = i1 * size2_ + j;
         const T tmp = std::exp(x[k] - max_x);
@@ -82,6 +83,7 @@ void Softmax<T>::backward_impl(const Variables &inputs,
   if (!propagate_down[0]) {
     return;
   }
+  typedef typename force_float<T>::type AccumType;
   // Setting up variables
   const T *y = outputs[0]->get_data_pointer<T>(this->ctx_);
   const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
@@ -91,7 +93,7 @@ void Softmax<T>::backward_impl(const Variables &inputs,
     for (int i2 = 0; i2 < size2_; ++i2) {
       const int j = i0 * size1_ * size2_ + i2;
       // compute sum of dy * y
-      T dyy_sum = 0;
+      AccumType dyy_sum = 0;
       for (int i1 = 0; i1 < size1_; ++i1) {
         const int k = i1 * size2_ + j;
         dyy_sum += dy[k] * y[k];


### PR DESCRIPTION
The PR sony/nnabla-ext-cuda#155 adds a CUDA implementation.

This adds:

* LogSoftmax operation which computes log followed by softmax more stable.
* Disabled fp16 softmax for mixed precision training.
* Use LogSoftmax in SoftmaxCrossEntropy for more stability.

Depends on #437.