### PR TITLE
Add scatter_nd function and tests.

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -506,3 +506,6 @@ Assign:
 GatherNd:
   float: [float]
   half: [Half]
+ScatterNd:
+  float: [float]
+  half: [Half]

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -3626,6 +3626,51 @@ Array Manipulation:
     c_runtime: not support
     function_ids:
       Empty: 264
+  ScatterNd:
+    snake_name: scatter_nd
+    doc: |2
+
+      Scatter `data` into a new array of given `shape` according to `indices`.
+      This operation is the inverse of :func:`~nnabla.functions.gather_nd`.
+
+      The forward of :func:`~nnabla.functions.scatter_nd` is equivalent to:
+
+      .. code-block:: python
+
+        def scatter_nd(data, indices, shape):
+            import numpy as np
+            if isinstance(indices, np.ndarray)
+                indices = indices.tolist()
+            result = np.zeros(shape, dtype=data.dtype)
+            result[indices] = data
+            return result
+
+      Examples:
+
+      >>> import numpy as np, nnabla as nn, nnabla.functions as F
+      >>> nn.set_auto_forward(True)
+      >>> data = nn.Variable.from_numpy_array(np.array([9, 10, 11, 12]))
+      >>> indices = nn.Variable.from_numpy_array(np.array([[4, 3, 1, 7]]))
+      >>> scattered = F.scatter_nd(data, indices, shape=(8,))
+      >>> print(scatterd.d)
+      [ 0. 11.  0. 10.  9.  0.  0. 12.]
+      >>> print(F.gather_nd(scattered, indices).d)
+      [ 9. 10. 11. 12.]
+    inputs:
+      data:
+        doc: N-D array input data.
+      indices:
+        doc: N-D array scatter indices.
+    arguments:
+      shape:
+        doc: Shape of output variable.
+        type: repeated int64
+    outputs:
+      y:
+        doc: N-D array of given `shape`.
+    c_runtime: not support
+    function_ids:
+      iI: 271
 Signal Processing:
   Interpolate:
     snake_name: interpolate

--- a/doc/python/api/function.rst
+++ b/doc/python/api/function.rst
@@ -185,6 +185,7 @@ Array Manipulation
 .. autofunction:: stack
 .. autofunction:: slice
 .. autofunction:: gather_nd
+.. autofunction:: scatter_nd
 .. autofunction:: pad
 .. autofunction:: transpose
 .. autofunction:: broadcast

