### PR TITLE
FIX: Add a missing implemenation to nnp::Monitor

### DIFF
--- a/src/nbla_utils/nnp.cpp
+++ b/src/nbla_utils/nnp.cpp
@@ -95,6 +95,7 @@ Monitor::Monitor(MonitorImpl *impl)
 
 string Monitor::name() const { return impl_->name(); }
 string Monitor::network_name() const { return impl_->network_name(); }
+shared_ptr<Network> Monitor::get_network() { return impl_->get_network(); }
 const float Monitor::monitor_epoch() { return impl_->monitor_epoch(); }
 
 // ----------------------------------------------------------------------


### PR DESCRIPTION
While the method is declared in `nnp.hpp`, the implementation is missing from `nnp.cpp`. Note that the functionality is already available in the implementation class.

Basically, we forgot the following line in `nnp.cpp`.

```
shared_ptr<Network> Monitor::get_network() { return impl_->get_network(); }
```