--- a/include/nbla/function/scatter_nd.hpp
+++ b/include/nbla/function/scatter_nd.hpp
@@ -1,0 +1,101 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_SCATTER_ND_HPP
+#define NBLA_FUNCTION_SCATTER_ND_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(ScatterNd, const vector<int> &);
+
+/** Scatter `data` into a new array of given `shape` according to `indices`.
+  This operation is the inverse of :func:`~nnabla.functions.gather_nd`.
+
+  The forward of :func:`~nnabla.functions.scatter_nd` is equivalent to:
+
+  .. code-block:: python
+
+    def scatter_nd(data, indices, shape):
+        import numpy as np
+        if isinstance(indices, np.ndarray)
+            indices = indices.tolist()
+        result = np.zeros(shape, dtype=data.dtype)
+        result[indices] = data
+        return result
+
+  Examples:
+
+    inputs:
+      data:
+        doc: N-D array input data.
+      indices:
+        doc: N-D array scatter indices.
+    arguments:
+      shape:
+        doc: Shape of output variable.
+        type: repeated int64
+    outputs:
+      y:
+        doc: N-D array of given `shape`.
+
+Inputs:
+- N-D array input data
+- N-D array scatter indices
+
+Outputs:
+- N-D array of given `shape`
+
+@param shape Shape of output variable.
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class ScatterNd : public BaseFunction<const vector<int> &> {
+protected:
+  const vector<int> shape_;
+
+public:
+  ScatterNd(const Context &ctx, const vector<int> &shape)
+      : BaseFunction(ctx, shape), shape_(shape) {}
+  virtual ~ScatterNd() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_ScatterNd(ctx_, shape_);
+  }
+  virtual int min_inputs() { return 2; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "ScatterNd"; }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -912,22 +912,24 @@ def gather_nd(data, indices):
     return gather_nd_base(data, indices)
 
 
-def scatter_nd(data, indices, shape, ref=None):
-    """Scatter `data` into a new array of given `shape` according to `indices`.
-    If `ref` is given as :obj:`~nnabla.NdArray` matching `shape` then `data is
-    scattered into `ref`. This operation is the inverse of
-    :func:`~nnabla.functions.gather_nd`.
+def scatter_nd(data, indices, shape=None, out=None):
+    """Scatter `data` according to `indices` into a new array of given `shape`
+    or an existing array provided as `out`. Exactly one of the `shape` or `out`
+    argument must be given. Given output `shape`, or shape of `out` array,
+    :math:`(X_0,X_1,\ldots,X_{N-1})` and `indices` shape
+    :math:`(M,Y_0,\ldots,Y_{K-1})` the input `data` shape is
+    :math:`(Y_0,\ldots,Y_{K-1},X_M,\ldots,X_{N-1})`, where :math:`M<=N`. If
+    :math:`M==N` the `data` shape is simply :math:`(Y_0,\ldots,Y_{K-1})`.
 
     The forward of :func:`~nnabla.functions.scatter_nd` is equivalent to:
 
     .. code-block:: python
 
-      def scatter_nd(data, indices, shape, ref=None):
-          import numpy as np
-          if isinstance(indices, np.ndarray)
+      def scatter_nd(data, indices, shape=None, out=None):
+          assert (shape and not out) or (out and not shape)
+          if isinstance(indices, numpy.ndarray)
               indices = indices.tolist()
-          assert ref is None or ref.shape == shape
-          result = ref if ref else np.zeros(shape)
+          result = out if out else numpy.zeros(shape)
           result[indices] = data
           return result
 
@@ -946,7 +948,8 @@ def scatter_nd(data, indices, shape, ref=None):
     Args:
         data(~nnabla.Variable, ~nnabla.NdArray): input data
         indices(list, numpy.ndarray, ~nnabla.Variable, ~nnabla.NdArray): scatter indices
-        ref(~nnabla.NdArray): reference data
+        shape(tuple, list): shape of new output array
+        out(~nnabla.Variable, ~nnabla.NdArray): existing output array
 
     Returns: ~nnabla.Variable or ~nnabla.NdArray of given `shape`.
 
@@ -956,9 +959,19 @@ def scatter_nd(data, indices, shape, ref=None):
         if not isinstance(indices, np.ndarray):
             indices = np.asarray(indices, dtype=np.int)
         indices = nn.Variable.from_numpy_array(indices)
-    if ref is not None:
-        if not isinstance(ref, nn.NdArray):
-            raise TypeError("reference data must be NdArray type")
-        if not ref.shape == shape:
-            raise ValueError("reference data must have shape {}".format(shape))
-    return scatter_nd_base(data, indices, shape, outputs=[ref])
+    if shape is None and out is None:
+        raise TypeError("One of `shape` or `out` argument must be supplied.")
+    if shape and out:
+        raise TypeError("Only one of `shape` or `out` argument may be used.")
+    if out:
+        if isinstance(out, nn.Variable):
+            out = out.data
+        if not isinstance(out, nn.NdArray):
+            raise TypeError("`out` argument must be NdArray or Variable type.")
+        shape = out.shape
+        outputs = [out]
+    else:
+        if isinstance(shape, np.ndarray):
+            shape = shape.tolist()
+        outputs = None
+    return scatter_nd_base(data, indices, shape, outputs=outputs)

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -920,6 +920,7 @@ def scatter_nd(data, indices, shape=None, out=None):
     :math:`(M,Y_0,\ldots,Y_{K-1})` the input `data` shape is
     :math:`(Y_0,\ldots,Y_{K-1},X_M,\ldots,X_{N-1})`, where :math:`M<=N`. If
     :math:`M==N` the `data` shape is simply :math:`(Y_0,\ldots,Y_{K-1})`.
+    Note that `indices` are treated as integers and potentially converted.
 
     The forward of :func:`~nnabla.functions.scatter_nd` is equivalent to:
 

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -910,3 +910,55 @@ def gather_nd(data, indices):
             indices = np.asarray(indices, dtype=np.int)
         indices = nn.Variable.from_numpy_array(indices)
     return gather_nd_base(data, indices)
+
+
+def scatter_nd(data, indices, shape, ref=None):
+    """Scatter `data` into a new array of given `shape` according to `indices`.
+    If `ref` is given as :obj:`~nnabla.NdArray` matching `shape` then `data is
+    scattered into `ref`. This operation is the inverse of
+    :func:`~nnabla.functions.gather_nd`.
+
+    The forward of :func:`~nnabla.functions.scatter_nd` is equivalent to:
+
+    .. code-block:: python
+
+      def scatter_nd(data, indices, shape, ref=None):
+          import numpy as np
+          if isinstance(indices, np.ndarray)
+              indices = indices.tolist()
+          assert ref is None or ref.shape == shape
+          result = ref if ref else np.zeros(shape)
+          result[indices] = data
+          return result
+
+    Examples:
+
+    >>> import numpy as np, nnabla as nn, nnabla.functions as F
+    >>> nn.set_auto_forward(True)
+    >>> data = nn.Variable.from_numpy_array(np.array([9, 10, 11, 12]))
+    >>> indices = nn.Variable.from_numpy_array(np.array([[4, 3, 1, 7]]))
+    >>> scattered = F.scatter_nd(data, indices, shape=(8,))
+    >>> print(scatterd.d)
+    [ 0. 11.  0. 10.  9.  0.  0. 12.]
+    >>> print(F.gather_nd(scattered, indices).d)
+    [ 9. 10. 11. 12.]
+
+    Args:
+        data(~nnabla.Variable, ~nnabla.NdArray): input data
+        indices(list, numpy.ndarray, ~nnabla.Variable, ~nnabla.NdArray): scatter indices
+        ref(~nnabla.NdArray): reference data
+
+    Returns: ~nnabla.Variable or ~nnabla.NdArray of given `shape`.
+
+    """
+    from .function_bases import scatter_nd as scatter_nd_base
+    if not isinstance(indices, (nn.Variable, nn.NdArray)):
+        if not isinstance(indices, np.ndarray):
+            indices = np.asarray(indices, dtype=np.int)
+        indices = nn.Variable.from_numpy_array(indices)
+    if ref is not None:
+        if not isinstance(ref, nn.NdArray):
+            raise TypeError("reference data must be NdArray type")
+        if not ref.shape == shape:
+            raise ValueError("reference data must have shape {}".format(shape))
+    return scatter_nd_base(data, indices, shape, outputs=[ref])

--- a/python/test/function/test_scatter_nd.py
+++ b/python/test/function/test_scatter_nd.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context, function_tester
+
+ctxs = list_context('ScatterNd')
+
+
+def scatter_nd(data, indices, shape):
+    indices = indices.tolist() if isinstance(indices, np.ndarray) else indices
+    result = np.zeros(shape, dtype=data.dtype)
+    result[indices] = data
+    return result
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ishape, index, oshape", [
+    ((2,), [[1, 3]], (10,)),
+    ((2,), [[-1, -3]], (10,)),
+    ((3,), [[1, 1, 0], [0, 1, 0]], (2, 2)),
+    ((4,), [[4, 3, 1, 7]], (8,)),
+    ((2, 4), [[0, 1], [2, 3]], (4, 4, 4)),
+    ((2, 4, 4), [[0, 2]], (4, 4, 4)),
+    ((2, 2, 2), [[0, 1], [1, 1]], (2, 2, 2, 2)),
+])
+def test_forward_backward(seed, ishape, index, oshape, ctx, func_name):
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*ishape).astype(np.float32), np.array(index)]
+    function_tester(rng, F.scatter_nd, scatter_nd, inputs, func_name=func_name,
+                    func_args=[oshape], ctx=ctx, backward=[True, False])

--- a/src/nbla/function/generic/scatter_nd.cpp
+++ b/src/nbla/function/generic/scatter_nd.cpp
@@ -1,0 +1,141 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/scatter_nd.hpp>
+#include <nbla/utils/nd_index.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(ScatterNd, const vector<int> &);
+
+template <typename T>
+void ScatterNd<T>::setup_impl(const Variables &inputs,
+                              const Variables &outputs) {
+  auto data = inputs.at(0);
+  auto indices = inputs.at(1);
+  auto outdata = outputs.at(0);
+
+  NBLA_CHECK(indices->ndim() >= 2, error_code::value,
+             "scatter_nd requires indices to have at least 2 dimensions");
+
+  NBLA_CHECK(indices->shape().at(0) <= shape_.size(), error_code::value,
+             "Number of indices exceeds output dimension");
+
+  auto N = data->ndim();
+  auto M = indices->shape().at(0);
+  auto K = indices->ndim() - 1;
+
+  NBLA_CHECK(shape_.size() == N + M - K, error_code::value,
+             "Output shape size does not match input data and indices.");
+
+  for (int i = 0; i < K; i++) {
+    NBLA_CHECK(data->shape().at(i) == indices->shape().at(i + 1),
+               error_code::value,
+               "Shape error: data shape[%d] %d != indices shape[%d] %d", i,
+               data->shape()[i], i + 1, indices->shape()[i + 1]);
+  }
+
+  for (int i = 0; i < shape_.size() - M; i++) {
+    NBLA_CHECK(data->shape().at(K + i) == shape_.at(M + i), error_code::value,
+               "Shape error: data shape[%d] %d != output shape[%d] %d", K + i,
+               data->shape()[K + i], M + i, indices->shape()[M + i]);
+  }
+
+  Shape_t outdata_shape(N + M - K);
+  std::copy(shape_.begin(), shape_.end(), outdata_shape.begin());
+  outdata->reshape(outdata_shape, true);
+  outdata->data()->zero();
+}
+
+template <typename T>
+void ScatterNd<T>::forward_impl(const Variables &inputs,
+                                const Variables &outputs) {
+  auto src = inputs[0]->get_data_pointer<T>(this->ctx_);
+  auto idx = inputs[1]->get_data_pointer<int>(this->ctx_);
+  auto dst = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, false);
+
+  auto idx_shape = inputs[1]->shape();
+  auto dst_shape = outputs[0]->shape();
+
+  auto dst_ndi = ndi::make_index<Size_t>(dst_shape.size());
+  auto dst_strides = ndi::strides(dst_shape);
+
+  auto idx_rows = idx_shape[0];
+  auto idx_cols = ndi::inner_size(idx_shape, 1);
+
+  for (int i = 0; i < idx_cols; i++) {
+    for (int m = 0; m < idx_rows; m++) {
+      auto index = idx[m * idx_cols + i];
+      NBLA_CHECK(index < dst_shape[m], error_code::value,
+                 "index %d for axis %d overflows shape %d", index, m,
+                 dst_shape[m]);
+      NBLA_CHECK(index >= -dst_shape[m], error_code::value,
+                 "index %d for axis %d underflows shape %d", index, m,
+                 dst_shape[m]);
+      dst_ndi[m] = (index < 0) ? dst_shape[m] + index : index;
+    }
+    auto slice_length = dst_strides.at(idx_rows - 1);
+    auto slice_offset = ndi::nd2flat(dst_ndi, dst_strides);
+    for (int k = 0; k < slice_length; k++) {
+      dst[slice_offset + k] = src[i * slice_length + k];
+    }
+  }
+}
+
+template <typename T>
+void ScatterNd<T>::backward_impl(const Variables &inputs,
+                                 const Variables &outputs,
+                                 const vector<bool> &propagate_down,
+                                 const vector<bool> &accum) {
+  if (!propagate_down[0]) {
+    return;
+  }
+
+  auto g_y = outputs[0]->get_grad_pointer<T>(this->ctx_);
+  auto g_x = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
+  auto idx = inputs[1]->get_data_pointer<int>(this->ctx_);
+
+  auto idx_shape = inputs[1]->shape();
+  auto src_shape = outputs[0]->shape();
+
+  auto src_ndi = ndi::make_index<Size_t>(src_shape.size());
+  auto src_strides = ndi::strides(src_shape);
+
+  auto idx_rows = idx_shape[0];
+  auto idx_cols = ndi::inner_size(idx_shape, 1);
+
+  for (int i = 0; i < idx_cols; i++) {
+    for (int m = 0; m < idx_rows; m++) {
+      auto index = idx[m * idx_cols + i];
+      NBLA_CHECK(index < src_shape[m], error_code::value,
+                 "index %d for axis %d overflows shape %d", index, m,
+                 src_shape[m]);
+      NBLA_CHECK(index >= -src_shape[m], error_code::value,
+                 "index %d for axis %d underflows shape %d", index, m,
+                 src_shape[m]);
+      src_ndi[m] = (index < 0) ? src_shape[m] + index : index;
+    }
+    auto slice_length = src_strides.at(idx_rows - 1);
+    auto slice_offset = ndi::nd2flat(src_ndi, src_strides);
+    for (int k = 0; k < slice_length; k++) {
+      g_x[i * slice_length + k] =
+          !accum[0] ? g_y[slice_offset + k]
+                    : g_x[i * slice_length + k] + g_y[slice_offset + k];
+    }
+  }
+}
+}

--- a/src/nbla/function/generic/scatter_nd.cpp
+++ b/src/nbla/function/generic/scatter_nd.cpp
@@ -121,12 +121,6 @@ void ScatterNd<T>::backward_impl(const Variables &inputs,
   for (int i = 0; i < idx_cols; i++) {
     for (int m = 0; m < idx_rows; m++) {
       auto index = idx[m * idx_cols + i];
-      NBLA_CHECK(index < src_shape[m], error_code::value,
-                 "index %d for axis %d overflows shape %d", index, m,
-                 src_shape[m]);
-      NBLA_CHECK(index >= -src_shape[m], error_code::value,
-                 "index %d for axis %d underflows shape %d", index, m,
-                 src_shape[m]);
       src_ndi[m] = (index < 0) ? src_shape[m] + index : index;
     }
     auto slice_length = src_strides.at(idx_rows - 1);


### PR DESCRIPTION
Add a scatter_nd function implementation for CPU backend. The function scatters an input data array according to given indices into either a new output array of specified shape or an existing output array.