### PR TITLE
Double backward

### DIFF
--- a/build-tools/code_generator/code_generator_utils.py
+++ b/build-tools/code_generator/code_generator_utils.py
@@ -249,3 +249,18 @@ def generate_skeleton_function_impl(function_info, function_types, ext_info={}, 
             continue
         generate_skeleton_function_impl_one(
             ext_info, name, func, template, output_dir, output_format)
+
+def generate_skeleton_backward_function_impl(function_info, template, output_dir, output_format='%s.py'):
+    """This function now generate the template of a backward function in python-layer using PythonFunction.
+    """
+    from mako.template import Template
+    import os
+
+    for name, func in function_info.items():
+        path_o = join(output_dir, output_format % func['snake_name'])
+        if os.path.exists(path_o):
+            continue
+        # Create the skelton file of Backward Function Class
+        generated = render_with_template(
+            filename=template, template_kwargs=dict(function_name=name))
+        check_update(path_o, generated, force=False)

--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -509,3 +509,6 @@ GatherNd:
 ScatterNd:
   float: [float]
   half: [Half]
+MaxPoolingBackward:
+  float: [float]
+  half: [Half]

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -15,10 +15,11 @@ Neural Network Layer:
           D_B \times ... \times D_N`). Dimensions before and after base_axis are flattened
           as if it is a matrix.
       weight:
-        doc: Weight matrix with shape (:math:`(D_B \times ... \times D_N) \times L`)
+        doc: Weight matrix with shape (:math:`(D_B \times ... \times D_N) \times L_{0}
+          \times \ldots \times L_{I}`)
         parameter: true
       bias:
-        doc: Bias vector (:math:`L`)
+        doc: Bias vector (:math:`L_{0} \times \ldots \times L_{I}`)
         optional: true
         parameter: true
     arguments:
@@ -30,7 +31,7 @@ Neural Network Layer:
     outputs:
       y:
         doc: :math:`(B + 1)`-D array. (:math:`M_0 \times ... \times M_{B-1} \times
-          L`)
+          L_{0} \times \ldots \times L_{I}`)
     function_ids:
       i: 0
     c_runtime: support

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -5563,3 +5563,42 @@ Unsupported, Special Use:
     function_ids:
       ffB: 231
     c_runtime: not support
+  MaxPoolingBackward:
+    snake_name: max_pooling_backward
+    doc: |2
+
+      Max pooling backward. This is tentative and temporal solution to support the double backward of 
+      the max pooling. The document of this function must not be shown.
+    inputs:
+      x:
+        doc: Input variable.
+      dy:
+        doc: Input variable.
+    arguments:
+      kernel:
+        doc: Kernel sizes for each spatial axis.
+        type: Shape
+      stride:
+        doc: Subsampling factors for each spatial axis.
+        type: Shape
+        default: kernel
+      ignore_border:
+        doc: If false, kernels covering borders are also considered for the output.
+        type: bool
+        default: 'True'
+      pad:
+        doc: Border padding values for each spatial axis. Padding will be added both
+          sides of the dimension.
+        type: Shape
+        default: (0,) * len(kernel)
+      channel_last:
+        doc: If True, the last dimension is considered as channel dimension, a.k.a
+          NHWC order.
+        type: bool
+        default: 'False'
+    outputs:
+      dx:
+        doc: Output
+    c_runtime: not support
+    function_ids:
+      iIiIBiIB: 272

--- a/build-tools/code_generator/generate.py
+++ b/build-tools/code_generator/generate.py
@@ -189,6 +189,12 @@ def generate_function_cpp_interface(function_info):
     utils.generate_from_template(
         join(base, 'src/nbla/functions.cpp.tmpl'), function_info=function_info, function_list=function_list)
 
+def generate_backward_function_mapping(function_info):
+    function_list = utils.info_to_list(function_info)
+    utils.generate_from_template(
+        join(base, 'python/src/nnabla/backward_functions.py.tmpl'),
+        function_info=function_info, function_list=function_list)
+
 def generate():
     version = sys.argv[1]
     update_function_order_in_functsions_yaml()
@@ -210,6 +216,7 @@ def generate():
     generate_proto(function_info, solver_info)
     generate_cpp_utils(function_info)
     generate_function_cpp_interface(function_info)
+    generate_backward_function_mapping(function_info)
 
     # Generate function skeletons if new ones are added to functions.yaml and function_types.yaml.
     utils.generate_skeleton_function_impl(
@@ -220,6 +227,13 @@ def generate():
     utils.generate_skeleton_function_impl(
         function_info, function_types,
         template=func_header_template, output_format='%s.hpp')
+
+    # Generate backward function skeletons if new ones are added to functions.yaml
+    utils.generate_skeleton_backward_function_impl(function_info,
+                                                   join(base,
+                                                        'python/src/nnabla/backward_function_class.py.tmpl'),
+                                                   join(base,
+                                                        'python/src/nnabla/backward_function'))
 
     # TODO: solver skeleton generation
 

--- a/doc/python/api.rst
+++ b/doc/python/api.rst
@@ -12,6 +12,7 @@ Python API Reference
     api/variable
     api/function
     api/parametric_function
+    api/grad
     api/solver
     api/communicator
     api/monitor

--- a/doc/python/api/grad.rst
+++ b/doc/python/api/grad.rst
@@ -1,0 +1,6 @@
+Grad
+====
+
+.. automodule:: nnabla.grad
+
+.. autofunction:: nnabla.grad.grad

--- a/include/nbla/function/max_pooling_backward.hpp
+++ b/include/nbla/function/max_pooling_backward.hpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_MAX_POOLING_BACKWARD_HPP
+#define NBLA_FUNCTION_MAX_POOLING_BACKWARD_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(MaxPoolingBackward, const vector<int> &,
+                              const vector<int> &, bool, const vector<int> &,
+                              bool);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class MaxPoolingBackward
+    : public BaseFunction<const vector<int> &, const vector<int> &, bool,
+                          const vector<int> &, bool> {
+protected:
+  const vector<int> kernel_;
+  const vector<int> stride_;
+  bool ignore_border_;
+  const vector<int> pad_;
+  bool channel_last_;
+
+public:
+  MaxPoolingBackward(const Context &ctx, const vector<int> &kernel,
+                     const vector<int> &stride, bool ignore_border,
+                     const vector<int> &pad, bool channel_last)
+      : BaseFunction(ctx, kernel, stride, ignore_border, pad, channel_last),
+        kernel_(kernel), stride_(stride), ignore_border_(ignore_border),
+        pad_(pad), channel_last_(channel_last) {}
+  virtual ~MaxPoolingBackward() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_MaxPoolingBackward(ctx_, kernel_, stride_, ignore_border_,
+                                     pad_, channel_last_);
+  }
+  virtual int min_inputs() { return 2; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "MaxPoolingBackward"; }
+  // TODO: This must be overridden if any of input grad depends on a output
+  // data. See doc in function.hpp.
+  // virtual bool grad_depends_output_data(int i, int o) const {
+  // }
+  // TODO: If any of data/grad storage is inplaced with any of output, you must
+  // override some of these. See doc in function.hpp.
+  // virtual int inplace_data(int i) const {
+  // }
+  // virtual int inplace_data_with(int i) const {
+  // }
+  // virtual int inplace_grad(int i) const {
+  // }
+  // virtual int inplace_grad_with(int i) const {
+  // }
+  // TODO: If you want to avoid clearing input buffers in any case, define this
+  // function returning true.
+  // virtual bool prohibit_clear_input_buffers() const {
+  //   return true;
+  // }
+  // TODO: If you want to avoid zero-ing gradient of inputs even when accum is
+  // true, uncomment the following function definition.
+  // virtual bool prohibit_zero_input_grad() const {
+  //   return true;
+  // }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/python/setup.py
+++ b/python/setup.py
@@ -255,6 +255,7 @@ if __name__ == '__main__':
                 'nnabla.utils.converter.tensorflow',
                 'nnabla.utils.factorization',
                 'nnabla.utils.image_utils',
+                'nnabla.backward_function',
                 'nnabla_ext',
                 'nnabla_ext.cpu', ]
 

--- a/python/src/nnabla/__init__.py
+++ b/python/src/nnabla/__init__.py
@@ -38,6 +38,7 @@ from .context import (
     context_scope, set_default_context, get_current_context)
 from .auto_forward import auto_forward, set_auto_forward, get_auto_forward
 from._computation_graph import forward_all
+from .grad import grad
 
 # Prefer cached array by default for performance.
 prefer_cached_array(True)

--- a/python/src/nnabla/backward_function/__init__.py
+++ b/python/src/nnabla/backward_function/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/python/src/nnabla/backward_function/abs.py
+++ b/python/src/nnabla/backward_function/abs.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class AbsBackward(BackwardFunction):
+
+    def name(self):
+        return 'AbsBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/absolute_error.py
+++ b/python/src/nnabla/backward_function/absolute_error.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class AbsoluteErrorBackward(BackwardFunction):
+
+    def name(self):
+        return 'AbsoluteErrorBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[2]:
+            sign = F.sign(x0 - x1, 1.0)
+            if accum[2]:
+                g_dy += sign * (g_dx0 - g_dx1)
+            else:
+                g_dy.copy_from(sign * (g_dx0 - g_dx1))

--- a/python/src/nnabla/backward_function/acos.py
+++ b/python/src/nnabla/backward_function/acos.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ACosBackward(BackwardFunction):
+
+    def name(self):
+        return 'ACosBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ACosBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/acosh.py
+++ b/python/src/nnabla/backward_function/acosh.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ACoshBackward(BackwardFunction):
+
+    def name(self):
+        return 'ACoshBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ACoshBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/add2.py
+++ b/python/src/nnabla/backward_function/add2.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Add2Backward(BackwardFunction):
+
+    def name(self):
+        return 'Add2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[2]:
+            if accum[2]:
+                g_dy += g_dx0 + g_dx1
+            else:
+                g_dy.copy_from(g_dx0 + g_dx1)

--- a/python/src/nnabla/backward_function/add_scalar.py
+++ b/python/src/nnabla/backward_function/add_scalar.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class AddScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'AddScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0
+            else:
+                g_dy.copy_from(g_dx0)

--- a/python/src/nnabla/backward_function/affine.py
+++ b/python/src/nnabla/backward_function/affine.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class AffineBackward(BackwardFunction):
+
+    def name(self):
+        return 'AffineBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        with_bias = True if len(inputs) == 4 else False
+        base_axis = self.forward_func.info.args["base_axis"]
+
+        # Inputs
+        x0 = inputs[0].data
+        w0 = inputs[1].data
+        b0 = inputs[2].data if with_bias else None
+        dy = inputs[3].data if with_bias else inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dw0 = outputs[1].data
+        db0 = outputs[2].data if with_bias else None
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_w0 = inputs[1].grad
+        g_b0 = inputs[2].grad if with_bias else None
+        g_dy = inputs[3].grad if with_bias else inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dw0 = outputs[1].grad
+        g_db0 = outputs[2].grad if with_bias else None
+
+        # Computation
+        ## w.r.t. x or w.r.t. w
+        if prop_down[0] or prop_down[1]:
+            # we can re-use the backward of the forward with different inputs
+            inp_x = nn.Variable(x0.shape).apply(
+                data=g_dx0, grad=g_x0, need_grad=prop_down[0])
+            inp_w = nn.Variable(w0.shape).apply(
+                data=g_dw0, grad=g_w0, need_grad=prop_down[1])
+            out_y = nn.Variable(dy.shape).apply(grad=dy)
+            inputs = [inp_x, inp_w]
+            outputs = [out_y]
+            if with_bias:
+                inp_b = nn.Variable(b0.shape).apply(need_grad=False)
+                inputs += [inp_b]
+            self.forward_func.backward(inputs, outputs, accum)
+        ## w.r.t. b
+        if with_bias and prop_down[2] and not accum[2]:
+            zeros = F.constant(0, b0.shape)
+            if not nn.get_auto_forward():
+                zeros.forward()
+            g_b0.copy_from(zeros.data)
+        ## w.r.t. dy
+        if (not with_bias and prop_down[2]) or (with_bias and prop_down[3]):
+            accum_dy = accum[3] if with_bias else accum[2]
+            g_dy_ = F.affine(g_dx0, w0, None, base_axis) + \
+                F.affine(x0, g_dw0, None, base_axis)
+            if with_bias:
+                nshape = [1] * base_axis + list(b0.shape)
+                g_db0 = F.reshape(g_db0, nshape)
+                g_dy_ += g_db0
+            if accum_dy:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/arange.py
+++ b/python/src/nnabla/backward_function/arange.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ArangeBackward(BackwardFunction):
+
+    def name(self):
+        return 'ArangeBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ArangeBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/asin.py
+++ b/python/src/nnabla/backward_function/asin.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ASinBackward(BackwardFunction):
+
+    def name(self):
+        return 'ASinBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ASinBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/asinh.py
+++ b/python/src/nnabla/backward_function/asinh.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ASinhBackward(BackwardFunction):
+
+    def name(self):
+        return 'ASinhBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ASinhBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/assign.py
+++ b/python/src/nnabla/backward_function/assign.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class AssignBackward(BackwardFunction):
+
+    def name(self):
+        return 'AssignBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of AssignBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/atan.py
+++ b/python/src/nnabla/backward_function/atan.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ATanBackward(BackwardFunction):
+
+    def name(self):
+        return 'ATanBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ATanBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/atan2.py
+++ b/python/src/nnabla/backward_function/atan2.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ATan2Backward(BackwardFunction):
+
+    def name(self):
+        return 'ATan2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ATan2Backward class is not implemented.")

--- a/python/src/nnabla/backward_function/atanh.py
+++ b/python/src/nnabla/backward_function/atanh.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ATanhBackward(BackwardFunction):
+
+    def name(self):
+        return 'ATanhBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ATanhBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/average_pooling.py
+++ b/python/src/nnabla/backward_function/average_pooling.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class AveragePoolingBackward(BackwardFunction):
+
+    def name(self):
+        return 'AveragePoolingBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        kernel = self.forward_func.info.args["kernel"]
+        stride = self.forward_func.info.args["stride"]
+        ignore_border = self.forward_func.info.args["ignore_border"]
+        pad = self.forward_func.info.args["pad"]
+        channel_last = self.forward_func.info.args["channel_last"]
+        including_pad = self.forward_func.info.args["including_pad"]
+
+        # TODO: BHWC
+        assert channel_last == False, "`channel_last = False` is only supported now."
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.average_pooling(g_dx0, kernel, stride, ignore_border, pad,
+                                      channel_last, including_pad)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/backward_function.py
+++ b/python/src/nnabla/backward_function/backward_function.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nnabla.function import PythonFunction
+
+
+class BackwardFunction(PythonFunction):
+    """Parent class for the backward functions.
+    """
+
+    def __init__(self):
+        self._num_inputs = 0
+        self._num_outputs = 0
+        self._num_inputs_fwd = 0
+        self._num_outputs_fwd = 0
+
+    def set_num_inputs_and_outputs(self, num_inputs, num_outputs, num_inputs_fwd, num_outputs_fwd):
+        self._num_inputs = num_inputs
+        self._num_outputs = num_outputs
+        self._num_inputs_fwd = num_inputs_fwd
+        self._num_outputs_fwd = num_outputs_fwd
+
+    def set_forward_function(self, f):
+        self.forward_func = f
+
+    def min_inputs(self):
+        return self._num_inputs
+
+    def min_outputs(self):
+        return self._num_outputs
+
+    def setup_impl(self, inputs, outputs):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Reset shape of outputs
+        for i in range(self._num_inputs_fwd):
+            inp = inputs[i]
+            out = outputs[i]
+            out.reset_shape(inp.shape, True)
+
+    def forward_impl(self, inputs, outputs):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        inputs_fwd, outputs_fwd = self._create_forward_inputs_and_outputs(
+            inputs, outputs)
+        self.forward_func.backward(inputs_fwd, outputs_fwd, accum=[
+                                   False] * self._num_inputs_fwd)

--- a/python/src/nnabla/backward_function/batch_matmul.py
+++ b/python/src/nnabla/backward_function/batch_matmul.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BatchMatmulBackward(BackwardFunction):
+
+    def name(self):
+        return 'BatchMatmulBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        transpose_a = self.forward_func.info.args["transpose_a"]
+        transpose_b = self.forward_func.info.args["transpose_b"]
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[0]:
+            # condition
+            if (transpose_a, transpose_b) == (True, True):
+                g_x0_ = F.batch_matmul(g_dx1, dy, True, True)
+            if (transpose_a, transpose_b) == (True, False):
+                g_x0_ = F.batch_matmul(g_dx1, dy, False, True)
+            if (transpose_a, transpose_b) == (False, True):
+                g_x0_ = F.batch_matmul(dy, g_dx1, False, False)
+            if (transpose_a, transpose_b) == (False, False):
+                g_x0_ = F.batch_matmul(dy, g_dx1, False, True)
+            # reshape for batch axes
+            if g_x0_.shape != g_x0.shape:
+                g_x0_ = F.reshape(g_x0_, g_x0.shape)
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+        if prop_down[1]:
+            # condition
+            if (transpose_a, transpose_b) == (True, True):
+                g_x1_ = F.batch_matmul(dy, g_dx0, True, True)
+            if (transpose_a, transpose_b) == (True, False):
+                g_x1_ = F.batch_matmul(g_dx0, dy, False, False)
+            if (transpose_a, transpose_b) == (False, True):
+                g_x1_ = F.batch_matmul(dy, g_dx0, True, False)
+            if (transpose_a, transpose_b) == (False, False):
+                g_x1_ = F.batch_matmul(g_dx0, dy, True, False)
+            # reshape for batch axes
+            if g_x1_.shape != g_x1.shape:
+                g_x1_ = F.reshape(g_x1_, g_x1.shape)
+            if accum[1]:
+                g_x1 += g_x1_
+            else:
+                g_x1.copy_from(g_x1_)
+        if prop_down[2]:
+            t1 = F.batch_matmul(g_dx0, x1, transpose_a, transpose_b)
+            t2 = F.batch_matmul(x0, g_dx1, transpose_a, transpose_b)
+            g_dy_ = t1 + t2
+            if accum[2]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/batch_normalization.py
+++ b/python/src/nnabla/backward_function/batch_normalization.py
@@ -1,0 +1,236 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BatchNormalizationBackward(BackwardFunction):
+
+    def name(self):
+        return 'BatchNormalizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+        self.inputs_fwd, self.outputs_fwd = self._create_forward_inputs_and_outputs(
+            inputs, outputs)
+        self.forward_func.backward(self.inputs_fwd, self.outputs_fwd, accum=[
+                                   False] * self._num_inputs_fwd)
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # TOOD: output_stat (can not be obtained by self.forward_func.info.args["batch_stat"])
+
+        batch_stat = self.forward_func.info.args["batch_stat"]
+        if batch_stat:
+            self.backward_impl_for_batch(inputs, outputs, prop_down, accum)
+        else:
+            self.backward_impl_global(inputs, outputs, prop_down, accum)
+
+    def backward_impl_global(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axes = self.forward_func.info.args["axes"]
+        decay_rate = self.forward_func.info.args["decay_rate"]
+        eps = self.forward_func.info.args["eps"]
+
+        # TODO: factorize more
+        # Inputs
+        x0 = inputs[0].data  # input
+        b0 = inputs[1].data  # beta
+        g0 = inputs[2].data  # gamma
+        rm = inputs[3].data  # running mean
+        rv = inputs[4].data  # running variance
+        dy = inputs[5].data  # grad input
+        # Outputs
+        dx0 = outputs[0].data
+        db0 = outputs[1].data
+        dg0 = outputs[2].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_b0 = inputs[1].grad
+        g_g0 = inputs[2].grad
+        g_rm = inputs[3].grad
+        g_rv = inputs[4].grad
+        g_dy = inputs[5].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_db0 = outputs[1].grad
+        g_dg0 = outputs[2].grad
+
+        # Prerequisite
+        # axes reduced and denominator
+        axes0 = [a for a in range(x0.ndim)]
+        axes = list(set(axes0) - set(axes))
+        # (variance + eps) * (-1/2)
+        v_eps_rsqrt1 = (rv + eps) ** (-1.0 / 2.0)
+
+        # w.r.t. x
+        if prop_down[0]:
+            g_x0_ = g_dg0 * dy * v_eps_rsqrt1
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+
+        # w.r.t. beta
+        # zero, do nothing
+
+        # w.r.t. gamma
+        if prop_down[2]:
+            g_g0_ = F.sum(g_dx0 * dy * v_eps_rsqrt1, axes, True)
+            if accum[2]:
+                g_g0 += g_g0_
+            else:
+                g_g0.copy_from(g_g0_)
+
+        # no backward w.r.t. rm and rv
+
+        # w.r.t. dy
+        if prop_down[5]:
+            g_dy_ = g_dx0 * g0 * v_eps_rsqrt1 + \
+                g_dg0 * (x0 - rm) * v_eps_rsqrt1 + g_db0
+            if accum[5]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)
+
+    def backward_impl_for_batch(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axes = self.forward_func.info.args["axes"]
+        decay_rate = self.forward_func.info.args["decay_rate"]
+        eps = self.forward_func.info.args["eps"]
+
+        # TODO: factorize more
+        # Inputs
+        x0 = inputs[0].data  # input
+        b0 = inputs[1].data  # beta
+        g0 = inputs[2].data  # gamma
+        rm = inputs[3].data  # running mean
+        rv = inputs[4].data  # running variance
+        dy = inputs[5].data  # grad input
+        # Outputs
+        dx0 = outputs[0].data
+        db0 = outputs[1].data
+        dg0 = outputs[2].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_b0 = inputs[1].grad
+        g_g0 = inputs[2].grad
+        g_rm = inputs[3].grad
+        g_rv = inputs[4].grad
+        g_dy = inputs[5].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_db0 = outputs[1].grad
+        g_dg0 = outputs[2].grad
+
+        # Prerequisite
+        # axes reduced and denominator
+        axes0 = [a for a in range(x0.ndim)]
+        axes = list(set(axes0) - set(axes))
+        de = np.prod([x0.shape[a] for a in axes])        # denominator
+        bm = F.mean(x0, axes, True)                      # batch mean
+        bv = F.mean(x0 ** 2.0, axes, True) - bm ** 2.0   # batch variance
+        x0_bm = x0 - bm                                  # x0 - batch mean
+        # (variance + eps) * (-1)
+        v_eps_r1 = (bv + eps) ** -1.0
+        # (variance + eps) * (-1/2)
+        v_eps_rsqrt1 = (bv + eps) ** (-1.0 / 2.0)
+        # (variance + eps) * (-3/2)
+        v_eps_rsqrt3 = v_eps_rsqrt1 ** 3.0
+
+        # common factors
+        if prop_down[0] or prop_down[2]:
+            dy_x0_bm_sum = F.sum(dy * x0_bm, axes, True)
+            dy_sum = F.sum(dy, axes, True)
+        if prop_down[0] or prop_down[5]:
+            g_dx0_x0_bm_sum = F.sum(g_dx0 * x0_bm, axes, True)
+            g_dx0_sum = F.sum(g_dx0, axes, True)
+
+        # w.r.t. x
+        if prop_down[0]:
+            # from dx
+            dv = (-1.0 / 2.0) * g0 * v_eps_rsqrt3 * \
+                  F.sum(dy * x0_bm, axes, True)
+            g_dx0_dy_sum = F.sum(g_dx0 * dy, axes, True)
+
+            g1 = (-1.0 / de) * v_eps_rsqrt3 * g_dx0_dy_sum * g0 * x0_bm
+            g2 = (1.0 / de) * g0 * g_dx0_x0_bm_sum * v_eps_rsqrt3 * (1.0 / de * dy_sum - dy
+                                                                     + (3.0 / de) * v_eps_r1 * dy_x0_bm_sum * x0_bm)
+            g2 += (2.0 / de) * dv * (g_dx0 - (1.0 / de) * g_dx0_sum)
+            g3 = (1.0 / de ** 2.0) * g_dx0_sum * \
+                dy_sum * g0 * v_eps_rsqrt3 * x0_bm
+
+            g_x0_ = g1 + g2 + g3
+
+            # from gamma
+            t1 = (dy - dy_sum / de) * v_eps_rsqrt1
+            t2 = (- 1.0 / de) * dy_x0_bm_sum * v_eps_rsqrt3 * x0_bm
+            g_x0_ += g_dg0 * (t1 + t2)
+
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+
+        # w.r.t. beta
+        # zero, do nothing
+
+        # w.r.t. gamma
+        if prop_down[2]:
+            t1 = dy * v_eps_rsqrt1
+            t2 = (- 1.0 / de) * dy_x0_bm_sum * v_eps_rsqrt3 * x0_bm
+            t3 = (- 1.0 / de) * dy_sum * v_eps_rsqrt1
+            g_g0_ = F.sum(g_dx0 * (t1 + t2 + t3), axes, True)
+            if accum[2]:
+                g_g0 += g_g0_
+            else:
+                g_g0.copy_from(g_g0_)
+
+        # no backward w.r.t. rm and rv
+
+        # w.r.t. dy
+        if prop_down[5]:
+            t1 = g_dx0 * g0 * v_eps_rsqrt1
+            t2 = - (1.0 / de) * g0 * v_eps_rsqrt3 * g_dx0_x0_bm_sum * x0_bm
+            t3 = - (1.0 / de) * g0 * v_eps_rsqrt1 * g_dx0_sum
+            x0_hat = x0_bm * v_eps_rsqrt1
+            g_dy_ = (t1 + t2 + t3) + g_dg0 * x0_hat + g_db0
+            if accum[5]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/bc_add2.py
+++ b/python/src/nnabla/backward_function/bc_add2.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BcAdd2Backward(BackwardFunction):
+
+    def name(self):
+        return 'BcAdd2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BcAdd2Backward class is not implemented.")

--- a/python/src/nnabla/backward_function/binary_connect_affine.py
+++ b/python/src/nnabla/backward_function/binary_connect_affine.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinaryConnectAffineBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinaryConnectAffineBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BinaryConnectAffineBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/binary_connect_convolution.py
+++ b/python/src/nnabla/backward_function/binary_connect_convolution.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinaryConnectConvolutionBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinaryConnectConvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BinaryConnectConvolutionBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/binary_cross_entropy.py
+++ b/python/src/nnabla/backward_function/binary_cross_entropy.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinaryCrossEntropyBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinaryCrossEntropyBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        #raise NotImplementedError("The backward method of BinaryCrossEntropyBackward class is not implemented.")
+
+        # Inputs
+        x0 = inputs[0].data  # probabilities
+        t0 = inputs[1].data  # labels
+        dz = inputs[2].data  # grad_input
+        # Outputs
+        dx0 = outputs[0].data
+        dt0 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_t0 = inputs[1].grad
+        g_dz = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dt0 = outputs[1].grad
+
+        # Computation
+        ## w.r.t. x0
+        if prop_down[0]:
+            u0 = g_dx0 * (t0 / x0 ** 2.0 + (1.0 - t0) / (1 - x0) ** 2.0)
+            u1 = g_dt0 / (x0 * (1.0 - x0))
+            g_x0_ = dz * (u0 - u1)
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+
+        ## w.r.t. t0
+        if prop_down[1]:
+            #g_t0_ = g_dx0 * dz * (1.0 / x0 + 1.0 / (1.0 - x0))
+            g_t0_ = g_dx0 * dz / (x0 * (1.0 - x0))
+            if accum[1]:
+                g_t0 -= g_t0_
+            else:
+                g_t0.copy_from(-g_t0_)
+
+        ## w.r.t. dz
+        if prop_down[2]:
+            #u0 = g_dx0 * ((1.0 - t0) / (1.0 - x0) - t0 / x0)
+            u0 = g_dx0 * (x0 - t0) / (x0 * (1.0 - x0))
+            u1 = g_dt0 * (F.log(1.0 - x0) - F.log(x0))
+            g_dz_ = u0 + u1
+            if accum[2]:
+                g_dz += g_dz_
+            else:
+                g_dz.copy_from(g_dz_)

--- a/python/src/nnabla/backward_function/binary_error.py
+++ b/python/src/nnabla/backward_function/binary_error.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinaryErrorBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinaryErrorBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BinaryErrorBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/binary_sigmoid.py
+++ b/python/src/nnabla/backward_function/binary_sigmoid.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinarySigmoidBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinarySigmoidBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BinarySigmoidBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/binary_tanh.py
+++ b/python/src/nnabla/backward_function/binary_tanh.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinaryTanhBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinaryTanhBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BinaryTanhBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/binary_weight_affine.py
+++ b/python/src/nnabla/backward_function/binary_weight_affine.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinaryWeightAffineBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinaryWeightAffineBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BinaryWeightAffineBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/binary_weight_convolution.py
+++ b/python/src/nnabla/backward_function/binary_weight_convolution.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BinaryWeightConvolutionBackward(BackwardFunction):
+
+    def name(self):
+        return 'BinaryWeightConvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BinaryWeightConvolutionBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/broadcast.py
+++ b/python/src/nnabla/backward_function/broadcast.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BroadcastBackward(BackwardFunction):
+
+    def name(self):
+        return 'BroadcastBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        shape = self.forward_func.info.args["shape"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.broadcast(g_dx0, shape)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/broadcast_to.py
+++ b/python/src/nnabla/backward_function/broadcast_to.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class BroadcastToBackward(BackwardFunction):
+
+    def name(self):
+        return 'BroadcastToBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of BroadcastToBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/categorical_cross_entropy.py
+++ b/python/src/nnabla/backward_function/categorical_cross_entropy.py
@@ -1,0 +1,73 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class CategoricalCrossEntropyBackward(BackwardFunction):
+
+    def name(self):
+        return 'CategoricalCrossEntropyBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axis = self.forward_func.info.args["axis"]
+
+        # Inputs
+        y0 = inputs[0].data
+        dz = inputs[2].data
+        # Outputs
+        dy0 = outputs[0].data
+        # Grads of inputs
+        g_y0 = inputs[0].grad
+        g_dz = inputs[2].grad
+        # Grads of outputs
+        g_dy0 = outputs[0].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                g_y0 += g_dy0 * dz * F.pow_scalar(y0, -2.0)
+            else:
+                g_y0.copy_from(g_dy0 * dz * F.pow_scalar(y0, -2.0))
+        if prop_down[2]:
+            if accum[2]:
+                g_dz -= F.sum(g_dy0 * F.pow_scalar(y0, -1.0), axis, True)
+            else:
+                g_dz.copy_from(- F.sum(g_dy0 *
+                                       F.pow_scalar(y0, -1.0), axis, True))

--- a/python/src/nnabla/backward_function/ceil.py
+++ b/python/src/nnabla/backward_function/ceil.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class CeilBackward(BackwardFunction):
+
+    def name(self):
+        return 'CeilBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0
+            else:
+                g_dy.copy_from(g_dx0)

--- a/python/src/nnabla/backward_function/celu.py
+++ b/python/src/nnabla/backward_function/celu.py
@@ -1,0 +1,96 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class CELUBackward(BackwardFunction):
+
+    def name(self):
+        return 'CELUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of CELUBackward class is not implemented.")
+
+        # Args
+        ## alpha = self.forward_func.info.args["alpha"]
+        ## axis = self.forward_func.info.args["axis"]
+
+        # Inputs
+        ## x0 = inputs[0].data
+        ## dy = inputs[1].data
+        # Outputs
+        ## dx0 = outputs[0].data
+        # Grads of inputs
+        ## g_x0 = inputs[0].grad
+        ## g_dy = inputs[1].grad
+        # Grads of outputs
+        ## g_dx0 = outputs[0].grad
+
+        # Computation
+        # if prop_down[0]:
+        # Slice the corresponding tensors
+        ##     s0 = [0 for _ in range(dy.ndim)]
+        ##     s1 = [d for d in dy.shape]
+        ##     s2 = [1 for _ in range(dy.ndim)]
+        ##     sp = [d // 2 if i == axis else d for i, d in enumerate(dy.shape)]
+        ##     sn = [d // 2 if i == axis else 0 for i, d in enumerate(dy.shape)]
+        ##     dy_p = F.slice(dy, s0, sp, s2)
+        ##     dy_n = F.slice(dy, sn, s1, s2)
+        # Mask for the corresponding tensor
+        ##     mask = F.less_equal_scalar(x0, 0.0)
+
+        ##     g_x0_ = g_dx0 * mask * alpha * (dy_p * F.exp(x0) + dy_n * F.exp(-x0))
+        # if accum[0]:
+        ##         g_x0.copy_from(g_x0 + g_x0_)
+        # else:
+        # g_x0.copy_from(g_x0_)
+        # if prop_down[1]:
+        # Mask for the corresponding tensors
+        ##     mask_p = F.greater_scalar(x0, 0.0)
+        ##     mask_n = 1.0 - mask_p
+        # w.r.t. dy_p and dy_n
+        ##     g_dy_p = g_dx0 * (mask_p + mask_n * alpha * F.exp(x0))
+        ##     g_dy_n = - g_dx0 * (mask_p + mask_n * alpha * F.exp(-x0))
+        # Concatenate
+        ##     g_dy_ = F.concatenate(*[g_dy_p, g_dy_n], axis=axis)
+        # if accum[1]:
+        ##         g_dy.copy_from(g_dy + g_dy_)
+        # else:
+        # g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/clip_grad_by_norm.py
+++ b/python/src/nnabla/backward_function/clip_grad_by_norm.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ClipGradByNormBackward(BackwardFunction):
+
+    def name(self):
+        return 'ClipGradByNormBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ClipGradByNormBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/clip_grad_by_value.py
+++ b/python/src/nnabla/backward_function/clip_grad_by_value.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ClipGradByValueBackward(BackwardFunction):
+
+    def name(self):
+        return 'ClipGradByValueBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ClipGradByValueBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/concatenate.py
+++ b/python/src/nnabla/backward_function/concatenate.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ConcatenateBackward(BackwardFunction):
+
+    def name(self):
+        return 'ConcatenateBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axis = self.forward_func.info.args["axis"]
+
+        # Compute
+        ## w.r.t. dy
+        if prop_down[-1]:
+            g_dy = inputs[-1].grad
+            g_dy_ = F.concatenate(*[o.grad for o in outputs], axis=axis)
+            if accum[-1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/confusion_matrix.py
+++ b/python/src/nnabla/backward_function/confusion_matrix.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ConfusionMatrixBackward(BackwardFunction):
+
+    def name(self):
+        return 'ConfusionMatrixBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ConfusionMatrixBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/constant.py
+++ b/python/src/nnabla/backward_function/constant.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ConstantBackward(BackwardFunction):
+
+    def name(self):
+        return 'ConstantBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+        pass

--- a/python/src/nnabla/backward_function/convolution.py
+++ b/python/src/nnabla/backward_function/convolution.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ConvolutionBackward(BackwardFunction):
+
+    def name(self):
+        return 'ConvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        with_bias = True if len(inputs) == 4 else False
+        base_axis = self.forward_func.info.args["base_axis"]
+        pad = self.forward_func.info.args["pad"]
+        stride = self.forward_func.info.args["stride"]
+        dilation = self.forward_func.info.args["dilation"]
+        group = self.forward_func.info.args["group"]
+        channel_last = self.forward_func.info.args["channel_last"]
+        # TODO: BHWC
+        assert channel_last == False, "`channel_last = False` is only supported now."
+
+        # Inputs
+        x0 = inputs[0].data
+        w0 = inputs[1].data
+        b0 = inputs[2].data if with_bias else None
+        dy = inputs[3].data if with_bias else inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dw0 = outputs[1].data
+        db0 = outputs[2].data if with_bias else None
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_w0 = inputs[1].grad
+        g_b0 = inputs[2].grad if with_bias else None
+        g_dy = inputs[3].grad if with_bias else inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dw0 = outputs[1].grad
+        g_db0 = outputs[2].grad if with_bias else None
+
+        # Computation
+        ## w.r.t. x or w.r.t. w
+        if prop_down[0] or prop_down[1]:
+            # we can re-use the backward of the forward with different inputs
+            inp_x = nn.Variable(x0.shape).apply(
+                data=g_dx0, grad=g_x0, need_grad=prop_down[0])
+            inp_w = nn.Variable(w0.shape).apply(
+                data=g_dw0, grad=g_w0, need_grad=prop_down[1])
+            out_y = nn.Variable(dy.shape).apply(grad=dy)
+            inputs = [inp_x, inp_w]
+            outputs = [out_y]
+            if with_bias:
+                inp_b = nn.Variable(b0.shape).apply(need_grad=False)
+                inputs += [inp_b]
+            self.forward_func.backward(inputs, outputs, accum)
+        ## w.r.t. b
+        if with_bias and prop_down[2] and not accum[2]:
+            zeros = F.constant(0, b0.shape)
+            if not nn.get_auto_forward():
+                zeros.forward()
+            g_b0.copy_from(zeros.data)
+        ## w.r.t. dy
+        if (not with_bias and prop_down[2]) or (with_bias and prop_down[3]):
+            accum_dy = accum[3] if with_bias else accum[2]
+            g_dy_ = F.convolution(g_dx0, w0, None, base_axis, pad, stride, dilation, group, channel_last) \
+                + F.convolution(x0, g_dw0, None, base_axis, pad,
+                                stride, dilation, group, channel_last)
+            if with_bias:
+                g_db0 = F.reshape(
+                    g_db0, [1 if i != base_axis else g_db0.shape[0] for i in range(g_dy.ndim)])
+                g_dy_ += g_db0
+            if accum_dy:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/cos.py
+++ b/python/src/nnabla/backward_function/cos.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class CosBackward(BackwardFunction):
+
+    def name(self):
+        return 'CosBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of CosBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/cosh.py
+++ b/python/src/nnabla/backward_function/cosh.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class CoshBackward(BackwardFunction):
+
+    def name(self):
+        return 'CoshBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of CoshBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/crelu.py
+++ b/python/src/nnabla/backward_function/crelu.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class CReLUBackward(BackwardFunction):
+
+    def name(self):
+        return 'CReLUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        axis = self.forward_func.info.args["axis"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            maskp = F.greater_equal_scalar(x0, 0.0)
+            maskn = maskp - 1.0
+            g_dy_p = maskp * g_dx0
+            g_dy_n = maskn * g_dx0
+            g_dy_ = F.concatenate(*[g_dy_p, g_dy_n], axis=axis)
+            if accum[1]:
+                g_dy.copy_from(g_dy + g_dy_)
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/deconvolution.py
+++ b/python/src/nnabla/backward_function/deconvolution.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class DeconvolutionBackward(BackwardFunction):
+
+    def name(self):
+        return 'DeconvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        with_bias = True if len(inputs) == 4 else False
+        base_axis = self.forward_func.info.args["base_axis"]
+        pad = self.forward_func.info.args["pad"]
+        stride = self.forward_func.info.args["stride"]
+        dilation = self.forward_func.info.args["dilation"]
+        group = self.forward_func.info.args["group"]
+
+        # TODO: BHWC
+
+        # Inputs
+        x0 = inputs[0].data
+        w0 = inputs[1].data
+        b0 = inputs[2].data if with_bias else None
+        dy = inputs[3].data if with_bias else inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dw0 = outputs[1].data
+        db0 = outputs[2].data if with_bias else None
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_w0 = inputs[1].grad
+        g_b0 = inputs[2].grad if with_bias else None
+        g_dy = inputs[3].grad if with_bias else inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dw0 = outputs[1].grad
+        g_db0 = outputs[2].grad if with_bias else None
+
+        # Computation
+        ## w.r.t. x or w.r.t. w
+        if prop_down[0] or prop_down[1]:
+            # we can re-use the backward of the forward with different inputs
+            inp_x = nn.Variable(x0.shape).apply(
+                data=g_dx0, grad=g_x0, need_grad=prop_down[0])
+            inp_w = nn.Variable(w0.shape).apply(
+                data=g_dw0, grad=g_w0, need_grad=prop_down[1])
+            out_y = nn.Variable(dy.shape).apply(grad=dy)
+            inputs = [inp_x, inp_w]
+            outputs = [out_y]
+            if with_bias:
+                inp_b = nn.Variable(b0.shape).apply(need_grad=False)
+                inputs += [inp_b]
+            self.forward_func.backward(inputs, outputs, accum)
+        ## w.r.t. b
+        if with_bias and prop_down[2] and not accum[2]:
+            zeros = F.constant(0, b0.shape)
+            if not nn.get_auto_forward():
+                zeros.forward()
+            g_b0.copy_from(zeros.data)
+        ## w.r.t. dy
+        if (not with_bias and prop_down[2]) or (with_bias and prop_down[3]):
+            accum_dy = accum[3] if with_bias else accum[2]
+            g_dy_ = F.deconvolution(g_dx0, w0, None, base_axis, pad, stride, dilation, group) \
+                + F.deconvolution(x0, g_dw0, None, base_axis,
+                                  pad, stride, dilation, group)
+            if with_bias:
+                g_db0 = F.reshape(
+                    g_db0, [1 if i != base_axis else g_db0.shape[0] for i in range(g_dy.ndim)])
+                g_dy_ += g_db0
+            if accum_dy:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/depthwise_convolution.py
+++ b/python/src/nnabla/backward_function/depthwise_convolution.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class DepthwiseConvolutionBackward(BackwardFunction):
+
+    def name(self):
+        return 'DepthwiseConvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of DepthwiseConvolutionBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/depthwise_deconvolution.py
+++ b/python/src/nnabla/backward_function/depthwise_deconvolution.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class DepthwiseDeconvolutionBackward(BackwardFunction):
+
+    def name(self):
+        return 'DepthwiseDeconvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of DepthwiseDeconvolutionBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/div2.py
+++ b/python/src/nnabla/backward_function/div2.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Div2Backward(BackwardFunction):
+
+    def name(self):
+        return 'Div2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        x1_inv_square = F.pow_scalar(x1, -2.0)
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 -= g_dx1 * dy * x1_inv_square
+            else:
+                g_x0.copy_from(- g_dx1 * dy * x1_inv_square)
+        if prop_down[1]:
+            if accum[1]:
+                g_x1 += dy * (g_dx1 * 2 * x0 *
+                              F.pow_scalar(x1, -3.0) - g_dx0 * x1_inv_square)
+            else:
+                g_x1.copy_from(
+                    dy * (2 * g_dx1 * x0 * F.pow_scalar(x1, -3.0) - g_dx0 * x1_inv_square))
+        if prop_down[2]:
+            if accum[2]:
+                g_dy += g_dx0 / x1 - g_dx1 * x0 * x1_inv_square
+            else:
+                g_dy.copy_from(g_dx0 / x1 - g_dx1 * x0 * x1_inv_square)

--- a/python/src/nnabla/backward_function/dropout.py
+++ b/python/src/nnabla/backward_function/dropout.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class DropoutBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'DropoutBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        p = self.forward_func.info.args["p"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            # TODO: Optimize by creating dropout with mask
+            # dx0 is not accumulated in the backward graph
+            mask = F.not_equal_scalar(dx0, 0.0)
+            if accum[1]:
+                g_dy += g_dx0 * mask / (1.0 - p)
+            else:
+                g_dy.copy_from(g_dx0 * mask / (1.0 - p))

--- a/python/src/nnabla/backward_function/elu.py
+++ b/python/src/nnabla/backward_function/elu.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ELUBackward(BackwardFunction):
+
+    def name(self):
+        return 'ELUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        alpha = self.forward_func.info.args["alpha"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += g_dx0 * dx0 * F.less_equal_scalar(x0, 0.0)
+            else:
+                g_x0.copy_from(g_dx0 * dx0 * F.less_equal_scalar(x0, 0.0))
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/embed.py
+++ b/python/src/nnabla/backward_function/embed.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class EmbedBackward(BackwardFunction):
+
+    def name(self):
+        return 'EmbedBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        w0 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dw0 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_w0 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dw0 = outputs[1].grad
+
+        # Computation
+        if prop_down[2]:
+            g_dy_ = F.embed(x0, g_dw0)
+            if accum[2]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/epsilon_insensitive_loss.py
+++ b/python/src/nnabla/backward_function/epsilon_insensitive_loss.py
@@ -1,0 +1,77 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class EpsilonInsensitiveLossBackward(BackwardFunction):
+
+    def name(self):
+        return 'EpsilonInsensitiveLossBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        epsilon = self.forward_func.info.args["epsilon"]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[2]:
+            # Simply using " / dy" causes the numerical instability
+            diff = x0 - x1
+            mask = F.greater_scalar(F.abs(diff), epsilon)
+            maskp = F.greater_scalar(diff, 0.0)
+            maskn = 1.0 - maskp
+            g_dy_ = (g_dx0 - g_dx1) * (maskp - maskn) * mask
+            if accum[2]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/equal.py
+++ b/python/src/nnabla/backward_function/equal.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class EqualBackward(BackwardFunction):
+
+    def name(self):
+        return 'EqualBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of EqualBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/equal_scalar.py
+++ b/python/src/nnabla/backward_function/equal_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class EqualScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'EqualScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of EqualScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/exp.py
+++ b/python/src/nnabla/backward_function/exp.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ExpBackward(BackwardFunction):
+
+    def name(self):
+        return 'ExpBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += g_dx0 * dx0
+            else:
+                g_x0.copy_from(g_dx0 * dx0)
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0 * F.exp(x0)
+            else:
+                g_dy.copy_from(g_dx0 * F.exp(x0))

--- a/python/src/nnabla/backward_function/fft.py
+++ b/python/src/nnabla/backward_function/fft.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class FFTBackward(BackwardFunction):
+
+    def name(self):
+        return 'FFTBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of FFTBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/fixed_point_quantize.py
+++ b/python/src/nnabla/backward_function/fixed_point_quantize.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class FixedPointQuantizeBackward(BackwardFunction):
+
+    def name(self):
+        return 'FixedPointQuantizeBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of FixedPointQuantizeBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/flip.py
+++ b/python/src/nnabla/backward_function/flip.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class FlipBackward(BackwardFunction):
+
+    def name(self):
+        return 'FlipBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of FlipBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/floor.py
+++ b/python/src/nnabla/backward_function/floor.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class FloorBackward(BackwardFunction):
+
+    def name(self):
+        return 'FloorBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0
+            else:
+                g_dy.copy_from(g_dx0)

--- a/python/src/nnabla/backward_function/fused_batch_normalization.py
+++ b/python/src/nnabla/backward_function/fused_batch_normalization.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class FusedBatchNormalizationBackward(BackwardFunction):
+
+    def name(self):
+        return 'FusedBatchNormalizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        grad_depends_on_outputs = (
+            self._num_inputs != self._num_inputs_fwd + self._num_outputs_fwd)
+        if grad_depends_on_outputs:
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.data = inp.data
+                outputs_fwd += [v]
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + self._num_outputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.grad = inp.data
+                outputs_fwd += [v]
+        else:
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.grad = inp.data
+                outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of FusedBatchNormalizationBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/gather_nd.py
+++ b/python/src/nnabla/backward_function/gather_nd.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GatherNdBackward(BackwardFunction):
+
+    def name(self):
+        return 'GatherNdBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        grad_depends_on_outputs = (
+            self._num_inputs != self._num_inputs_fwd + self._num_outputs_fwd)
+        if grad_depends_on_outputs:
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.data = inp.data
+                outputs_fwd += [v]
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + self._num_outputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.grad = inp.data
+                outputs_fwd += [v]
+        else:
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.grad = inp.data
+                outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GatherNdBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/gelu.py
+++ b/python/src/nnabla/backward_function/gelu.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GELUBackward(BackwardFunction):
+
+    def name(self):
+        return 'GELUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GELUBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/global_average_pooling.py
+++ b/python/src/nnabla/backward_function/global_average_pooling.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GlobalAveragePoolingBackward(BackwardFunction):
+
+    def name(self):
+        return 'GlobalAveragePoolingBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GlobalAveragePoolingBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/greater.py
+++ b/python/src/nnabla/backward_function/greater.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GreaterBackward(BackwardFunction):
+
+    def name(self):
+        return 'GreaterBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GreaterBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/greater_equal.py
+++ b/python/src/nnabla/backward_function/greater_equal.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GreaterEqualBackward(BackwardFunction):
+
+    def name(self):
+        return 'GreaterEqualBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GreaterEqualBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/greater_equal_scalar.py
+++ b/python/src/nnabla/backward_function/greater_equal_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GreaterEqualScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'GreaterEqualScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GreaterEqualScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/greater_scalar.py
+++ b/python/src/nnabla/backward_function/greater_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GreaterScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'GreaterScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GreaterScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/gru.py
+++ b/python/src/nnabla/backward_function/gru.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GRUBackward(BackwardFunction):
+
+    def name(self):
+        return 'GRUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GRUBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/hard_sigmoid.py
+++ b/python/src/nnabla/backward_function/hard_sigmoid.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class HardSigmoidBackward(BackwardFunction):
+
+    def name(self):
+        return 'HardSigmoidBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/hard_tanh.py
+++ b/python/src/nnabla/backward_function/hard_tanh.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class HardTanhBackward(BackwardFunction):
+
+    def name(self):
+        return 'HardTanhBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/huber_loss.py
+++ b/python/src/nnabla/backward_function/huber_loss.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class HuberLossBackward(BackwardFunction):
+
+    def name(self):
+        return 'HuberLossBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        delta = self.forward_func.info.args["delta"]
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[0] or prop_down[1] or prop_down[2]:
+            mask = F.less_scalar(F.abs(x0 - x1), delta)
+
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += mask * 2 * dy * (g_dx0 - g_dx1)
+            else:
+                g_x0.copy_from(mask * 2 * dy * (g_dx0 - g_dx1))
+        if prop_down[1]:
+            if accum[1]:
+                g_x1 += mask * 2 * dy * (g_dx1 - g_dx0)
+            else:
+                g_x1.copy_from(mask * 2 * dy * (g_dx1 - g_dx0))
+        if prop_down[2]:
+            # Simply using " / dy" causes the numerical instability
+            diff = x0 - x1
+            pmask = F.greater_scalar(diff, 0.0)
+            nmask = (1.0 - pmask)
+            omask = (1.0 - mask)
+            g_dx_diff = g_dx0 - g_dx1
+            g_dy_ = 2.0 * g_dx_diff * \
+                (diff * mask + delta * omask * (pmask - nmask))
+            if accum[2]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/identity.py
+++ b/python/src/nnabla/backward_function/identity.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class IdentityBackward(BackwardFunction):
+
+    def name(self):
+        return 'IdentityBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0
+            else:
+                g_dy.copy_from(g_dx0)

--- a/python/src/nnabla/backward_function/ifft.py
+++ b/python/src/nnabla/backward_function/ifft.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class IFFTBackward(BackwardFunction):
+
+    def name(self):
+        return 'IFFTBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of IFFTBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/image_augmentation.py
+++ b/python/src/nnabla/backward_function/image_augmentation.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ImageAugmentationBackward(BackwardFunction):
+
+    def name(self):
+        return 'ImageAugmentationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ImageAugmentationBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/inq_affine.py
+++ b/python/src/nnabla/backward_function/inq_affine.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class INQAffineBackward(BackwardFunction):
+
+    def name(self):
+        return 'INQAffineBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of INQAffineBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/inq_convolution.py
+++ b/python/src/nnabla/backward_function/inq_convolution.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class INQConvolutionBackward(BackwardFunction):
+
+    def name(self):
+        return 'INQConvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of INQConvolutionBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/interpolate.py
+++ b/python/src/nnabla/backward_function/interpolate.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class InterpolateBackward(BackwardFunction):
+
+    def name(self):
+        return 'InterpolateBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        # output_size is the primary argument even if `scale` specified.
+        output_size = self.forward_func.info.args["output_size"]
+        mode = self.forward_func.info.args["mode"]
+        align_corners = self.forward_func.info.args["align_corners"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.interpolate(
+                g_dx0, output_size=output_size, mode=mode, align_corners=align_corners)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/isinf.py
+++ b/python/src/nnabla/backward_function/isinf.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class IsInfBackward(BackwardFunction):
+
+    def name(self):
+        return 'IsInfBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of IsInfBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/isnan.py
+++ b/python/src/nnabla/backward_function/isnan.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class IsNaNBackward(BackwardFunction):
+
+    def name(self):
+        return 'IsNaNBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of IsNaNBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/kl_multinomial.py
+++ b/python/src/nnabla/backward_function/kl_multinomial.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class KLMultinomialBackward(BackwardFunction):
+
+    def name(self):
+        return 'KLMultinomialBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of KLMultinomialBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/leaky_relu.py
+++ b/python/src/nnabla/backward_function/leaky_relu.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LeakyReLUBackward(BackwardFunction):
+
+    def name(self):
+        return 'LeakyReLUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+        # Args
+        alpha = self.forward_func.info.args["alpha"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/less.py
+++ b/python/src/nnabla/backward_function/less.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LessBackward(BackwardFunction):
+
+    def name(self):
+        return 'LessBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LessBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/less_equal.py
+++ b/python/src/nnabla/backward_function/less_equal.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LessEqualBackward(BackwardFunction):
+
+    def name(self):
+        return 'LessEqualBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LessEqualBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/less_equal_scalar.py
+++ b/python/src/nnabla/backward_function/less_equal_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LessEqualScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'LessEqualScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LessEqualScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/less_scalar.py
+++ b/python/src/nnabla/backward_function/less_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LessScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'LessScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LessScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/log.py
+++ b/python/src/nnabla/backward_function/log.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 -= g_dx0 * F.pow_scalar(x0, -2.0)
+            else:
+                g_x0.copy_from(- g_dx0 * F.pow_scalar(x0, -2.0))
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/log_sigmoid.py
+++ b/python/src/nnabla/backward_function/log_sigmoid.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogSigmoidBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogSigmoidBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # w.r.t. x0
+        sigmoid = F.sigmoid(x0)
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += g_dx0 * dy * sigmoid * (sigmoid - 1.0)
+            else:
+                g_x0.copy_from(g_dx0 * dy * sigmoid * (sigmoid - 1.0))
+        # w.r.t. dy
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/log_softmax.py
+++ b/python/src/nnabla/backward_function/log_softmax.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogSoftmaxBackward(BackwardFunction):
+
+    def name(self):
+        return 'SoftmaxBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        inp0 = inputs[self._num_inputs_fwd]      # y
+        inp1 = inputs[self._num_inputs_fwd + 1]  # dy
+        v = nn.Variable(inp1.shape)
+        v.data = inp0.data
+        v.grad = inp1.data
+        outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axis = self.forward_func.info.args["axis"]
+
+        # Inputs
+        x0 = inputs[0].data
+        y0 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_y0 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # w.r.t. x0
+        if prop_down[0]:
+            # gradient is the backward of softmax with (g_x0 * -sum_i dy_i) as in-coming gradient
+            neg_sum_dy = -F.sum(dy, axis, True)
+            si = nn.Variable(x0.shape).apply(data=x0, need_grad=True)
+            si.grad.fill(0.0)
+            so = F.softmax(si, axis)
+            if not nn.get_auto_forward():
+                so.forward()
+            so.backward(g_dx0 * neg_sum_dy, clear_buffer=False)
+            g_x0_ = si.grad
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+
+        # w.r.t. y0 is the grad-depends
+
+        # w.r.t. dy
+        if prop_down[2]:
+            # gradient is the backward of log_softmax with g_dx0 as in-coming gradient
+            lsi = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            lso = nn.Variable(x0.shape).apply(data=y0, grad=g_dx0)
+            self.forward_func.backward([lsi], [lso], accum=[accum[2]])

--- a/python/src/nnabla/backward_function/logical_and.py
+++ b/python/src/nnabla/backward_function/logical_and.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogicalAndBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogicalAndBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LogicalAndBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/logical_and_scalar.py
+++ b/python/src/nnabla/backward_function/logical_and_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogicalAndScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogicalAndScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LogicalAndScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/logical_not.py
+++ b/python/src/nnabla/backward_function/logical_not.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogicalNotBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogicalNotBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LogicalNotBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/logical_or.py
+++ b/python/src/nnabla/backward_function/logical_or.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogicalOrBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogicalOrBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LogicalOrBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/logical_or_scalar.py
+++ b/python/src/nnabla/backward_function/logical_or_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogicalOrScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogicalOrScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LogicalOrScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/logical_xor.py
+++ b/python/src/nnabla/backward_function/logical_xor.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogicalXorBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogicalXorBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LogicalXorBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/logical_xor_scalar.py
+++ b/python/src/nnabla/backward_function/logical_xor_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LogicalXorScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'LogicalXorScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LogicalXorScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/lstm.py
+++ b/python/src/nnabla/backward_function/lstm.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LSTMBackward(BackwardFunction):
+
+    def name(self):
+        return 'LSTMBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LSTMBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/matrix_diag.py
+++ b/python/src/nnabla/backward_function/matrix_diag.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MatrixDiagBackward(BackwardFunction):
+
+    def name(self):
+        return 'MatrixDiagBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of MatrixDiagBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/matrix_diag_part.py
+++ b/python/src/nnabla/backward_function/matrix_diag_part.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MatrixDiagPartBackward(BackwardFunction):
+
+    def name(self):
+        return 'MatrixDiagPartBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of MatrixDiagPartBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/max.py
+++ b/python/src/nnabla/backward_function/max.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MaxBackward(BackwardFunction):
+
+    def name(self):
+        return 'MaxBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+        self.inputs_fwd, self.outputs_fwd = self._create_forward_inputs_and_outputs(
+            inputs, outputs)
+        self.forward_func.backward(self.inputs_fwd, self.outputs_fwd, accum=[
+                                   False] * self._num_inputs_fwd)
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axes = self.forward_func.info.args["axes"]
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        # TODO: Optimize by creating max_pooling with indeces
+        if prop_down[1]:
+            # dx0 is not accumulated on the backward graph
+            mask = F.not_equal_scalar(dx0, 0.0)
+            g_dy_ = F.sum(g_dx0 * mask, axes)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/max_pooling.py
+++ b/python/src/nnabla/backward_function/max_pooling.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MaxPoolingBackward(BackwardFunction):
+
+    def name(self):
+        return 'MaxPoolingBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        kernel = self.forward_func.info.args["kernel"]
+        stride = self.forward_func.info.args["stride"]
+        ignore_border = self.forward_func.info.args["ignore_border"]
+        pad = self.forward_func.info.args["pad"]
+        channel_last = self.forward_func.info.args["channel_last"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        ctx = nn.get_current_context()
+        backward_func = nn.function.MaxPoolingBackward(
+            ctx, kernel, stride, ignore_border, pad, channel_last)
+
+        if prop_down[1]:
+            x0_ = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_x0, need_grad=True)
+            dy_ = nn.Variable(dy.shape).apply(
+                data=dy, grad=g_dy, need_grad=True)
+            dx0_ = nn.Variable(dx0.shape).apply(data=dx0, grad=g_dx0)
+            backward_func.setup([x0_, dy_], [dx0_])
+            backward_func.backward([x0_, dy_], [dx0_], accum=accum)

--- a/python/src/nnabla/backward_function/max_pooling_backward.py
+++ b/python/src/nnabla/backward_function/max_pooling_backward.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MaxPoolingBackwardBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'MaxPoolingBackwardBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of MaxPoolingBackwardBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/maximum2.py
+++ b/python/src/nnabla/backward_function/maximum2.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Maximum2Backward(BackwardFunction):
+
+    def name(self):
+        return 'Maximum2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[2]:
+            mask = F.greater(x0, x1)
+            if accum[2]:
+                g_dy += g_dx0 * mask + g_dx1 * (1.0 - mask)
+            else:
+                g_dy.copy_from(g_dx0 * mask + g_dx1 * (1.0 - mask))

--- a/python/src/nnabla/backward_function/maximum_scalar.py
+++ b/python/src/nnabla/backward_function/maximum_scalar.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MaximumScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'MaximumScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        val = self.forward_func.info.args["val"]
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            mask = F.greater_scalar(x0, val)
+            if accum[1]:
+                g_dy += g_dx0 * mask
+            else:
+                g_dy.copy_from(g_dx0 * mask)

--- a/python/src/nnabla/backward_function/mean.py
+++ b/python/src/nnabla/backward_function/mean.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MeanBackward(BackwardFunction):
+
+    def name(self):
+        return 'MeanBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axes = self.forward_func.info.args["axes"]
+        keep_dims = self.forward_func.info.args["keep_dims"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.mean(g_dx0, axes, keep_dims)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/mean_subtraction.py
+++ b/python/src/nnabla/backward_function/mean_subtraction.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MeanSubtractionBackward(BackwardFunction):
+
+    def name(self):
+        return 'MeanSubtractionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of MeanSubtractionBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/min.py
+++ b/python/src/nnabla/backward_function/min.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MinBackward(BackwardFunction):
+
+    def name(self):
+        return 'MinBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+        self.inputs_fwd, self.outputs_fwd = self._create_forward_inputs_and_outputs(
+            inputs, outputs)
+        self.forward_func.backward(self.inputs_fwd, self.outputs_fwd, accum=[
+                                   False] * self._num_inputs_fwd)
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axes = self.forward_func.info.args["axes"]
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        # TODO: Optimize by creating max_pooling with indeces
+        if prop_down[1]:
+            # dx0 is not accumulated on the backward graph
+            mask = F.not_equal_scalar(dx0, 0.0)
+            if accum[1]:
+                g_dy_ = F.sum(g_dx0 * mask, axes)
+                g_dy += g_dy_
+            else:
+                g_dy_ = F.sum(g_dx0 * mask, axes)
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/minimum2.py
+++ b/python/src/nnabla/backward_function/minimum2.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Minimum2Backward(BackwardFunction):
+
+    def name(self):
+        return 'Minimum2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[2]:
+            mask = F.less(x0, x1)
+            if accum[2]:
+                g_dy += g_dx0 * mask + g_dx1 * (1.0 - mask)
+            else:
+                g_dy.copy_from(g_dx0 * mask + g_dx1 * (1.0 - mask))

--- a/python/src/nnabla/backward_function/minimum_scalar.py
+++ b/python/src/nnabla/backward_function/minimum_scalar.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MinimumScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'MinimumScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        val = self.forward_func.info.args["val"]
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            mask = F.less_scalar(x0, val)
+            if accum[1]:
+                g_dy += g_dx0 * mask
+            else:
+                g_dy.copy_from(g_dx0 * mask)

--- a/python/src/nnabla/backward_function/mul2.py
+++ b/python/src/nnabla/backward_function/mul2.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Mul2Backward(BackwardFunction):
+
+    def name(self):
+        return 'Mul2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                g_x0.copy_from(g_x0 + g_dx1 * dy)
+            else:
+                g_x0.copy_from(g_dx1 * dy)
+        if prop_down[1]:
+            if accum[1]:
+                g_x1.copy_from(g_x1 + g_dx0 * dy)
+            else:
+                g_x1.copy_from(g_dx0 * dy)
+        if prop_down[2]:
+            if accum[2]:
+                g_dy.copy_from(g_dy + g_dx0 * x1 + g_dx1 * x0)
+            else:
+                g_dy.copy_from(g_dx0 * x1 + g_dx1 * x0)

--- a/python/src/nnabla/backward_function/mul_scalar.py
+++ b/python/src/nnabla/backward_function/mul_scalar.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MulScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'MulScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        scalar = self.forward_func.info.args["val"]
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0 * scalar
+            else:
+                g_dy.copy_from(g_dx0 * scalar)

--- a/python/src/nnabla/backward_function/nms_detection2d.py
+++ b/python/src/nnabla/backward_function/nms_detection2d.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class NmsDetection2dBackward(BackwardFunction):
+
+    def name(self):
+        return 'NmsDetection2dBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of NmsDetection2dBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/not_equal.py
+++ b/python/src/nnabla/backward_function/not_equal.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class NotEqualBackward(BackwardFunction):
+
+    def name(self):
+        return 'NotEqualBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of NotEqualBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/not_equal_scalar.py
+++ b/python/src/nnabla/backward_function/not_equal_scalar.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class NotEqualScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'NotEqualScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of NotEqualScalarBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/one_hot.py
+++ b/python/src/nnabla/backward_function/one_hot.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class OneHotBackward(BackwardFunction):
+
+    def name(self):
+        return 'OneHotBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of OneHotBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/pad.py
+++ b/python/src/nnabla/backward_function/pad.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class PadBackward(BackwardFunction):
+
+    def name(self):
+        return 'PadBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        pad_width = self.forward_func.info.args["pad_width"]
+        mode = self.forward_func.info.args["mode"]
+        constant_value = self.forward_func.info.args["constant_value"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.pad(g_dx0, pad_width, mode, constant_value)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/pow2.py
+++ b/python/src/nnabla/backward_function/pow2.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Pow2Backward(BackwardFunction):
+
+    def name(self):
+        return 'Pow2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                # factors
+                x1_1 = x1 - 1.0
+                # terms
+                t0 = g_dx0 * (x1 * x1_1 * x0 ** (x1 - 2.0))
+                t1 = g_dx1 * (x0 ** x1_1 * (x1 * F.log(x0) + 1.0))
+                g_x0 += dy * (t0 + t1)
+            else:
+                # factors
+                x1_1 = x1 - 1.0
+                # terms
+                t0 = g_dx0 * (x1 * x1_1 * x0 ** (x1 - 2.0))
+                t1 = g_dx1 * (x0 ** x1_1 * (x1 * F.log(x0) + 1.0))
+                g_x0.copy_from(dy * (t0 + t1))
+        if prop_down[1]:
+            if accum[1]:
+                # factors
+                x1_1 = x1 - 1.0
+                log_x0 = F.log(x0)
+                # terms
+                t0 = g_dx0 * x0 ** x1_1 * (1.0 + x1 * log_x0)
+                t1 = g_dx1 * (x0 ** x1 * log_x0 ** 2.0)
+                g_x1 += dy * (t0 + t1)
+            else:
+                # factors
+                x1_1 = x1 - 1.0
+                log_x0 = F.log(x0)
+                # terms
+                t0 = g_dx0 * x0 ** x1_1 * (1.0 + x1 * log_x0)
+                t1 = g_dx1 * (x0 ** x1 * log_x0 ** 2.0)
+                g_x1.copy_from(dy * (t0 + t1))
+        if prop_down[2]:
+            if accum[2]:
+                t0 = g_dx0 * x1 * x0 ** (x1 - 1.0)
+                t1 = g_dx1 * x0 ** x1 * F.log(x0)
+                g_dy += t0 + t1
+            else:
+                t0 = g_dx0 * x1 * x0 ** (x1 - 1.0)
+                t1 = g_dx1 * x0 ** x1 * F.log(x0)
+                g_dy.copy_from(t0 + t1)

--- a/python/src/nnabla/backward_function/pow2_quantize.py
+++ b/python/src/nnabla/backward_function/pow2_quantize.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Pow2QuantizeBackward(BackwardFunction):
+
+    def name(self):
+        return 'Pow2QuantizeBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of Pow2QuantizeBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/pow_scalar.py
+++ b/python/src/nnabla/backward_function/pow_scalar.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class PowScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'PowScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        val = self.forward_func.info.args["val"]
+
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += g_dx0 * dy * val * (val - 1.0) * x0 ** (val - 2.0)
+            else:
+                g_x0.copy_from(g_dx0 * dy * val * (val - 1.0)
+                               * x0 ** (val - 2.0))
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0 * val * x0 ** (val - 1.0)
+            else:
+                g_dy.copy_from(g_dx0 * val * x0 ** (val - 1.0))

--- a/python/src/nnabla/backward_function/prelu.py
+++ b/python/src/nnabla/backward_function/prelu.py
@@ -1,0 +1,95 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class PReLUBackward(BackwardFunction):
+
+    def name(self):
+        return 'PReLUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        base_axis = self.forward_func.info.args["base_axis"]
+        # Inputs
+        x = inputs[0].data
+        w = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx = outputs[0].data
+        dw = outputs[1].data
+        # Grads of inputs
+        g_x = inputs[0].grad
+        g_w = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx = outputs[0].grad
+        g_dw = outputs[1].grad
+
+        # Computation
+        shared = True if w.shape == () else False
+        shape = [x.shape[i] if i == base_axis else 1 for i in range(x.ndim)]
+        axes = [i for i in range(x.ndim)]
+        _ = axes.pop(base_axis) if not shared else None
+
+        def reshape(v, shape):
+            if shared:
+                shape = [1 for _ in range(len(shape))]
+            return F.reshape(v, shape)
+
+        if prop_down[0] or prop_down[1]:
+            nmask = F.less_scalar(x, 0.0)
+        if prop_down[0]:
+            if accum[0]:
+                g_x += dy * reshape(g_dw, shape) * nmask
+            else:
+                g_x.copy_from(dy * reshape(g_dw, shape) * nmask)
+        if prop_down[1]:
+            if accum[1]:
+                g_w += F.sum(dy * g_dx * nmask, axes)
+            else:
+                g_w.copy_from(F.sum(dy * g_dx * nmask, axes))
+        if prop_down[2]:
+            pmask = 1.0 - nmask
+            g_dx_ = g_dx * (pmask + reshape(w, shape) * nmask) + \
+                reshape(g_dw, shape) * x * nmask
+            if accum[2]:
+                g_dy += g_dx_
+            else:
+                g_dy.copy_from(g_dx_)

--- a/python/src/nnabla/backward_function/prod.py
+++ b/python/src/nnabla/backward_function/prod.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ProdBackward(BackwardFunction):
+
+    def name(self):
+        return 'ProdBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # TODO: grad depends
+        # TODO: outer_prod is necessary?
+        raise NotImplementedError(
+            "The backward method of ProdBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/prune.py
+++ b/python/src/nnabla/backward_function/prune.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class PruneBackward(BackwardFunction):
+
+    def name(self):
+        return 'PruneBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of PruneBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/r_div_scalar.py
+++ b/python/src/nnabla/backward_function/r_div_scalar.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RDivScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'RDivScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        scalar = self.forward_func.info.args["val"]
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += 2.0 * scalar * g_dx0 * dy * x0 ** -3.0
+            else:
+                g_x0.copy_from(2.0 * scalar * g_dx0 * dy * x0 ** -3.0)
+        if prop_down[1]:
+            if accum[1]:
+                g_dy -= scalar * g_dx0 * x0 ** -2.0
+            else:
+                g_dy.copy_from(- scalar * g_dx0 * x0 ** -2.0)

--- a/python/src/nnabla/backward_function/r_pow_scalar.py
+++ b/python/src/nnabla/backward_function/r_pow_scalar.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RPowScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'RPowScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        val = self.forward_func.info.args["val"]
+        if prop_down[0] or prop_down[1]:
+            cv = F.constant(val, x0.shape)
+            if not nn.get_auto_forward():
+                cv.forward()
+            log_v = F.log(cv.data)
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += g_dx0 * dy * F.r_pow_scalar(x0, val) * log_v ** 2.0
+            else:
+                g_x0.copy_from(
+                    g_dx0 * dy * F.r_pow_scalar(x0, val) * log_v ** 2.0)
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0 * F.r_pow_scalar(x0, val) * log_v
+            else:
+                g_dy.copy_from(g_dx0 * F.r_pow_scalar(x0, val) * log_v)

--- a/python/src/nnabla/backward_function/r_sub_scalar.py
+++ b/python/src/nnabla/backward_function/r_sub_scalar.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RSubScalarBackward(BackwardFunction):
+
+    def name(self):
+        return 'RSubScalarBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        if prop_down[1]:
+            if accum[1]:
+                g_dy -= g_dx0
+            else:
+                g_dy.copy_from(-g_dx0)

--- a/python/src/nnabla/backward_function/rand.py
+++ b/python/src/nnabla/backward_function/rand.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RandBackward(BackwardFunction):
+
+    def name(self):
+        return 'RandBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RandBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/randint.py
+++ b/python/src/nnabla/backward_function/randint.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RandintBackward(BackwardFunction):
+
+    def name(self):
+        return 'RandintBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RandintBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/randn.py
+++ b/python/src/nnabla/backward_function/randn.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RandnBackward(BackwardFunction):
+
+    def name(self):
+        return 'RandnBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RandnBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/random_choice.py
+++ b/python/src/nnabla/backward_function/random_choice.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RandomChoiceBackward(BackwardFunction):
+
+    def name(self):
+        return 'RandomChoiceBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RandomChoiceBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/random_crop.py
+++ b/python/src/nnabla/backward_function/random_crop.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RandomCropBackward(BackwardFunction):
+
+    def name(self):
+        return 'RandomCropBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RandomCropBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/random_flip.py
+++ b/python/src/nnabla/backward_function/random_flip.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RandomFlipBackward(BackwardFunction):
+
+    def name(self):
+        return 'RandomFlipBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RandomFlipBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/random_shift.py
+++ b/python/src/nnabla/backward_function/random_shift.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RandomShiftBackward(BackwardFunction):
+
+    def name(self):
+        return 'RandomShiftBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RandomShiftBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/reduce_mean.py
+++ b/python/src/nnabla/backward_function/reduce_mean.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ReduceMeanBackward(BackwardFunction):
+
+    def name(self):
+        return 'ReduceMeanBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ReduceMeanBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/reduce_sum.py
+++ b/python/src/nnabla/backward_function/reduce_sum.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ReduceSumBackward(BackwardFunction):
+
+    def name(self):
+        return 'ReduceSumBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ReduceSumBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/relu.py
+++ b/python/src/nnabla/backward_function/relu.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ReLUBackward(BackwardFunction):
+
+    def name(self):
+        return 'ReLUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/relu6.py
+++ b/python/src/nnabla/backward_function/relu6.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ReLU6Backward(BackwardFunction):
+
+    def name(self):
+        return 'ReLU6Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/reset_inf.py
+++ b/python/src/nnabla/backward_function/reset_inf.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ResetInfBackward(BackwardFunction):
+
+    def name(self):
+        return 'ResetInfBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ResetInfBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/reset_nan.py
+++ b/python/src/nnabla/backward_function/reset_nan.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ResetNaNBackward(BackwardFunction):
+
+    def name(self):
+        return 'ResetNaNBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ResetNaNBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/reshape.py
+++ b/python/src/nnabla/backward_function/reshape.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ReshapeBackward(BackwardFunction):
+
+    def name(self):
+        return 'ReshapeBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        shape = self.forward_func.info.args["shape"]
+        inplace = self.forward_func.info.args["inplace"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.reshape(g_dx0, shape, inplace)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/rnn.py
+++ b/python/src/nnabla/backward_function/rnn.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RNNBackward(BackwardFunction):
+
+    def name(self):
+        return 'RNNBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of RNNBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/round.py
+++ b/python/src/nnabla/backward_function/round.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class RoundBackward(BackwardFunction):
+
+    def name(self):
+        return 'RoundBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0
+            else:
+                g_dy.copy_from(g_dx0)

--- a/python/src/nnabla/backward_function/scatter_nd.py
+++ b/python/src/nnabla/backward_function/scatter_nd.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ScatterNdBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'ScatterNdBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ScatterNdBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/selu.py
+++ b/python/src/nnabla/backward_function/selu.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SELUBackward(BackwardFunction):
+
+    def name(self):
+        return 'SELUBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += g_dx0 * dx0 * F.less_scalar(x0, 0.0)
+            else:
+                g_x0.copy_from(g_dx0 * dx0 * F.less_scalar(x0, 0.0))
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/shift.py
+++ b/python/src/nnabla/backward_function/shift.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class ShiftBackward(BackwardFunction):
+
+    def name(self):
+        return 'ShiftBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of ShiftBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/sigmoid.py
+++ b/python/src/nnabla/backward_function/sigmoid.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SigmoidBackward(BackwardFunction):
+
+    def name(self):
+        return 'SigmoidBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        inp0 = inputs[self._num_inputs_fwd]      # y
+        inp1 = inputs[self._num_inputs_fwd + 1]  # dy
+        v = nn.Variable(inp1.shape)
+        v.data = inp0.data
+        v.grad = inp1.data
+        outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        y0 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_y0 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += g_dx0 * dx0 * (1.0 - 2.0 * y0)
+            else:
+                g_x0.copy_from(g_dx0 * dx0 * (1.0 - 2.0 * y0))
+        if prop_down[2]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(data=y0, grad=g_dx0)
+            self.forward_func.backward([inp], [out], [accum[2]])

--- a/python/src/nnabla/backward_function/sigmoid_cross_entropy.py
+++ b/python/src/nnabla/backward_function/sigmoid_cross_entropy.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SigmoidCrossEntropyBackward(BackwardFunction):
+
+    def name(self):
+        return 'SigmoidCrossEntropyBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data  # logits
+        t0 = inputs[1].data  # labels
+        dz = inputs[2].data  # grad_input
+        # Outputs
+        dx0 = outputs[0].data
+        dt0 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_t0 = inputs[1].grad
+        g_dz = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dt0 = outputs[1].grad
+
+        # Computation
+        ## w.r.t. x0
+        if prop_down[0]:
+            sigmoid = F.sigmoid(x0)
+            g_x0_ = g_dx0 * dz * sigmoid * (1.0 - sigmoid)
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+        ## w.r.t. t0 is not required
+
+        ## w.r.t. dz
+        if prop_down[2]:
+            # Instable implementation since using `/ dz`
+            # g_dz_ = g_dx0 * dx0 / dz
+
+            # x0 and t0 are of the same shape, no need to call F.sigmoid_cross_entropy
+            g_dz_ = g_dx0 * (F.sigmoid(x0) - t0)
+            if accum[2]:
+                g_dz += g_dz_
+            else:
+                g_dz.copy_from(g_dz_)

--- a/python/src/nnabla/backward_function/sign.py
+++ b/python/src/nnabla/backward_function/sign.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SignBackward(BackwardFunction):
+
+    def name(self):
+        return 'SignBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            if accum[1]:
+                g_dy += g_dx0
+            else:
+                g_dy.copy_from(g_dx0)

--- a/python/src/nnabla/backward_function/sin.py
+++ b/python/src/nnabla/backward_function/sin.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SinBackward(BackwardFunction):
+
+    def name(self):
+        return 'SinBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of SinBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/sinc.py
+++ b/python/src/nnabla/backward_function/sinc.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SincBackward(BackwardFunction):
+
+    def name(self):
+        return 'SincBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of SincBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/sinh.py
+++ b/python/src/nnabla/backward_function/sinh.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SinhBackward(BackwardFunction):
+
+    def name(self):
+        return 'SinhBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of SinhBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/sink.py
+++ b/python/src/nnabla/backward_function/sink.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SinkBackward(BackwardFunction):
+
+    def name(self):
+        return 'SinkBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of SinkBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/slice.py
+++ b/python/src/nnabla/backward_function/slice.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SliceBackward(BackwardFunction):
+
+    def name(self):
+        return 'SliceBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        start = self.forward_func.info.args["start"]
+        stop = self.forward_func.info.args["stop"]
+        step = self.forward_func.info.args["step"]
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dx0_ = F.slice(g_dx0, start, stop, step)
+            if accum[1]:
+                g_dy += g_dx0_
+            else:
+                g_dy.copy_from(g_dx0_)

--- a/python/src/nnabla/backward_function/softmax.py
+++ b/python/src/nnabla/backward_function/softmax.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SoftmaxBackward(BackwardFunction):
+
+    def name(self):
+        return 'SoftmaxBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        inp0 = inputs[self._num_inputs_fwd]      # y
+        inp1 = inputs[self._num_inputs_fwd + 1]  # dy
+        v = nn.Variable(inp1.shape)
+        v.data = inp0.data
+        v.grad = inp1.data
+        outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        axis = self.forward_func.info.args["axis"]
+
+        # Inputs
+        x0 = inputs[0].data
+        y0 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_y0 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # w.r.t. x0
+        if prop_down[0]:
+            gdx_y = g_dx0 * y0
+            gdx_dy_y = gdx_y * dy
+            dy_y = dy * y0
+            gdx_y_sum = F.sum(gdx_y, axis, True)
+            dy_y_sum = F.sum(dy_y, axis, True)
+            gdx_dy_y_sum = F.sum(gdx_dy_y, axis, True)
+
+            t1 = gdx_dy_y
+            t2 = y0 * gdx_dy_y_sum
+            t3 = gdx_y_sum * (y0 * dy_y_sum - dy_y)
+            t4 = dy_y_sum * (y0 * gdx_y_sum - gdx_y)
+
+            g_x0_ = t1 - t2 + t3 + t4
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+
+        # w.r.t. dy
+        if prop_down[2]:
+            si = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            so = nn.Variable(dx0.shape).apply(data=y0, grad=g_dx0)
+            self.forward_func.backward([si], [so], accum=[accum[2]])

--- a/python/src/nnabla/backward_function/softmax_cross_entropy.py
+++ b/python/src/nnabla/backward_function/softmax_cross_entropy.py
@@ -1,0 +1,101 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SoftmaxCrossEntropyBackward(BackwardFunction):
+
+    def name(self):
+        return 'SoftmaxCrossEntropyBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axis = self.forward_func.info.args["axis"]
+        # Inputs
+        x0 = inputs[0].data  # logits
+        t0 = inputs[1].data  # labels
+        dz = inputs[2].data  # grad_input
+        # Outputs
+        dx0 = outputs[0].data
+        dt0 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_t0 = inputs[1].grad
+        g_dz = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dt0 = outputs[1].grad
+
+        # Computation
+        ## w.r.t. x0
+        if prop_down[0]:
+            # gradient is the backward of softmax with (g_dx0 * dz) as in-coming gradient
+            si = nn.Variable(x0.shape).apply(data=x0, need_grad=True)
+            si.grad.fill(0.0)
+            so = F.softmax(si, axis)
+            if not nn.get_auto_forward():
+                so.forward()
+            so.backward(g_dx0 * dz, clear_buffer=False)
+            g_x0_ = si.grad
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+
+        ## w.r.t. t0 is not required
+
+        ## w.r.t. dz
+        if prop_down[2]:
+            # Instable implementation since using `/ dz`
+            ## g_dz_ = g_dx0 * dx0 / dz
+            ## g_dz_ = F.sum(g_dz_, axis)
+
+            shape = dz.shape if dz.shape != [] else [1]
+            si = nn.Variable(x0.shape).apply(data=x0, need_grad=True)
+            ti = nn.Variable(t0.shape).apply(data=t0)
+            o = nn.Variable(shape)
+            o.grad.fill(1.0)
+            self.forward_func.backward([si, ti], [o], [False, False])
+
+            # Sum g_dx0_i * (y_hat_i - y_i) over i
+            g_dz_ = F.sum(g_dx0 * si.grad, axis)
+            if accum[2]:
+                g_dz += g_dz_
+            else:
+                g_dz.copy_from(g_dz_)

--- a/python/src/nnabla/backward_function/softplus.py
+++ b/python/src/nnabla/backward_function/softplus.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SoftPlusBackward(BackwardFunction):
+
+    def name(self):
+        return 'SoftPlusBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[0]:
+            s = F.sigmoid(x0)
+            if accum[0]:
+                g_x0 += g_dx0 * dy * s * (1.0 - s)
+            else:
+                g_x0.copy_from(g_dx0 * dy * s * (1.0 - s))
+        if prop_down[1]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[1]])

--- a/python/src/nnabla/backward_function/softsign.py
+++ b/python/src/nnabla/backward_function/softsign.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SoftSignBackward(BackwardFunction):
+
+    def name(self):
+        return 'SoftSignBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of SoftSignBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/sort.py
+++ b/python/src/nnabla/backward_function/sort.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SortBackward(BackwardFunction):
+
+    def name(self):
+        return 'SortBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of SortBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/split.py
+++ b/python/src/nnabla/backward_function/split.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SplitBackward(BackwardFunction):
+
+    def name(self):
+        return 'SplitBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd.append(v)
+        outputs_fwd.reverse()
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axis = self.forward_func.info.args["axis"]
+
+        # Compute
+        # w.r.t. dy_{0}, ..., dy_{N-1}
+        g_dx = outputs[0].grad
+        g_dy_list = list(F.split(g_dx, axis))
+        g_dy_list.reverse()
+        for i in range(len(inputs[1:])):
+            g_dy = inputs[i + 1].grad
+            g_dy_ = g_dy_list[i]
+            if prop_down[i + 1]:
+                if accum[i + 1]:
+                    g_dy += g_dy_
+                else:
+                    g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/squared_error.py
+++ b/python/src/nnabla/backward_function/squared_error.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SquaredErrorBackward(BackwardFunction):
+
+    def name(self):
+        return 'SquaredErrorBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 += 2.0 * dy * (g_dx0 - g_dx1)
+            else:
+                g_x0.copy_from(2.0 * dy * (g_dx0 - g_dx1))
+        if prop_down[1]:
+            if accum[1]:
+                g_x1 += 2.0 * dy * (g_dx1 - g_dx0)
+            else:
+                g_x1.copy_from(2.0 * dy * (g_dx1 - g_dx0))
+        if prop_down[2]:
+            if accum[2]:
+                g_dy += 2.0 * (x0 - x1) * (g_dx0 - g_dx1)
+            else:
+                g_dy.copy_from(2.0 * (x0 - x1) * (g_dx0 - g_dx1))

--- a/python/src/nnabla/backward_function/stack.py
+++ b/python/src/nnabla/backward_function/stack.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class StackBackward(BackwardFunction):
+
+    def name(self):
+        return 'StackBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axis = self.forward_func.info.args["axis"]
+
+        # Compute
+        ## w.r.t. dy
+        if prop_down[-1]:
+            g_dy = inputs[-1].grad
+            g_dy_ = F.stack(*[o.grad for o in outputs], axis=axis)
+            if accum[-1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/sub2.py
+++ b/python/src/nnabla/backward_function/sub2.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class Sub2Backward(BackwardFunction):
+
+    def name(self):
+        return 'Sub2Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        x1 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        dx1 = outputs[1].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_x1 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+        g_dx1 = outputs[1].grad
+
+        # Computation
+        if prop_down[2]:
+            if accum[2]:
+                g_dy += g_dx0 - g_dx1
+            else:
+                g_dy.copy_from(g_dx0 - g_dx1)

--- a/python/src/nnabla/backward_function/sum.py
+++ b/python/src/nnabla/backward_function/sum.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SumBackward(BackwardFunction):
+
+    def name(self):
+        return 'SumBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axes = self.forward_func.info.args["axes"]
+        keep_dims = self.forward_func.info.args["keep_dims"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.sum(g_dx0, axes, keep_dims)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/sum_pooling.py
+++ b/python/src/nnabla/backward_function/sum_pooling.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SumPoolingBackward(BackwardFunction):
+
+    def name(self):
+        return 'SumPoolingBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        kernel = self.forward_func.info.args["kernel"]
+        stride = self.forward_func.info.args["stride"]
+        ignore_border = self.forward_func.info.args["ignore_border"]
+        pad = self.forward_func.info.args["pad"]
+        channel_last = self.forward_func.info.args["channel_last"]
+
+        # TODO: BHWC
+        assert channel_last == False, "`channel_last = False` is only supported now."
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.sum_pooling(g_dx0, kernel, stride,
+                                  ignore_border, pad, channel_last)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/swish.py
+++ b/python/src/nnabla/backward_function/swish.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SwishBackward(BackwardFunction):
+
+    def name(self):
+        return 'SwishBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        inp0 = inputs[self._num_inputs_fwd]      # y
+        inp1 = inputs[self._num_inputs_fwd + 1]  # dy
+        v = nn.Variable(inp1.shape)
+        v.data = inp0.data
+        v.grad = inp1.data
+        outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        y0 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_y0 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        if prop_down[0]:
+            s = F.sigmoid(x0)
+            #y_dev = dx0 / dy
+            y_dev = y0 + s * (1.0 - y0)
+            g_x0_ = g_dx0 * dy * (y_dev + s * (1.0 - s)
+                                  * (1.0 - y0) - s * y_dev)
+            if accum[0]:
+                g_x0 += g_x0_
+            else:
+                g_x0.copy_from(g_x0_)
+        if prop_down[2]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(data=y0, grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[2]])

--- a/python/src/nnabla/backward_function/sync_batch_normalization.py
+++ b/python/src/nnabla/backward_function/sync_batch_normalization.py
@@ -1,0 +1,63 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class SyncBatchNormalizationBackward(BackwardFunction):
+
+    def name(self):
+        return 'SyncBatchNormalizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        grad_depends_on_outputs = (
+            self._num_inputs != self._num_inputs_fwd + self._num_outputs_fwd)
+        if grad_depends_on_outputs:
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.data = inp.data
+                outputs_fwd += [v]
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + self._num_outputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.grad = inp.data
+                outputs_fwd += [v]
+        else:
+            for i in range(self._num_outputs_fwd):
+                inp = inputs[self._num_inputs_fwd + i]
+                v = nn.Variable(inp.shape)
+                v.grad = inp.data
+                outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of SyncBatchNormalizationBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/tan.py
+++ b/python/src/nnabla/backward_function/tan.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TanBackward(BackwardFunction):
+
+    def name(self):
+        return 'TanBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of TanBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/tanh.py
+++ b/python/src/nnabla/backward_function/tanh.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TanhBackward(BackwardFunction):
+
+    def name(self):
+        return 'TanhBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        inp0 = inputs[self._num_inputs_fwd]      # y
+        inp1 = inputs[self._num_inputs_fwd + 1]  # dy
+        v = nn.Variable(inp1.shape)
+        v.data = inp0.data
+        v.grad = inp1.data
+        outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Inputs
+        x0 = inputs[0].data
+        y0 = inputs[1].data
+        dy = inputs[2].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_y0 = inputs[1].grad
+        g_dy = inputs[2].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        if prop_down[0]:
+            if accum[0]:
+                g_x0 -= 2 * g_dx0 * dx0 * y0
+            else:
+                g_x0.copy_from(- 2 * g_dx0 * dx0 * y0)
+        if prop_down[2]:
+            inp = nn.Variable(x0.shape).apply(
+                data=x0, grad=g_dy, need_grad=True)
+            out = nn.Variable(dy.shape).apply(data=y0, grad=g_dx0)
+            self.forward_func.backward([inp], [out], accum=[accum[2]])

--- a/python/src/nnabla/backward_function/tanh_shrink.py
+++ b/python/src/nnabla/backward_function/tanh_shrink.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TanhShrinkBackward(BackwardFunction):
+
+    def name(self):
+        return 'TanhShrinkBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of TanhShrinkBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/tile.py
+++ b/python/src/nnabla/backward_function/tile.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TileBackward(BackwardFunction):
+
+    def name(self):
+        return 'TileBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of TileBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/top_k_data.py
+++ b/python/src/nnabla/backward_function/top_k_data.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TopKDataBackward(BackwardFunction):
+
+    def name(self):
+        return 'TopKDataBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of TopKDataBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/top_k_grad.py
+++ b/python/src/nnabla/backward_function/top_k_grad.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TopKGradBackward(BackwardFunction):
+
+    def name(self):
+        return 'TopKGradBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of TopKGradBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/top_n_error.py
+++ b/python/src/nnabla/backward_function/top_n_error.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TopNErrorBackward(BackwardFunction):
+
+    def name(self):
+        return 'TopNErrorBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of TopNErrorBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/transpose.py
+++ b/python/src/nnabla/backward_function/transpose.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TransposeBackward(BackwardFunction):
+
+    def name(self):
+        return 'TransposeBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        axes = self.forward_func.info.args["axes"]
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Computation
+        if prop_down[1]:
+            g_dy_ = F.transpose(g_dx0, axes)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/unlink.py
+++ b/python/src/nnabla/backward_function/unlink.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class UnlinkBackward(BackwardFunction):
+
+    def name(self):
+        return 'UnlinkBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of UnlinkBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/unpooling.py
+++ b/python/src/nnabla/backward_function/unpooling.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class UnpoolingBackward(BackwardFunction):
+
+    def name(self):
+        return 'UnpoolingBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        # Args
+        kernel = self.forward_func.info.args["kernel"]
+
+        # Inputs
+        x0 = inputs[0].data
+        dy = inputs[1].data
+        # Outputs
+        dx0 = outputs[0].data
+        # Grads of inputs
+        g_x0 = inputs[0].grad
+        g_dy = inputs[1].grad
+        # Grads of outputs
+        g_dx0 = outputs[0].grad
+
+        # Compute
+        if prop_down[1]:
+            # Optimize by creating max_pooling with indeces
+            g_dy_ = F.unpooling(g_dx0, kernel)
+            if accum[1]:
+                g_dy += g_dy_
+            else:
+                g_dy.copy_from(g_dy_)

--- a/python/src/nnabla/backward_function/vat_noise.py
+++ b/python/src/nnabla/backward_function/vat_noise.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class VATNoiseBackward(BackwardFunction):
+
+    def name(self):
+        return 'VATNoiseBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of VATNoiseBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/where.py
+++ b/python/src/nnabla/backward_function/where.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class WhereBackward(BackwardFunction):
+
+    def name(self):
+        return 'WhereBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of WhereBackward class is not implemented.")

--- a/python/src/nnabla/backward_function_class.py.tmpl
+++ b/python/src/nnabla/backward_function_class.py.tmpl
@@ -1,0 +1,54 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+class ${function_name}Backward(BackwardFunction):
+
+    @property
+    def name(self):
+        return '${function_name}Backward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+        
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or 
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError("The backward method of ${function_name}Backward class is not implemented.")

--- a/python/src/nnabla/backward_functions.py.tmpl
+++ b/python/src/nnabla/backward_functions.py.tmpl
@@ -1,0 +1,26 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Backward function
+% for function_name, sname_name, _ in function_list:
+from .backward_function.${sname_name} import ${function_name}Backward
+% endfor
+
+# Mapping
+mappings = {
+% for function_name, snake_name, _ in function_list:
+    "${function_name}": ${function_name}Backward,
+% endfor
+}
+

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -491,9 +491,8 @@ class PythonFunction:
     def __call__(self, *inputs, n_outputs=-1, outputs=None):
         from .auto_forward import get_auto_forward
         info = Info()
-        info.type_name = 'PythonFunction'
-        from pickle import dumps
-        info.args = {'pickle': dumps(self)}
+        info.args = {}
+        info.type_name = self.name
         info.tags = {}
         # Increment reference count to prevent deleting this object as long as
         # the CgFunction instance created below exists.

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -239,6 +239,14 @@ cdef class Function:
     def inplace_grad_with(self, int i):
         return self.funp.function().get().inplace_grad_with(i)
 
+    @property
+    def need_grad(self):
+        return self.funp.need_grad()
+    
+    @property
+    def rank(self):
+        return self.funp.rank()
+    
     def _imperative_call(self, inputs, int n_outputs, outputs):
         cdef vector[NdArrayPtr] na_outputs
         if n_outputs < 0:

--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -1,0 +1,312 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+from functools import reduce
+from collections import OrderedDict
+
+import nnabla as nn
+import nnabla.functions as F
+from nnabla.function import PythonFunction
+
+from .backward_functions import mappings
+
+
+class GradEndFunction(PythonFunction):
+    """This nnabla function is used for the very end of a computational graph in the grad function.
+    """
+
+    @property
+    def name(self):
+        return 'GradEndFunction'
+
+    def min_outputs(self):
+        return 1
+
+    def setup_impl(self, inputs, outputs):
+        i = inputs[0]
+        o = outputs[0]
+        o.reset_shape(i.shape, True)
+
+    def forward_impl(self, inputs, outputs):
+        o = outputs[0].data.fill(1.0)
+
+    def backward_impl(self, inputs, outputs, propagate_down, accum):
+        gi = inputs[0].grad.fill(0.0)
+
+
+class Grad(object):
+
+    def __init__(self, ):
+        ctx = nn.get_current_context()
+        if "half" in [x.split(":")[-1] for x in ctx.backend]:
+            raise ValueError(
+                "Half is not supported up to now, context = {}".format(ctx))
+
+    def _force_list(self, x):
+        if isinstance(x, list):
+            return x
+        elif hasattr(x, "__iter__"):
+            return [o for o in x]
+        else:
+            return [x]
+
+    def _connect_on_backward_graph(self, grad_vars, f):
+        # 1. accumulate variables used more than one or do nothing
+        vf_vb_map = grad_vars.pop(f)  # {VO_fwd: [VI_bwd]}
+        grad_inputs = []
+        for v in vf_vb_map.values():
+            if len(v) > 1:
+                grad_inputs += [sum(v)]
+            else:
+                grad_inputs += v
+
+        # 2. check if grad depends on output data
+        f_outputs = []
+        for i in range(len(f.inputs)):
+            for j in range(len(f.outputs)):
+                if f.grad_depends_output_data(i, j):
+                    # overhead for putting all outputs, but there is no way
+                    f_outputs += f.outputs
+                    break
+        # 3. instantiate backward class
+        f_fwd_name = f.info.type_name
+        if f_fwd_name not in mappings:
+            raise ValueError(
+                "{} is not in the backward function mappings".format(f_fwd_name))
+        f_bwd_class = mappings[f_fwd_name]
+        f_bwd = f_bwd_class()
+        f_bwd.set_num_inputs_and_outputs(len(f.inputs) + len(f_outputs) + len(grad_inputs),
+                                         len(f.inputs),
+                                         len(f.inputs),
+                                         len(f.outputs))
+        f_bwd.set_forward_function(f)
+
+        # 4. connect
+        grad_inputs = f.inputs + f_outputs + grad_inputs
+        grad_outputs = f_bwd(*grad_inputs)
+        grad_outputs = self._force_list(grad_outputs)
+
+        # 5. put each grad_output as grad_input to a corresponding forward function
+        for inp, grad_out in zip(f.inputs, grad_outputs):
+            if inp.parent not in grad_vars:
+                grad_vars[inp.parent] = OrderedDict()
+            if inp not in grad_vars[inp.parent]:
+                grad_vars[inp.parent][inp] = [grad_out]
+            else:
+                grad_vars[inp.parent][inp] += [grad_out]
+
+        return grad_outputs
+
+    def __call__(self, outputs, inputs, grad_outputs=None,
+                 persistent_outputs=[], bind_grad_output=False):
+        """
+        The logic of this method is almost same as one in visit_function_backward in C++ layer.
+        """
+        # TODO: address test in the dynamic graph mode
+        # TODO: address inplace-Function and its test
+        # TODO: address auto_forward is very slow. It may be python overhead since small diff when BS is large.
+        # TODO: address auto_forward consumes lots of memory, need to call v.get_unlinked_variable()?
+        # TODO: address auto_forward consumes lots of memory, need to use NdArray as inputs?
+        # TODO: NHWC format
+        # TODO: Half
+        # TODO: address `set default context`
+
+        # Check outputs/inputs
+        outputs = self._force_list(outputs)
+        if not all([isinstance(o, nn.Variable) for o in outputs]):
+            raise ValueError("Element of outputs must be `nnabla.Variable`.")
+        inputs = self._force_list(inputs)
+        if not all([isinstance(i, nn.Variable) for i in inputs]):
+            raise ValueError("Element of inputs must be `nnabla.Variable`.")
+
+        # Check grad_outputs
+        if grad_outputs is None:
+            grad_outputs = [None] * len(outputs)
+        elif isinstance(grad_outputs, (int, float, np.ndarray, nn.NdArray)):
+            grad_outputs = self._force_list(grad_outputs)
+        elif isinstance(grad_outputs, list):
+            if len(outputs) != len(grad_outputs):
+                raise ValueError(
+                    "Length of `grad_outputs` and lenght of `outputs` must be the same.")
+            for i in range(len(outputs)):
+                o = outputs[i]
+                go = grad_outputs[i]
+                if not isinstance(go, (type(None), int, float, np.ndarray, nn.NdArray)):
+                    raise ValueError("Element of `grad_outputs` must be "
+                                     "in (`None`, `int`, `float`, `numpy.ndarray`, `nnabla.NdArray`) or "
+                                     "list of (`None`, `int`, `float`, `numpy.ndarray`, `nnabla.NdArray`)\n"
+                                     "type(grad_outputs[{}] = {}".format(i, type(go)))
+                elif isinstance(go, np.ndarray) and go.shape != o.shape:
+                    raise ValueError("Shape of each of outputs and grad_outputs must be same.\n"
+                                     "output[{}]({}) != grad_output[{}]({})".format(i, o.shape, i, go.shape))
+                elif isinstance(go, nn.NdArray) and go.shape != o.shape:
+                    raise ValueError("Shape of each of outputs and grad_outputs must be same.\n"
+                                     "output[{}]({}) != grad_output[{}]({})".format(i, o.shape, i, go.shape))
+        # Check persistent_outputs
+        if len(persistent_outputs) != 0 and len(outputs) != len(persistent_outputs):
+            raise ValueError("Length of outputs and persistent_outputs "
+                             "must be the same except for "
+                             "the case that the lenght of the persistent_outputs is 0.")
+
+        # Persistent outputs since outputs are basically losses to be monitored
+        persistent_outputs = [
+            True] * len(outputs) if persistent_outputs == [] else persistent_outputs
+        for o, p in zip(outputs, persistent_outputs):
+            o.persistent = p
+
+        # Set grad_outputs
+        for i in range(len(outputs)):
+            o = outputs[i]
+            go = grad_outputs[i]
+            if go is None:
+                pass
+            elif isinstance(go, (int, float)):
+                grad_output = nn.Variable(o.shape).apply(d=go, need_grad=False)
+                outputs[i] = o * grad_output
+            elif isinstance(go, np.ndarray):
+                grad_output = nn.Variable(o.shape).apply(d=go, need_grad=False)
+                outputs[i] = o * grad_output
+            elif isinstance(go, nn.NdArray):
+                grad_output = nn.Variable(o.shape).apply(
+                    data=go, need_grad=False)
+                outputs[i] = o * grad_output
+
+        # Coerce to sum if there is multiple outputs
+        output = sum(outputs) if len(outputs) != 1 else outputs[0]
+
+        # Connect the forward and backward graph
+        grad_output = GradEndFunction()(output).apply(need_grad=False)
+
+        # Open list of next search candidate
+        ids = {}
+
+        def get_id(func):
+            if func not in ids.keys():
+                size = len(ids)
+                ids[func] = size
+                return size
+            return ids[func]
+        open = set()
+        func = output.parent
+        open.add((-output.rank, get_id(func), func))
+
+        # Map for grad_variables consumed on the backward graph
+        grad_vars = OrderedDict()  # {F_fwd: {VO_fwd: [VI_bwd]}}
+        grad_vars[func] = OrderedDict({output: [grad_output]})
+
+        # Return grads
+        wrt_inputs = inputs
+        grads = [None] * len(wrt_inputs)
+
+        # Expand the forward graph to the backward graph
+        while len(open) != 0:
+            open = sorted(open)  # python set is NOT sorted set.
+            rank_func = open.pop(0)  # 0 is necessary
+            open = set(open)
+            f = rank_func[2]
+            if not f.need_grad:
+                continue
+            # Connect variables on the backward graph
+            grad_outputs = self._connect_on_backward_graph(grad_vars, f)
+
+            # Check grads w.r.t. inputs
+            for inp, grad_out in zip(f.inputs, grad_outputs):
+                if inp not in wrt_inputs or inp.need_grad == False:
+                    continue
+                idx = wrt_inputs.index(inp)
+                grads[idx] = grad_out
+                if bind_grad_output:
+                    inp.grad = grad_out.data
+
+            # Propagate down
+            for inp in f.inputs:
+                if not inp.need_grad:
+                    continue
+                p_i = inp.parent
+                if not p_i:
+                    continue
+                open.add((-p_i.rank, get_id(p_i), p_i))
+
+        return grads
+
+
+def grad(outputs, inputs, grad_outputs=None, persistent_outputs=[], bind_grad_output=False):
+    r"""Gradient function for the outputs with respect to the inputs.
+
+    The grad function computes the sum of gradients of the outputs w.r.t. the inputs.
+
+    .. math::
+
+       g_i = \sum_{j} {\frac{\partial y_j}{\partial x_i}}, 
+
+    :math:`y_j` is each output, :math:`x_i` is each input, and :math:`g_i` is the sum of the gradient of :math:`y_j` w.r.t. :math:`x_i` over all :math:`j`.
+
+    Args: 
+        outputs (list of :obj:`~nnabla.Variable` or :obj:`~nnabla.Variable`): Outputs of the differentiable function.
+        inputs (list of :obj:`~nnabla.Variable` or :obj:`~nnabla.Variable`): Inputs w.r.t. which the gradients of outputs are computed.
+        grad_outputs (None, scalar, :obj:`numpy.ndarray`, :obj:`nnabla._nd_array.NdArray`, or list of scalar, :obj:`numpy.ndarray`, or :obj:`nnabla._nd_array.NdArray`, ): Gradient outputs corresponding to outputs. This is same as the grad argument of :meth:`~nnabla.Variable.backward`. Default is None, so the one is used as the in-coming gradient at the very end of the Variable in the backward graph.
+        persistent_outputs (list of `bool`): Outputs become persistent accordingly. If not specified, all outputs become persistent.
+        bind_grad_output (`bool`): Bind data to grad of input Varaible. This is useful for the case where one wants to use the backward graph for training a neural network using the first-order gradients only. Default is False.
+
+    Returns
+        List of :obj:`~nnabla.Variable`. 
+
+        If the backpropagation does not reach input(s), the corresponding returned value(s) are None.
+
+    Example: 
+
+    .. code-block:: python
+
+        import nnabla as nn
+        import nnabla.functions as F
+        import nnabla.parametric_functions as PF
+        import numpy as np
+        from nnabla.ext_utils import get_extension_context
+
+        # Context
+        extension_module = "cudnn"
+        ctx = get_extension_context(extension_module)
+
+        # Input and label
+        x = nn.Variable.from_numpy_array(np.random.randn(4, 3, 32, 32))
+        y = nn.Variable.from_numpy_array(np.random.randint(0, 10, 4).reshape(4, 1))
+
+        # Network
+        h = PF.convolution(x, 8, (3, 3), (1, 1), name="conv1")
+        h = F.relu(h)
+        h = F.max_pooling(h, (2, 2))
+        h = PF.convolution(h, 16, (3, 3), (1, 1), name="conv2")
+        h = F.relu(h)
+        h = F.max_pooling(h, (2, 2))
+        p = PF.affine(h, 10, name="pred")
+        loss = F.mean(F.softmax_cross_entropy(p, y))
+
+        # Grad
+        outputs = [loss]
+        inputs = nn.get_parameters().values()
+        grads = nn.grad(outputs, inputs)  # gradients of the parameters
+
+        # Double backward of the outputs w.r.t. the parameters by constraining the gradient norms.
+        gp = sum([F.sum(g ** 2.0) ** 0.5 for g in grads])
+        loss += gp
+        loss.forward()
+        loss.backward()
+
+    """
+
+    grad_outputs = Grad()(outputs, inputs, grad_outputs=grad_outputs,
+                          persistent_outputs=persistent_outputs,
+                          bind_grad_output=bind_grad_output)
+    return grad_outputs

--- a/python/test/function/test_abs.py
+++ b/python/test/function/test_abs.py
@@ -32,3 +32,19 @@ def test_abs_forward_backward(seed, ctx, func_name):
             (-1e-3, 1e-3))]
     function_tester(rng, F.abs, np.abs, inputs,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_abs_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.abs, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_absolute_error.py
+++ b/python/test/function/test_absolute_error.py
@@ -28,11 +28,22 @@ def test_abs_forward_backward(seed, ctx, func_name):
     rng = np.random.RandomState(seed)
     inputs = []
     for _ in range(2):
-        inputs.append(
-            cap_ignore_region(
-                rng.randn(2, 3,).astype(np.float32) * 2,
-                (-1e-3, 1e-3)))
+        inputs.append(rng.randn(2, 3,).astype(np.float32) * 2)
 
     function_tester(rng, F.absolute_error, lambda x, y: np.abs(x - y), inputs,
                     ctx=ctx, func_name=func_name,
                     atol_b=1e-2)  # NOTE if atol_b=1e-3, then a numerical error occurs.
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_abs_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = []
+    for _ in range(2):
+        inputs.append(rng.randn(2, 3,).astype(np.float32) * 2)
+
+    backward_function_tester(rng, F.absolute_error, None, inputs,
+                             ctx=ctx, func_name=func_name,
+                             atol_b=1e-3, atol_accum=1e-3)

--- a/python/test/function/test_add2.py
+++ b/python/test/function/test_add2.py
@@ -54,3 +54,20 @@ def test_add2_inplace(seed, ctx, func_name):
     x1 = nn.Variable([2, 3, 4], need_grad=True)
     inplace_function_test_helper(
         [x0, x1], F.add2, ctx=ctx, rng=np.random.RandomState(seed))
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_add2_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32),
+              rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.add2, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_add_scalar.py
+++ b/python/test/function/test_add_scalar.py
@@ -31,3 +31,20 @@ def test_add_scalar_forward_backward(seed, val, ctx, func_name):
     function_tester(rng, F.add_scalar, lambda x, y: x + y, inputs,
                     func_args=[val],
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("val", [0.5, 1, -2])
+def test_add_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.add_scalar, None,
+                             inputs=inputs,
+                             func_args=[val], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_affine.py
+++ b/python/test/function/test_affine.py
@@ -52,3 +52,26 @@ def test_affine_forward_backward(seed, base_axis, weight_shape, bias,
         inputs += [None]
     function_tester(rng, F.affine, ref_affine, inputs, func_args=[base_axis],
                     atol_b=1e-2, dstep=1e-3, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("base_axis, weight_shape",
+                         [(1, (12, 2, 3)), (2, (4, 4))])
+@pytest.mark.parametrize("bias", [True, False])
+def test_affine_double_backward(seed, base_axis, weight_shape, bias,
+                                ctx, func_name):
+
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    # Input
+    inputs = [rng.randn(2, 3, 4).astype(np.float32)]
+    # Weight
+    inputs += [rng.randn(*weight_shape).astype(np.float32)]
+    # Bias
+    if bias:
+        inputs += [rng.randn(*weight_shape[1:]).astype(np.float32) * 1e2]
+    else:
+        inputs += [None]
+    backward_function_tester(rng, F.affine, None, inputs, func_args=[base_axis],
+                             atol_b=1e-2, atol_accum=1e-2, dstep=1e-3, ctx=ctx, func_name=func_name)

--- a/python/test/function/test_average_pooling.py
+++ b/python/test/function/test_average_pooling.py
@@ -116,3 +116,61 @@ def test_average_pooling_3d(seed, inshape, kernel, stride, pad, ignore_border, c
     function_tester(rng, F.average_pooling, ref_average_pooling,
                     inputs=inputs, func_args=func_args, func_name=func_name,
                     ctx=ctx, atol_f=1e-6, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("including_pad", [True, False])
+@pytest.mark.parametrize("ignore_border", [True, False])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("inshape, kernel, stride, pad", [
+    ((2, 2, 4, 6), (2, 2), (2, 1), (1, 0)),
+    ((2, 2, 2, 4, 6), (2, 2), (1, 2), (0, 1)),
+])
+def test_average_pooling_2d_double_backward(seed, inshape, kernel, stride, pad, ignore_border,
+                                            channel_last,
+                                            including_pad, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    if channel_last:
+        pytest.skip('Channel last is not supported in the double backward.')
+    # if channel_last and not func_name.endswith('Cudnn'):
+    #     pytest.skip('Channel last is only supported in Cudnn so far')
+    # if channel_last:
+    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [kernel, stride, ignore_border,
+                 pad, channel_last, including_pad]
+    backward_function_tester(rng, F.average_pooling, None,
+                             inputs=inputs, func_args=func_args, func_name=func_name,
+                             ctx=ctx, atol_f=1e-6, atol_b=1e-2, atol_accum=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("including_pad", [True, False])
+@pytest.mark.parametrize("ignore_border", [True, False])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("inshape, kernel, stride, pad", [
+    ((2, 2, 3, 4, 6), (2, 2, 2), (2, 1, 1), (1, 0, 1)),
+    ((2, 2, 2, 3, 4, 6), (2, 2, 2), (1, 1, 2), (0, 1, 0)),
+])
+def test_average_pooling_3d_double_backward(seed, inshape, kernel, stride, pad, ignore_border,
+                                            channel_last,
+                                            including_pad, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    if channel_last:
+        pytest.skip('Channel last is not supported in the double backward.')
+    # if channel_last and not func_name.endswith('Cudnn'):
+    #     pytest.skip('Channel last is only supported in Cudnn so far')
+    # if channel_last:
+    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [kernel, stride, ignore_border,
+                 pad, channel_last, including_pad]
+    backward_function_tester(rng, F.average_pooling, None,
+                             inputs=inputs, func_args=func_args, func_name=func_name,
+                             ctx=ctx, atol_f=1e-6, atol_b=1e-2, atol_accum=1e-2)

--- a/python/test/function/test_binary_cross_entropy.py
+++ b/python/test/function/test_binary_cross_entropy.py
@@ -31,3 +31,17 @@ def test_binary_cross_entropy_forward_backward(seed, ctx, func_name):
     function_tester(rng, F.binary_cross_entropy,
                     lambda x, y: -(y * np.log(x) + (1 - y) * np.log(1 - x)),
                     inputs, atol_b=5e-2, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_binary_cross_entropy_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.rand(2, 3, 4).astype(np.float32) for _ in range(2)]
+    inputs[1] = np.round(inputs[1])
+    backward_function_tester(rng, F.binary_cross_entropy,
+                             None,
+                             inputs,
+                             atol_b=2e-1, atol_accum=2e-1, dstep=1e-3,
+                             ctx=ctx, func_name=func_name)

--- a/python/test/function/test_broadcast.py
+++ b/python/test/function/test_broadcast.py
@@ -62,3 +62,37 @@ def test_broadcast_forward_backward(ndim, broadcast_dim, seed, fname, ctx, func_
     function_tester(rng, func, ref_func, inputs, [shape],
                     ctx=ctx, backward=[True], func_name=func_name,
                     atol_b=6e-3)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("fname, ctx, func_name", list_ctx_and_func_name(['broadcast']))
+@pytest.mark.parametrize("ndim, broadcast_dim", get_combinations(*range(0, 6)))
+def test_broadcast_double_backward(ndim, broadcast_dim, seed, fname, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+
+    rng = np.random.RandomState(seed)
+    shape = rng.randint(2, 5, size=(ndim,))
+    inshape = shape.copy()
+    inshape[broadcast_dim] = 1
+    if ndim == 0:
+        # Performing 0-dim array test too.
+        inputs = [np.array(rng.randn()).astype("float32")]
+        backward_function_tester(rng, F.broadcast, None,
+                                 inputs=inputs,
+                                 func_args=[shape], func_kwargs={},
+                                 atol_b=1e-3,
+                                 atol_accum=1e-3,
+                                 dstep=1e-3,
+                                 ctx=ctx, func_name=None,
+                                 disable_half_test=True)
+
+    inputs = [np.array(rng.randn(*inshape)).astype("float32")]
+    backward_function_tester(rng, F.broadcast, None,
+                             inputs=inputs,
+                             func_args=[shape], func_kwargs={},
+                             atol_f=1e-3,
+                             atol_b=2e-2,
+                             atol_accum=2e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_categorical_cross_entropy.py
+++ b/python/test/function/test_categorical_cross_entropy.py
@@ -51,3 +51,26 @@ def test_categorical_cross_entropy_forward_backward(seed, axis, ctx, func_name):
     function_tester(rng, F.categorical_cross_entropy,
                     ref_categorical_cross_entropy, inputs,
                     atol_b=5e-2, func_args=[axis], backward=[True, False], ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_categorical_cross_entropy_double_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    ishape = [2, 3, 4]
+    rng = np.random.RandomState(seed)
+
+    l_shape = list(ishape)
+    l_shape[axis] = 1
+    n_class = ishape[axis]
+
+    inputs = [
+        rng.rand(2, 3, 4).astype(np.float32) * 0.9 + 0.05,
+        rng.randint(0, n_class, size=l_shape).astype(np.int)]
+
+    backward_function_tester(rng, F.categorical_cross_entropy,
+                             ref_categorical_cross_entropy, inputs,
+                             atol_b=5e-2, atol_accum=5e-2, dstep=1e-3,
+                             func_args=[axis],
+                             backward=[True, False], ctx=ctx, func_name=func_name)

--- a/python/test/function/test_ceil.py
+++ b/python/test/function/test_ceil.py
@@ -36,10 +36,7 @@ def test_ceil_forward_backward(seed,
     from nbla_test_utils import cap_ignore_region, \
         function_tester
     rng = np.random.RandomState(seed)
-    inputs = [
-        cap_ignore_region(
-            rng.randn(2, 3, 4).astype(np.float32) * 2,
-            (-1e-3, 1e-3))]
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
 
     function_tester(rng, F.ceil,
                     ref_ceil,
@@ -47,3 +44,18 @@ def test_ceil_forward_backward(seed,
                     atol_b=1e-3, backward=[True],
                     ctx=ctx, func_name=func_name,
                     ref_grad=ref_grad_ceil)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_ceil_double_backward(seed,
+                              ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+
+    backward_function_tester(rng, F.ceil,
+                             None,
+                             inputs,
+                             atol_b=5e-1, atol_accum=5e-1, backward=[True],
+                             ctx=ctx, func_name=func_name)

--- a/python/test/function/test_celu.py
+++ b/python/test/function/test_celu.py
@@ -38,3 +38,16 @@ def test_celu_forward_backward(seed, alpha, axis, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     function_tester(rng, F.celu, ref_celu, inputs, func_args=[alpha, axis],
                     ctx=ctx, func_name=func_name, atol_b=4e-3)
+
+
+# @pytest.mark.parametrize("ctx, func_name", ctxs)
+# @pytest.mark.parametrize("alpha", [1.0, 0.5, 0.0])
+# @pytest.mark.parametrize("alpha", [1.0])
+# @pytest.mark.parametrize("axis", [0, 1, 2])
+# @pytest.mark.parametrize("seed", [313])
+# def test_celu_double_backward(seed, alpha, axis, ctx, func_name):
+##     from nbla_test_utils import backward_function_tester
+##     rng = np.random.RandomState(seed)
+##     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+# backward_function_tester(rng, F.celu, None, inputs, func_args=[alpha, axis],
+# ctx=ctx, func_name=func_name, atol_b=1e-3, atol_accum=1e-3)

--- a/python/test/function/test_concatenate.py
+++ b/python/test/function/test_concatenate.py
@@ -49,3 +49,26 @@ def test_no_value():
     b = nn.Variable(())
     with pytest.raises(RuntimeError):
         F.concatenate(*[a, b], axis=0)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize('different_size', [False, True])
+@pytest.mark.parametrize('num_inputs', [2, 3])
+def test_concatenate_double_backward(seed, axis, different_size, num_inputs, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    shape0 = [2, 3, 4]
+    inputs = []
+    for i in range(num_inputs):
+        inputs.append(rng.randn(*shape0).astype(np.float32))
+        shape0[axis] += int(different_size)
+    backward_function_tester(rng, F.concatenate, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs=dict(axis=axis),
+                             atol_b=1e-2,
+                             atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_constant.py
+++ b/python/test/function/test_constant.py
@@ -34,3 +34,6 @@ def test_constant_forward(value, shape, ctx, func_name):
     inputs = []
     function_tester(rng, F.constant, ref_constant, inputs, func_args=[value, shape],
                     ctx=ctx, func_name=func_name, backward=[])
+
+
+# No need to test backward_function

--- a/python/test/function/test_convolution.py
+++ b/python/test/function/test_convolution.py
@@ -133,3 +133,99 @@ def test_convolution_3d_forward_backward(inshape, kernel, outmaps, pad, stride,
     core_test_convolution_forward_backward(inshape, kernel, outmaps, pad, stride,
                                            dilation, group, channel_last, with_bias, seed, ctx,
                                            func_name)
+
+
+def core_test_convolution_double_backward(inshape, kernel, outmaps, pad, stride,
+                                          dilation, group, channel_last, with_bias, seed, ctx,
+                                          func_name, atol_f=1e-4, atol_b=1e-1, atol_accum=1e-1, dstep=1e-3):
+    from nbla_test_utils import backward_function_tester, cap_ignore_region
+    if channel_last:
+        pytest.skip('Channel last is not supported in the double backward.')
+
+    if func_name == 'ConvolutionCuda':
+        pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
+    # if channel_last and not func_name.endswith('Cudnn'):
+    # pytest.skip(
+    # 'channel_last=True is only supported in CUDNN backend so far.')
+    # if channel_last and func_name.endswith('Cudnn') and (np.any(np.asarray(dilation) > 1) or group > 1):
+    ##     import nnabla_ext.cuda as nc
+    ##     major, minor, revision = map(int, nc.__cudnn_version__.split('.'))
+    ##     version = major * 1000 + minor * 100
+    # if version < 7200:
+    # pytest.skip(
+    # 'channel_last dilated convolution not work in CUDNN {}.'.format(version))
+
+    base_axis = len(inshape) - len(kernel) - 1
+    inmaps = inshape[base_axis]
+    # if channel_last:
+    ##     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+    ##     inshape = tuple(inshape[i] for i in t.inv_axes)
+    rng = np.random.RandomState(seed)
+    i = rng.randn(*inshape).astype(np.float32)
+    kshape = (outmaps,) + (inmaps // group,) + kernel
+    if channel_last:
+        t = refs.ChannelLastToFirstTranspose(len(kshape), len(kernel))
+        kshape = tuple(kshape[i] for i in t.inv_axes)
+    k = rng.randn(*kshape).astype(np.float32)
+    b = None
+    if with_bias:
+        #b = rng.randn(outmaps).astype(np.float32) * 1e3
+        b = rng.randn(outmaps).astype(np.float32)
+    inputs = [i, k, b]
+    atol_half = 1.0 if inmaps > 64 else 1e-1
+    backward_function_tester(rng, F.convolution, None, inputs,
+                             func_args=[base_axis, pad, stride,
+                                        dilation, group, channel_last],
+                             atol_f=atol_f, atol_b=atol_b, atol_accum=atol_accum, dstep=dstep,
+                             ctx=ctx, func_name=func_name, atol_half=atol_half)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, kernel, outmaps, pad, stride, dilation", [
+    ((2, 2, 10), (1,), 4, (3,), (2,), (1,)),
+    ((2, 2, 10), (3,), 2, (0,), (1,), (2,)),
+])
+@pytest.mark.parametrize("group", [1, 2])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_convolution_1d_double_backward(inshape, kernel, outmaps, pad, stride,
+                                        dilation, group, channel_last, with_bias, seed, ctx,
+                                        func_name):
+    core_test_convolution_double_backward(inshape, kernel, outmaps, pad, stride,
+                                          dilation, group, channel_last, with_bias, seed, ctx,
+                                          func_name, atol_b=2e-2, atol_accum=2e-2, dstep=1e-3)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, kernel, outmaps, pad, stride, dilation", [
+    ((2, 2, 10, 10), (3, 2), 4, (3, 0), (1, 2), (2, 1)),
+    # ((32, 128, 64, 64), (3, 3), 128, (1, 1), (1, 1), (1, 1)),  # This takes looooooooong to test.
+    ((2, 2, 10, 10), (3, 2), 4, (0, 0), (1, 1), (1, 1)),
+])
+@pytest.mark.parametrize("group", [1, 2])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_convolution_2d_double_backward(inshape, kernel, outmaps, pad, stride,
+                                        dilation, group, channel_last, with_bias, seed, ctx,
+                                        func_name):
+    core_test_convolution_double_backward(inshape, kernel, outmaps, pad, stride,
+                                          dilation, group, channel_last, with_bias, seed, ctx,
+                                          func_name, atol_b=2e-1, atol_accum=2e-1, dstep=1e-3)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, kernel, outmaps, pad, stride, dilation", [
+    ((2, 2, 7, 8, 5), (2, 3, 2), 4, (3, 0, 0), (1, 2, 1), (2, 1, 1)),
+])
+@pytest.mark.parametrize("group", [1, 2])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_convolution_3d_double_backward_with_bias(inshape, kernel, outmaps, pad, stride,
+                                                  dilation, group, channel_last, with_bias, seed, ctx,
+                                                  func_name):
+    core_test_convolution_double_backward(inshape, kernel, outmaps, pad, stride,
+                                          dilation, group, channel_last, with_bias, seed, ctx,
+                                          func_name, atol_b=3e-1, atol_accum=3e-1, dstep=1e-3)

--- a/python/test/function/test_crelu.py
+++ b/python/test/function/test_crelu.py
@@ -37,3 +37,17 @@ def test_crelu_forward_backward(seed, axis, ctx, func_name):
             (-1e-3, 1e-3))]
     function_tester(rng, F.crelu, ref_crelu, inputs, func_args=[axis],
                     ctx=ctx, func_name=func_name, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("seed", [313])
+def test_crelu_double_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        cap_ignore_region(
+            rng.randn(2, 3, 4).astype(np.float32) * 2,
+            (-1e-3, 1e-3))]
+    backward_function_tester(rng, F.crelu, None, inputs, func_args=[axis],
+                             ctx=ctx, func_name=func_name, atol_b=1e-3, atol_accum=1e-3)

--- a/python/test/function/test_div2.py
+++ b/python/test/function/test_div2.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('Div2')
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_div2_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32),
+              rng.randn(2, 3).astype(np.float32) * 2]
+    backward_function_tester(rng, F.div2, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-1,
+                             atol_accum=1e-1,
+                             dstep=1e-4,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_elu.py
+++ b/python/test/function/test_elu.py
@@ -35,3 +35,20 @@ def test_elu_forward_backward(seed, alpha, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     function_tester(rng, F.elu, ref_elu, inputs, func_args=[alpha],
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("alpha", [1.0, 0.5, 0.0])
+@pytest.mark.parametrize("seed", [313])
+def test_elu_double_backward(seed, alpha, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32) * 2]
+    backward_function_tester(rng, F.elu, None,
+                             inputs=inputs,
+                             func_args=[alpha], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_embed.py
+++ b/python/test/function/test_embed.py
@@ -35,3 +35,20 @@ def test_embed_forward_backward(seed, shape_x, shape_w, ctx, func_name):
     function_tester(rng, F.embed, lambda x, w: w[x], inputs,
                     ctx=ctx, func_name=func_name, atol_b=1e-2,
                     backward=[False, True])
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("shape_x", [(10,), (2, 8), (2, 3, 4), (2, 2, 3, 4)])
+@pytest.mark.parametrize("shape_w", [(5, 3), (4, 3, 4), (6, 2, 2, 3)])
+def test_embed_double_backward(seed, shape_x, shape_w, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    n_class = shape_w[0]
+    x = rng.randint(0, n_class - 1, shape_x).astype(np.int32)
+    w = rng.randn(*shape_w).astype(np.float32)
+    inputs = [x, w]
+    backward_function_tester(rng, F.embed, None, inputs,
+                             ctx=ctx, func_name=func_name, atol_b=6e-2, atol_accum=6e-2,
+                             dstep=1e-3,
+                             backward=[False, True])

--- a/python/test/function/test_epsilon_insensitive_loss.py
+++ b/python/test/function/test_epsilon_insensitive_loss.py
@@ -40,3 +40,16 @@ def test_epsilon_insensitive_loss_forward_backward(seed, ctx, func_name, epsilon
                     ref_epsilon_insensitive_loss_forward, inputs,
                     func_args=[epsilon],
                     atol_b=1e-2, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("epsilon", [0.001, 1])
+def test_epsilon_insensitive_loss_double_backward(seed, ctx, func_name, epsilon):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2 for _ in range(2)]
+    backward_function_tester(rng, F.epsilon_insensitive_loss,
+                             None, inputs,
+                             func_args=[epsilon],
+                             atol_b=5e-3, atol_accum=5e-3, ctx=ctx, func_name=func_name)

--- a/python/test/function/test_exp.py
+++ b/python/test/function/test_exp.py
@@ -29,3 +29,19 @@ def test_exp_forward_backward(seed, ctx, func_name):
     inputs = [np.clip(rng.randn(2, 3, 4).astype(np.float32) * 2.0, -2.0, 2.0)]
     function_tester(rng, F.exp, np.exp, inputs, atol_f=1e-6,
                     atol_b=1e-2, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_exp_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.exp, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-2,
+                             atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_floor.py
+++ b/python/test/function/test_floor.py
@@ -36,10 +36,7 @@ def test_floor_forward_backward(seed,
     from nbla_test_utils import cap_ignore_region, \
         function_tester
     rng = np.random.RandomState(seed)
-    inputs = [
-        cap_ignore_region(
-            rng.randn(2, 3, 4).astype(np.float32) * 2,
-            (-1e-3, 1e-3))]
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
 
     function_tester(rng, F.floor,
                     ref_floor,
@@ -47,3 +44,19 @@ def test_floor_forward_backward(seed,
                     atol_b=1e-3, backward=[True],
                     ctx=ctx, func_name=func_name,
                     ref_grad=ref_grad_floor)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_floor_double_backward(seed,
+                               ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+
+    backward_function_tester(rng, F.floor,
+                             None,
+                             inputs,
+                             atol_b=5e-1, atol_accum=5e-1,
+                             backward=[True],
+                             ctx=ctx, func_name=func_name)

--- a/python/test/function/test_hard_sigmoid.py
+++ b/python/test/function/test_hard_sigmoid.py
@@ -38,3 +38,19 @@ def test_hard_sigmoid_forward_backward(seed, ctx, func_name):
         np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
     function_tester(rng, F.hard_sigmoid, ref_hard_sigmoid, inputs,
                     ctx=ctx, func_name=func_name, ref_grad=ref_hard_sigmoid_backward)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_hard_sigmoid_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+    backward_function_tester(rng, F.hard_sigmoid, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_hard_tanh.py
+++ b/python/test/function/test_hard_tanh.py
@@ -38,3 +38,20 @@ def test_hard_tanh_forward_backward(seed, ctx, func_name):
         np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
     function_tester(rng, F.hard_tanh, ref_hard_tanh, inputs,
                     ctx=ctx, func_name=func_name, ref_grad=ref_hard_tanh_backward)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_hard_tanh_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester, cap_ignore_region
+    rng = np.random.RandomState(seed)
+    inputs = [cap_ignore_region(
+        rng.randn(2, 3).astype(np.float32), (-0.9, 0.9))]
+    backward_function_tester(rng, F.hard_tanh, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_huber_loss.py
+++ b/python/test/function/test_huber_loss.py
@@ -38,3 +38,15 @@ def test_huber_loss_forward_backward(seed, ctx, func_name, delta):
     function_tester(rng, F.huber_loss, ref_huber_loss, inputs,
                     func_args=[delta],
                     atol_b=1e-2, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("delta", [0.5, 1.0, 1.5])
+def test_huber_loss_double_backward(seed, ctx, func_name, delta):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2 for _ in range(2)]
+    backward_function_tester(rng, F.huber_loss, None, inputs,
+                             func_args=[delta],
+                             atol_b=1e-2, atol_accum=1e-2, ctx=ctx, func_name=func_name)

--- a/python/test/function/test_identity.py
+++ b/python/test/function/test_identity.py
@@ -33,3 +33,19 @@ def test_identity_forward_backward(seed, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32)]
     function_tester(rng, F.identity, ref_identity, inputs,
                     ctx=ctx, func_name=func_name, atol_b=1e-3)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_identity_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+    backward_function_tester(rng, F.identity, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_interpolate.py
+++ b/python/test/function/test_interpolate.py
@@ -264,3 +264,71 @@ def test_interpolate_nearest_forward_backward(seed, inshape, outsize, scale,
     function_tester(rng, F.interpolate, ref_interpolate, inputs,
                     func_name=func_name, func_args=func_args,
                     atol_f=1e-6, atol_b=1e-2, ctx=ctx)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("inshape, outsize, scale", [
+    # 2-dimensional
+    ((3, 3), (8, 6), None),
+    ((3, 3), (2, 1), None),
+    ((3, 3), None, (2.5, 1.0)),
+    ((3, 3), None, (0.5, 0.5)),
+    ((2, 3, 4, 4), (8, 6), None),
+    ((2, 3, 4, 4), (2, 1), None),
+    ((2, 3, 4, 4), None, (2.5, 1.0)),
+    ((2, 3, 4, 4), None, (0.5, 0.5)),
+    # 3-dimensional
+    ((3, 3, 3), (6, 8, 6), None),
+    ((3, 3, 3), (1, 2, 1), None),
+    ((3, 3, 3), None, (1.5, 2.5, 1.0)),
+    ((3, 3, 3), None, (1.2, 0.5, 0.5)),
+    ((2, 2, 3, 4, 4), (6, 8, 6), None),
+    ((2, 2, 3, 4, 4), (1, 2, 1), None),
+    ((2, 2, 3, 4, 4), None, (1.5, 2.5, 1.0)),
+    ((2, 2, 3, 4, 4), None, (1.2, 0.5, 0.5)),
+])
+@pytest.mark.parametrize('align_corners', [False, True])
+@pytest.mark.parametrize("seed", [313])
+def test_interpolate_linear_double_backward(seed, inshape, outsize, scale,
+                                            align_corners, ctx, func_name):
+    # TODO: some test fail.
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [scale, outsize, 'linear', align_corners]
+    backward_function_tester(rng, F.interpolate, None, inputs,
+                             func_name=func_name, func_args=func_args,
+                             atol_f=1e-6, atol_b=1e-2, atol_accum=1e-2, dstep=1e-3, ctx=ctx)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("inshape, outsize, scale", [
+    # 2-dimensional
+    ((3, 3), (8, 6), None),
+    ((3, 3), (2, 1), None),
+    ((3, 3), None, (2.5, 1.0)),
+    ((3, 3), None, (0.5, 0.5)),
+    ((2, 3, 4, 5), (8, 6), None),
+    ((2, 3, 4, 5), (2, 1), None),
+    ((2, 3, 4, 5), None, (2.5, 1.0)),
+    ((2, 3, 4, 5), None, (0.5, 0.5)),
+    # 3-dimensional
+    ((3, 3, 3), (6, 8, 6), None),
+    ((3, 3, 3), (1, 2, 1), None),
+    ((3, 3, 3), None, (1.5, 2.5, 1.0)),
+    ((3, 3, 3), None, (1.2, 0.5, 0.5)),
+    ((1, 2, 3, 4, 5), (6, 8, 6), None),
+    ((1, 2, 3, 4, 5), (1, 2, 3), None),
+    ((1, 2, 3, 4, 5), None, (1.5, 2.5, 1.0)),
+    ((1, 2, 3, 4, 5), None, (1.2, 0.5, 0.5)),
+])
+@pytest.mark.parametrize("seed", [313])
+def test_interpolate_nearest_double_backward(seed, inshape, outsize, scale,
+                                             ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [scale, outsize, 'nearest']
+    backward_function_tester(rng, F.interpolate, ref_interpolate, inputs,
+                             func_name=func_name, func_args=func_args,
+                             atol_f=1e-6, atol_b=1e-2, atol_accum=1e-2, ctx=ctx)

--- a/python/test/function/test_leaky_relu.py
+++ b/python/test/function/test_leaky_relu.py
@@ -47,3 +47,25 @@ def test_leaky_relu_inplace(seed, alpha, ctx, func_name):
     x = nn.Variable([2, 3, 4], need_grad=True)
     inplace_function_test_helper(
         [x], F.leaky_relu, ctx=ctx, rng=np.random.RandomState(seed))
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("alpha", [0, 0.2])
+def test_relu_double_backward(seed, alpha, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        cap_ignore_region(
+            rng.randn(2, 3, 4).astype(np.float32) * 2,
+            (-1e-3, 1e-3))]
+    backward_function_tester(rng, F.leaky_relu, None,
+                             inputs=inputs,
+                             func_args=[alpha], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)
+
+# TODO: inplace double_backward

--- a/python/test/function/test_log.py
+++ b/python/test/function/test_log.py
@@ -30,3 +30,20 @@ def test_log_forward_backward(seed, ctx, func_name):
         np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
     function_tester(rng, F.log, np.log, inputs, atol_f=1e-6,
                     atol_b=1e-2, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_log_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
+    backward_function_tester(rng, F.log, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_log_sigmoid.py
+++ b/python/test/function/test_log_sigmoid.py
@@ -34,3 +34,20 @@ def test_log_sigmoid_forward_backward(seed, ctx, func_name):
         np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
     function_tester(rng, F.log_sigmoid, ref_log_sigmoid, inputs,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_log_sigmoid_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
+    backward_function_tester(rng, F.log_sigmoid, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_log_softmax.py
+++ b/python/test/function/test_log_softmax.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+
+def ref_log_softmax(x, axis):
+    x = x - x.max(axis, keepdims=True)
+    x = x - np.log(np.exp(x).sum(axis, keepdims=True))
+    return x
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("ctx, func_name", list_context('LogSoftmax'))
+def test_log_softmax_forward_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32)]
+    function_tester(rng, F.log_softmax, ref_log_softmax, inputs, func_args=[axis],
+                    ctx=ctx, func_name=func_name, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("ctx, func_name", list_context('LogSoftmax'))
+def test_log_softmax_double_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32)]
+    backward_function_tester(rng, F.log_softmax, None, inputs, func_args=[axis],
+                             ctx=ctx, func_name=func_name,
+                             atol_b=1e-1, atol_accum=1e-1, dstep=1e-3)

--- a/python/test/function/test_max_pooling.py
+++ b/python/test/function/test_max_pooling.py
@@ -111,3 +111,57 @@ def test_max_pooling_3d(seed, inshape, kernel, stride, pad, ignore_border, chann
     function_tester(rng, F.max_pooling, ref_max_pooling, inputs=inputs,
                     func_args=func_args, func_name=func_name, ctx=ctx,
                     atol_f=1e-6, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ignore_border", [True, False])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("inshape, kernel, stride, pad", [
+   ((2, 2, 4, 6), (2, 2), (2, 1), (1, 0)),
+   ((2, 2, 2, 4, 6), (2, 2), (1, 2), (0, 1)),
+])
+def test_max_pooling_2d_double_backward(seed, inshape, kernel, stride, pad, ignore_border, channel_last,
+                                        ctx, func_name):
+    from nbla_test_utils import backward_function_tester, cap_ignore_region
+    if channel_last:
+        pytest.skip('Channel last is not supported in the double backward.')
+    # if channel_last and not func_name.endswith('Cudnn'):
+    ##     pytest.skip('Channel last is only supported in Cudnn so far')
+    # if channel_last:
+    ##     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+    ##     inshape = tuple(inshape[i] for i in t.inv_axes)
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [kernel, stride, ignore_border, pad, channel_last]
+    backward_function_tester(rng, F.max_pooling, None, inputs=inputs,
+                             func_args=func_args, func_name=func_name, ctx=ctx,
+                             atol_f=1e-6, atol_b=1e-2, atol_accum=1e-2, dstep=1e-3)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ignore_border", [True, False])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("inshape, kernel, stride, pad", [
+   ((2, 2, 3, 4, 6), (2, 2, 2), (2, 1, 1), (1, 0, 1)),
+   ((2, 2, 2, 3, 4, 6), (2, 2, 2), (1, 1, 2), (0, 1, 0)),
+])
+def test_max_pooling_3d_double_backward(seed, inshape, kernel, stride, pad, ignore_border, channel_last,
+                                        ctx, func_name):
+    # pytest.skip('`>3`-dimension are not supported.')
+    # TODO: some test fail
+    from nbla_test_utils import backward_function_tester, cap_ignore_region
+    if channel_last:
+        pytest.skip('Channel last is not supported in the double backward.')
+    # if channel_last and not func_name.endswith('Cudnn'):
+    ##     pytest.skip('Channel last is only supported in Cudnn so far')
+    # if channel_last:
+    ##     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+    ##     inshape = tuple(inshape[i] for i in t.inv_axes)
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [kernel, stride, ignore_border, pad, channel_last]
+    backward_function_tester(rng, F.max_pooling, None, inputs=inputs,
+                             func_args=func_args, func_name=func_name, ctx=ctx,
+                             atol_f=1e-2, atol_b=1e-1, atol_accum=1e-1, dstep=1e-3)

--- a/python/test/function/test_maximum2.py
+++ b/python/test/function/test_maximum2.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This is still left unlike other *2 operation (sub2, mul2, ...) because
+it has cudnn implementation.
+"""
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('Maximum2')
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_maximum2_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32),
+              rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.maximum2, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_maximum_scalar.py
+++ b/python/test/function/test_maximum_scalar.py
@@ -31,3 +31,20 @@ def test_maximum_scalar_forward_backward(seed, val, ctx, func_name):
     function_tester(rng, F.maximum_scalar, np.maximum, inputs,
                     func_args=[val],
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("val", [0.5, 1, -2])
+def test_maximum_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.maximum_scalar, None,
+                             inputs=inputs,
+                             func_args=[val], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_minimum2.py
+++ b/python/test/function/test_minimum2.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This is still left unlike other *2 operation (sub2, mul2, ...) because
+it has cudnn implementation.
+"""
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('Minimum2')
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_minimum2_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32),
+              rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.minimum2, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_minimum_scalar.py
+++ b/python/test/function/test_minimum_scalar.py
@@ -31,3 +31,20 @@ def test_minimum_scalar_forward_backward(seed, val, ctx, func_name):
     function_tester(rng, F.minimum_scalar, np.minimum, inputs,
                     func_args=[val],
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("val", [0.5, 1, -2])
+def test_minimum_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.minimum_scalar, None,
+                             inputs=inputs,
+                             func_args=[val], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_mul2.py
+++ b/python/test/function/test_mul2.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('Mul2')
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_mul2_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32),
+              rng.randn(2, 3).astype(np.float32) * 2]
+    backward_function_tester(rng, F.mul2, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-2,
+                             atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_mul_scalar.py
+++ b/python/test/function/test_mul_scalar.py
@@ -31,3 +31,20 @@ def test_mul_scalar_forward_backward(seed, val, ctx, func_name):
     function_tester(rng, F.mul_scalar, lambda x, y: x * y, inputs,
                     func_args=[val],
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("val", [0.5, 1, -2])
+def test_mul_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.mul_scalar, None,
+                             inputs=inputs,
+                             func_args=[val], func_kwargs={},
+                             atol_b=2e-3,
+                             atol_accum=2e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_pad.py
+++ b/python/test/function/test_pad.py
@@ -76,3 +76,52 @@ def test_pad_reflect_forward_backward(seed, ctx, func_name, inshape,
     func_args = [pad_width, "reflect"]
     function_tester(rng, F.pad, ref_pad_reflect, inputs, ctx=ctx, dstep=1e-1,
                     func_name=func_name, func_args=func_args)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("inshape, pad_width", [
+    ((4,), (2, 9)),
+    ((5,), (4, 3)),
+    ((4, 5), (5, 4)),
+    ((3, 6), (1, 2, 3, 4)),
+    ((3, 5, 7), (2, 3)),
+    ((5, 4, 6), (2, 3, 1, 4)),
+    ((2, 3, 5), (1, 2, 3, 4, 5, 6)),
+    ((1, 2, 3, 4), (2, 3, 4, 5)),
+    ((2, 2, 3, 3), (2, 2, 2, 2, 2, 2, 2, 2)),
+])
+@pytest.mark.parametrize("constant_value", [0.11, -1.1])
+def test_pad_constant_double_backward(seed, ctx, func_name, inshape,
+                                      pad_width, constant_value):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [pad_width, "constant", constant_value]
+    backward_function_tester(rng, F.pad, ref_pad_constant, inputs, ctx=ctx,
+                             dstep=1e-3, atol_b=1e-2, atol_accum=1e-2,
+                             func_name=func_name, func_args=func_args)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("inshape, pad_width", [
+    ((4,), (2, 9)),
+    ((5,), (4, 3)),
+    ((4, 5), (5, 4)),
+    ((3, 6), (1, 2, 3, 4)),
+    ((3, 5, 7), (2, 3)),
+    ((5, 4, 6), (2, 3, 1, 4)),
+    ((2, 3, 5), (1, 2, 3, 4, 5, 6)),
+    ((1, 2, 3, 4), (2, 3, 4, 5)),
+    ((2, 2, 3, 3), (2, 2, 2, 2, 2, 2, 2, 2)),
+])
+def test_pad_reflect_double_backward(seed, ctx, func_name, inshape,
+                                     pad_width):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [pad_width, "reflect"]
+    backward_function_tester(rng, F.pad, ref_pad_reflect, inputs, ctx=ctx,
+                             dstep=1e-3, atol_b=5e-2, atol_accum=5e-2,
+                             func_name=func_name, func_args=func_args)

--- a/python/test/function/test_pow2.py
+++ b/python/test/function/test_pow2.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('Pow2')
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_pow2_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [(rng.randint(5, size=(2, 3)).astype(np.float32) + 1.0) * 0.2,
+              rng.randn(2, 3).astype(np.float32), ]
+    backward_function_tester(rng, F.pow2, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=5e-2,
+                             atol_accum=5e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_pow_scalar.py
+++ b/python/test/function/test_pow_scalar.py
@@ -31,3 +31,20 @@ def test_pow_scalar_forward_backward(seed, val, ctx, func_name):
     function_tester(rng, F.pow_scalar, lambda x, y: x ** y, inputs,
                     func_args=[val], atol_b=5e-2,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("val", [0.5, 1, 2])
+def test_pow_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [(rng.randint(5, size=(2, 3)).astype(np.float32) + 1.0) * 0.2]
+    backward_function_tester(rng, F.pow_scalar, None,
+                             inputs=inputs,
+                             func_args=[val], func_kwargs={},
+                             atol_b=1e-2,
+                             atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_prelu.py
+++ b/python/test/function/test_prelu.py
@@ -42,3 +42,20 @@ def test_prelu_forward_backward(seed, inshape, wshape, base_axis, ctx, func_name
     function_tester(rng, F.prelu, ref_prelu, inputs,
                     func_args=[base_axis],
                     ctx=ctx, func_name=func_name, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, wshape, base_axis",
+                         [((2, 3, 2, 3, 2), tuple(), 4),
+                          ((2, 3, 1, 3), (3,), 1)
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+def test_prelu_double_backward(seed, inshape, wshape, base_axis, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    x = rng.randn(*inshape).astype(np.float32)
+    w = np.array(rng.randn(*wshape)).astype(np.float32)
+    inputs = [x, w]
+    backward_function_tester(rng, F.prelu, None, inputs,
+                             func_args=[base_axis],
+                             ctx=ctx, func_name=func_name, atol_b=1e-1, atol_accum=1e-1, dstep=1e-3)

--- a/python/test/function/test_r_div_scalar.py
+++ b/python/test/function/test_r_div_scalar.py
@@ -33,3 +33,22 @@ def test_r_div_scalar_forward_backward(seed, val, ctx, func_name):
     function_tester(rng, F.r_div_scalar, lambda x, y: y / x, inputs,
                     func_args=[val], dstep=1e-4, atol_b=1e-1,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("val", [0.5, 1, 2])
+def test_r_div_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester, cap_ignore_region
+    rng = np.random.RandomState(seed)
+    inputs = [
+        cap_ignore_region(
+            rng.randn(2, 3).astype(np.float32) * 3, (-0.5, 0.5))]
+    backward_function_tester(rng, F.r_div_scalar, None,
+                             inputs=inputs,
+                             func_args=[val], func_kwargs={},
+                             atol_b=1e-2,
+                             atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_r_pow_scalar.py
+++ b/python/test/function/test_r_pow_scalar.py
@@ -31,3 +31,16 @@ def test_r_pow_scalar_forward_backward(seed, val, ctx, func_name):
     function_tester(rng, F.r_pow_scalar, lambda x, y: y ** x, inputs,
                     func_args=[val], atol_b=1e-2,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [314])
+@pytest.mark.parametrize("val", [0.5, 1, 2])
+def test_r_pow_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+    backward_function_tester(rng, F.r_pow_scalar, None, inputs,
+                             func_args=[val], atol_b=1e-2, atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=func_name)

--- a/python/test/function/test_r_sub_scalar.py
+++ b/python/test/function/test_r_sub_scalar.py
@@ -34,3 +34,21 @@ def test_r_sub_scalar_forward_backward(seed, val, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32)]
     function_tester(rng, F.r_sub_scalar, ref_r_sub_scalar,
                     inputs, func_args=[val], ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("val", [0.5, 1, 2])
+def test_r_sub_scalar_double_backward(seed, val, ctx, func_name):
+    from nbla_test_utils import backward_function_tester, cap_ignore_region
+    rng = np.random.RandomState(seed)
+    inputs = [
+        cap_ignore_region(
+            rng.randn(2, 3).astype(np.float32) * 3, (-0.5, 0.5))]
+    backward_function_tester(rng, F.r_sub_scalar, None,
+                             inputs=inputs,
+                             func_args=[val], func_kwargs={},
+                             atol_b=1e-3, atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_relu.py
+++ b/python/test/function/test_relu.py
@@ -45,3 +45,25 @@ def test_relu_inplace(seed, ctx, func_name):
     x = nn.Variable([2, 3, 4], need_grad=True)
     inplace_function_test_helper(
         [x], F.relu, ctx=ctx, rng=np.random.RandomState(seed))
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_relu_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        cap_ignore_region(
+            rng.randn(2, 3, 4).astype(np.float32) * 2,
+            (-1e-3, 1e-3))]
+    backward_function_tester(rng, F.relu, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)
+
+
+# TODO: inplace double_backward

--- a/python/test/function/test_relu6.py
+++ b/python/test/function/test_relu6.py
@@ -34,3 +34,20 @@ def test_relu6_forward_backward(seed, ctx, func_name):
         np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
     function_tester(rng, F.relu6, ref_relu6, inputs,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_relu6_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        np.clip(np.abs(rng.randn(2, 3, 4).astype(np.float32)) * 1e4, 1e-2, 1e4)]
+    backward_function_tester(rng, F.relu6, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_reshape.py
+++ b/python/test/function/test_reshape.py
@@ -49,3 +49,26 @@ def test_reshpae_inplace(seed, ctx, func_name, inshape, outshape):
     inplace_function_test_helper(
         inputs, F.reshape, func_args=[
             outshape], ctx=ctx, rng=np.random.RandomState(seed))
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, outshape", [((1, 1, 6), (1, 2, 3)), ((2, 3), (1, 6)), ((2, 4), (-1, 2, 2))])
+def test_reshape_double_backward(seed, ctx, func_name, inshape, outshape):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    # Input
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    inplace = False
+    # TODO: backward_ref
+    backward_function_tester(rng, F.reshape, None,
+                             inputs=inputs,
+                             func_args=[outshape, inplace], func_kwargs={},
+                             atol_b=5e-3,
+                             atol_accum=5e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)
+
+
+# TODO: inplace double_backward

--- a/python/test/function/test_round.py
+++ b/python/test/function/test_round.py
@@ -36,10 +36,7 @@ def test_round_forward_backward(seed,
     from nbla_test_utils import cap_ignore_region, \
         function_tester
     rng = np.random.RandomState(seed)
-    inputs = [
-        cap_ignore_region(
-            rng.randn(2, 3, 4).astype(np.float32) * 2,
-            (-1e-3, 1e-3))]
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
 
     function_tester(rng, F.round,
                     ref_round,
@@ -47,3 +44,18 @@ def test_round_forward_backward(seed,
                     atol_b=1e-3, backward=[True],
                     ctx=ctx, func_name=func_name,
                     ref_grad=ref_grad_round)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_round_double_backward(seed,
+                               ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+
+    backward_function_tester(rng, F.round,
+                             None,
+                             inputs,
+                             atol_b=5e-1, atol_accum=5e-1, backward=[True],
+                             ctx=ctx, func_name=func_name)

--- a/python/test/function/test_selu.py
+++ b/python/test/function/test_selu.py
@@ -36,3 +36,21 @@ def test_selu_forward_backward(seed, scale, alpha, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     function_tester(rng, F.selu, ref_selu, inputs, func_args=[scale, alpha],
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("scale", [1.050700987355480, 1.0, 0.5, 0.0])
+@pytest.mark.parametrize("alpha", [1.673263242354377, 1.0, 0.5, 0.0])
+def test_selu_double_backward(seed, scale, alpha, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+    backward_function_tester(rng, F.selu, None,
+                             inputs=inputs,
+                             func_args=[scale, alpha], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_sigmoid.py
+++ b/python/test/function/test_sigmoid.py
@@ -33,3 +33,18 @@ def test_sigmoid_forward_backward(seed, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     function_tester(rng, F.sigmoid, ref_sigmoid, inputs,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_sigmoid_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+    backward_function_tester(rng, F.sigmoid, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3, atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_sigmoid_cross_entropy.py
+++ b/python/test/function/test_sigmoid_cross_entropy.py
@@ -35,3 +35,18 @@ def test_sigmoid_cross_entropy_forward_backward(seed, ctx, func_name):
                      * np.log(1 - 1 / (np.exp(-x) + 1))),
                     inputs,
                     atol_b=1e-2, ctx=ctx, func_name=func_name, backward=[True, False])
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_sigmoid_cross_entropy_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(
+        np.float32), rng.rand(2, 3, 4).astype(np.float32)]
+    inputs[1] = np.round(inputs[1])
+    backward_function_tester(rng, F.sigmoid_cross_entropy,
+                             None,
+                             inputs,
+                             atol_b=1e-2, atol_accum=1e-2, dstep=1e-3,
+                             ctx=ctx, func_name=func_name, backward=[True, False])

--- a/python/test/function/test_slice.py
+++ b/python/test/function/test_slice.py
@@ -68,3 +68,23 @@ def test_slice_forward_special(seed, inshape, start, stop, step, ctx, fname):
         x_key.forward()
 
     assert np.allclose(x_data_key, x_key.d)
+
+
+@pytest.mark.parametrize("ctx, fname", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, start, stop, step", [
+    ((2, 2), (0, 0), (2, 2), (1, 1)),
+    ((6, 7, 8), (1, 2, 3), (5, 4, 8), (1, 1, 2)),
+    ((6, 7, 6, 5), (4, 3, 2, 1), (5, 6, 5, 4), (1, 2, 3, 4)),
+    ((7, 6, 5, 4, 3), (5, 4, 3, 2, 1), (6, 6, 5, 4, 2), (1, 2, 3, 2, 1)),
+    # Negative but not empty array, different from test_slice_forward_backward
+    ((6, 7, 6, 5), (0, 0, 1, 2), (6, -1, -2, -2), (1, 1, 1, 1)),
+    ((6, 7, 6, 5), (5, 0, -2, 1), (4, -6, 5, 4), (-1, 2, 3, 4)),
+])
+def test_slice_double_backward(seed, inshape, start, stop, step, ctx, fname):
+    from nbla_test_utils import backward_function_tester, cap_ignore_region
+    rng = np.random.RandomState(seed)
+    x = rng.randn(*inshape).astype(np.float32)
+    backward_function_tester(rng, F.slice, None, [x], ctx=ctx, func_name=fname,
+                             func_args=[start, stop, step], atol_f=1e-4,
+                             atol_b=1e-2, atol_accum=1e-2, dstep=1e-4)

--- a/python/test/function/test_softmax.py
+++ b/python/test/function/test_softmax.py
@@ -25,12 +25,6 @@ def ref_softmax(x, axis):
     return x
 
 
-def ref_log_softmax(x, axis):
-    x = x - x.max(axis, keepdims=True)
-    x = x - np.log(np.exp(x).sum(axis, keepdims=True))
-    return x
-
-
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("axis", [0, 1, 2])
 @pytest.mark.parametrize("ctx, func_name", list_context('Softmax'))
@@ -44,10 +38,11 @@ def test_softmax_forward_backward(seed, axis, ctx, func_name):
 
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("axis", [0, 1, 2])
-@pytest.mark.parametrize("ctx, func_name", list_context('LogSoftmax'))
-def test_log_softmax_forward_backward(seed, axis, ctx, func_name):
-    from nbla_test_utils import function_tester
+@pytest.mark.parametrize("ctx, func_name", list_context('Softmax'))
+def test_softmax_double_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
     rng = np.random.RandomState(seed)
-    inputs = [rng.randn(2, 3, 4).astype(np.float32)]
-    function_tester(rng, F.log_softmax, ref_log_softmax, inputs, func_args=[axis],
-                    ctx=ctx, func_name=func_name, atol_b=1e-2)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+    backward_function_tester(rng, F.softmax, None, inputs, func_args=[axis],
+                             ctx=ctx, func_name=func_name,
+                             atol_b=1e-4, atol_accum=1e-4, dstep=1e-3)

--- a/python/test/function/test_softmax_cross_entropy.py
+++ b/python/test/function/test_softmax_cross_entropy.py
@@ -53,3 +53,27 @@ def test_softmax_cross_entropy_forward_backward(seed, axis, ctx, func_name):
     function_tester(rng, F.softmax_cross_entropy, ref_softmax_cross_entropy,
                     inputs, func_args=[axis], backward=[True, False],
                     atol_b=2e-3, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [314])
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_softmax_cross_entropy_double_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    ishape = [2, 3, 4]
+    rng = np.random.RandomState(seed)
+
+    l_shape = list(ishape)
+    l_shape[axis] = 1
+    n_class = ishape[axis]
+
+    inputs = [
+        rng.randn(2, 3, 4).astype(np.float32) * 2,
+        rng.randint(0, n_class, size=l_shape).astype(np.int)]
+
+    backward_function_tester(rng, F.softmax_cross_entropy, ref_softmax_cross_entropy,
+                             inputs, func_args=[axis], backward=[True, False],
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=func_name)

--- a/python/test/function/test_softplus.py
+++ b/python/test/function/test_softplus.py
@@ -33,3 +33,13 @@ def test_softplus_forward_backward(seed, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     function_tester(rng, F.softplus, ref_softplus, inputs,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_softplus_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
+    backward_function_tester(rng, F.softplus, None, inputs,
+                             ctx=ctx, func_name=func_name)

--- a/python/test/function/test_split.py
+++ b/python/test/function/test_split.py
@@ -43,3 +43,23 @@ def test_zero_value():
     a = nn.Variable((1, 6, 0))
     with pytest.raises(RuntimeError):
         F.split(a, axis=1)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("seed", [313])
+def test_split_double_backward(seed, axis, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    shape = [2, 3, 4]
+    x = rng.randn(*shape).astype(np.float32)
+    inputs = [x]
+    backward_function_tester(rng, F.split, None,
+                             inputs=inputs,
+                             func_args=[axis], func_kwargs={},
+                             atol_f=1e-3,
+                             atol_b=5e-3,
+                             atol_accum=5e-3,
+                             dstep=1e-2,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_squared_error.py
+++ b/python/test/function/test_squared_error.py
@@ -29,3 +29,13 @@ def test_squared_error_forward_backward(seed, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2 for _ in range(2)]
     function_tester(rng, F.squared_error, lambda x, y: (x - y)**2, inputs,
                     atol_b=2e-2, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_squared_error_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2 for _ in range(2)]
+    backward_function_tester(rng, F.squared_error, None, inputs,
+                             atol_b=2e-1, atol_accum=2e-1, ctx=ctx, func_name=func_name)

--- a/python/test/function/test_stack.py
+++ b/python/test/function/test_stack.py
@@ -38,3 +38,22 @@ def test_stack_forward_backward(seed, axis, num_inputs, ctx, func_name):
     function_tester(rng, F.stack, ref_stack, inputs,
                     func_kwargs=dict(axis=axis), ctx=ctx, func_name=func_name,
                     atol_b=2e-3)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("axis", [0, 1, 2])
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("num_inputs", [2, 3])
+def test_stack_double_backward(seed, axis, num_inputs, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    shape = [2, 3, 4]
+    inputs = [rng.randn(*shape).astype(np.float32) for x in range(num_inputs)]
+    backward_function_tester(rng, F.stack, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs=dict(axis=axis),
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_stft.py
+++ b/python/test/function/test_stft.py
@@ -17,15 +17,25 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 import scipy.signal as sig
+from nbla_test_utils import list_context
+
+# Proxy to get the appropriate context.
+# Using convolution is natural since stft/istft depends on 1d convolution now.
+ctx_list = [ctx_fname[0] for ctx_fname in list_context('Convolution')]
 
 
+@pytest.mark.parametrize("ctx", ctx_list)
 @pytest.mark.parametrize("window_size, stride, fft_size, window_type, center", [
     (256, 128, 512, 'hamming', True),
     (256, 128, 256, 'hanning', False),
     (256, 128, 512, None, True),
     (256, 128, 256, 'rectangular', False),
 ])
-def test_istft(window_size, stride, fft_size, window_type, center):
+def test_istft(ctx, window_size, stride, fft_size, window_type, center):
+    backend = ctx.backend[0].split(":")[0]
+    if backend == 'cuda':
+        pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
+
     # clear all previous STFT conv/deconv kernels
     nn.clear_parameters()
 
@@ -33,18 +43,19 @@ def test_istft(window_size, stride, fft_size, window_type, center):
     x = np.random.randn(1, window_size * 10)
 
     nx = nn.Variable.from_numpy_array(x)
-    nyr, nyi = F.stft(nx,
-                      window_size=window_size,
-                      stride=stride,
-                      fft_size=fft_size,
-                      window_type=window_type,
-                      center=center)
-    nz = F.istft(nyr, nyi,
-                 window_size=window_size,
-                 stride=stride,
-                 fft_size=fft_size,
-                 window_type=window_type,
-                 center=center)
+    with nn.context_scope(ctx):
+        nyr, nyi = F.stft(nx,
+                          window_size=window_size,
+                          stride=stride,
+                          fft_size=fft_size,
+                          window_type=window_type,
+                          center=center)
+        nz = F.istft(nyr, nyi,
+                     window_size=window_size,
+                     stride=stride,
+                     fft_size=fft_size,
+                     window_type=window_type,
+                     center=center)
     nz.forward()
 
     invalid = window_size - stride
@@ -53,10 +64,15 @@ def test_istft(window_size, stride, fft_size, window_type, center):
                        atol=1e-5, rtol=1e-5))
 
 
+@pytest.mark.parametrize("ctx", ctx_list)
 @pytest.mark.parametrize("window_size, stride, fft_size, window_type", [
     (256, 128, 256, 'hanning'),
 ])
-def test_stft(window_size, stride, fft_size, window_type):
+def test_stft(ctx, window_size, stride, fft_size, window_type):
+    backend = ctx.backend[0].split(":")[0]
+    if backend == 'cuda':
+        pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
+
     # clear all previous STFT conv/deconv kernels
     nn.clear_parameters()
 
@@ -64,12 +80,14 @@ def test_stft(window_size, stride, fft_size, window_type):
     x = np.random.randn(1, window_size * 10)
 
     nx = nn.Variable.from_numpy_array(x)
-    nyr, nyi = F.stft(nx,
-                      window_size=window_size,
-                      stride=stride,
-                      fft_size=fft_size,
-                      window_type=window_type,
-                      center=False)
+
+    with nn.context_scope(ctx):
+        nyr, nyi = F.stft(nx,
+                          window_size=window_size,
+                          stride=stride,
+                          fft_size=fft_size,
+                          window_type=window_type,
+                          center=False)
     nn.forward_all([nyr, nyi])
 
     stft_nnabla = nyr.d + 1j * nyi.d

--- a/python/test/function/test_sub2.py
+++ b/python/test/function/test_sub2.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This is still left unlike other *2 operation (sub2, mul2, ...) because
+it has cudnn implementation.
+"""
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('Sub2')
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_sub2_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(2, 3).astype(np.float32),
+              rng.randn(2, 3).astype(np.float32)]
+    backward_function_tester(rng, F.sub2, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-3,
+                             atol_accum=1e-3,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_sum_pooling.py
+++ b/python/test/function/test_sum_pooling.py
@@ -110,3 +110,55 @@ def test_sum_pooling_3d(seed, inshape, kernel, stride, pad, ignore_border, chann
     function_tester(rng, F.sum_pooling, ref_sum_pooling, inputs=inputs,
                     func_args=func_args, func_name=func_name, ctx=ctx,
                     atol_f=1e-6, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ignore_border", [True, False])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("inshape, kernel, stride, pad", [
+    ((2, 2, 4, 6), (2, 2), (2, 1), (1, 0)),
+    ((2, 2, 2, 4, 6), (2, 2), (1, 2), (0, 1)),
+])
+def test_sum_pooling_2d_double_backward(seed, inshape, kernel, stride, pad, ignore_border, channel_last,
+                                        ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    if channel_last:
+        pytest.skip('Channel last is not supported in the double backward.')
+    # if channel_last and not func_name.endswith('Cudnn'):
+    #     pytest.skip('Channel last is only supported in Cudnn so far')
+    # if channel_last:
+    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [kernel, stride, ignore_border, pad, channel_last]
+    backward_function_tester(rng, F.sum_pooling, ref_sum_pooling, inputs=inputs,
+                             func_args=func_args, func_name=func_name, ctx=ctx,
+                             atol_f=1e-6, atol_b=1e-2, atol_accum=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ignore_border", [True, False])
+@pytest.mark.parametrize("channel_last", [False, True])
+@pytest.mark.parametrize("inshape, kernel, stride, pad", [
+    ((2, 2, 3, 4, 6), (2, 2, 2), (2, 1, 1), (1, 0, 1)),
+    ((2, 2, 2, 3, 4, 6), (2, 2, 2), (1, 1, 2), (0, 1, 0)),
+])
+def test_sum_pooling_3d_double_backward(seed, inshape, kernel, stride, pad, ignore_border, channel_last,
+                                        ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    if channel_last:
+        pytest.skip('Channel last is not supported in the double backward.')
+    # if channel_last and not func_name.endswith('Cudnn'):
+    #     pytest.skip('Channel last is only supported in Cudnn so far')
+    # if channel_last:
+    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    func_args = [kernel, stride, ignore_border, pad, channel_last]
+    backward_function_tester(rng, F.sum_pooling, ref_sum_pooling, inputs=inputs,
+                             func_args=func_args, func_name=func_name, ctx=ctx,
+                             atol_f=1e-6, atol_b=1e-1, atol_accum=1e-1)

--- a/python/test/function/test_swish.py
+++ b/python/test/function/test_swish.py
@@ -33,3 +33,22 @@ def test_swish_forward_backward(seed, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     function_tester(rng, F.swish, ref_swish, inputs,
                     ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_swish_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        cap_ignore_region(
+            rng.randn(2, 3, 4).astype(np.float32) * 2,
+            (-1e-3, 1e-3))]
+    backward_function_tester(rng, F.swish, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-2,
+                             atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_tanh.py
+++ b/python/test/function/test_tanh.py
@@ -28,3 +28,22 @@ def test_tanh_forward_backward(seed, ctx, func_name):
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 1]
     function_tester(rng, F.tanh, np.tanh, inputs, ctx=ctx, func_name=func_name)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_tanh_double_backward(seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [
+        cap_ignore_region(
+            rng.randn(2, 3, 4).astype(np.float32) * 2,
+            (-1e-3, 1e-3))]
+    backward_function_tester(rng, F.tanh, None,
+                             inputs=inputs,
+                             func_args=[], func_kwargs={},
+                             atol_b=1e-2,
+                             atol_accum=1e-2,
+                             dstep=1e-3,
+                             ctx=ctx, func_name=None,
+                             disable_half_test=True)

--- a/python/test/function/test_transpose.py
+++ b/python/test/function/test_transpose.py
@@ -39,3 +39,21 @@ def test_transpose_forward_backward(seed, inshape, axes, ctx, func_name):
     inputs = [rng.randn(*inshape).astype(np.float32)]
     function_tester(rng, F.transpose, ref_transpose, inputs, func_args=[
                     axes], ctx=ctx, func_name=func_name, atol_f=1e-6, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, axes",
+                         [((11, 13, 7), (2, 1, 0)),
+                          ((3, 7, 4, 5), (3, 0, 1, 2)),
+                          ((4, 2, 5, 2, 3), (3, 0, 1, 2, 4)),
+                          ((4, 2, 3, 2, 3, 3), (5, 3, 0, 1, 2, 4))])
+def test_transpose_double_backward(seed, inshape, axes, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    # Input
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    # TODO: backward_ref
+    backward_function_tester(rng, F.transpose, ref_transpose, inputs,
+                             func_args=[axes], ctx=ctx, func_name=func_name,
+                             atol_f=1e-6, atol_b=1e-2, atol_accum=1e-2, dstep=1e-3)

--- a/python/test/function/test_unpooling.py
+++ b/python/test/function/test_unpooling.py
@@ -42,3 +42,19 @@ def test_unpooling_forward_backward(seed, inshape, kernel, ctx, func_name):
                     func_args=[kernel],
                     ctx=ctx, func_name=func_name,
                     atol_f=1e-6, atol_b=1e-2)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape", [(1, 2, 3), (2, 4, 6), (2, 2, 4, 6), (2, 2, 2, 4, 6)])
+@pytest.mark.parametrize("kernel", [(1, 1), (2, 3), (2, 1, 2)])
+def test_unpooling_double_backward(seed, inshape, kernel, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    backward_function_tester(rng,
+                             F.unpooling, None,
+                             inputs=inputs,
+                             func_args=[kernel],
+                             ctx=ctx, func_name=func_name,
+                             atol_f=1e-6, atol_b=1e-1, atol_accum=1e-1)

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -803,7 +803,7 @@ def backward_function_tester(rng, func, ref_func, inputs,
     grads = nn.grad(voutputs, vinputs, agrad_outputs)
     grads = list(filter(lambda x: x is not None, grads))
     o = F.sink(*grads)
-    o.forward(clear_buffer=True)
+    o.forward()
     # Check forward
     for vi, go in zip(vinputs, grads):
         if vi.need_grad is False:

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -238,6 +238,14 @@ def force_tuple(x):
     return (x,)
 
 
+def force_list(x):
+    if isinstance(x, list):
+        return x
+    if isinstance(x, tuple):
+        return list(x)
+    return [x]
+
+
 def half_test(rng, func, finputs, hinputs, func_args, func_kwargs, backward, ctx, func_name, atol=1e-1):
 
     # 0. Define utility functions
@@ -677,3 +685,168 @@ def convert_to_complex_array(x_float2, dtype=np.complex64):
     x_imag = x_float2[..., 1]
     x_complex = x_real + 1j * x_imag
     return x_complex
+
+
+def backward_function_tester(rng, func, ref_func, inputs,
+                             func_args=[], func_kwargs={},
+                             atol_f=1e-6, atol_b=1e-3, atol_accum=1e-3, dstep=1e-3, backward=None,
+                             ctx=None, func_name=None, ref_grad=None, disable_half_test=False, atol_half=1e-1):
+    """Backward function tester
+
+    In the forward test, it compares the results of nn.grad and `func`.backward.
+    In the backward test, it compares the analytical gradients and numerical gradient with `grad_outputs`.
+    """
+    # TODO: half
+
+    from scipy.optimize import approx_fprime
+
+    if ctx is None:
+        ctx = nn.Context()
+    if backward is None:
+        backward = [True if i is not None else False for i in inputs]
+
+    # TODO: Remove set_default_context after adding ctx to BackwardFunction.
+    nn.set_default_context(ctx)
+
+    # Create Variables
+    def create_variables(inputs, backward):
+        vinputs = []
+        for i, b in zip(inputs, backward):
+            if i is None:
+                vinputs += [None]
+                continue
+            vinputs += [nn.Variable(i.shape, need_grad=b)]
+            vinputs[-1].data.cast(i.dtype)[...] = i
+        return vinputs
+
+    # Create grad_outputs
+    def create_grad_outputs(outputs):
+        grad_outputs = []
+        for o in outputs:
+            if o.shape == ():
+                go = nn.NdArray.from_numpy_array(np.array(rng.randn()))
+                #go = nn.NdArray.from_numpy_array(np.array(1.0))
+            else:
+                go = nn.NdArray.from_numpy_array(rng.randn(*o.shape))
+                #go = nn.NdArray.from_numpy_array(np.ones(o.shape))
+
+            grad_outputs.append(go)
+        return grad_outputs
+
+    # Fill grads
+    def fill_grads(vinputs, grads):
+        for vi, gd in zip(vinputs, grads):
+            if vi is None:
+                continue
+            vi.g = gd
+
+    # Fill grads
+    def zero_grads(vinputs):
+        for vi in vinputs:
+            if vi is None:
+                continue
+            vi.grad.zero()
+        return
+
+    # Gradient penalty on grads
+    def gradient_penalty2(grads):
+        gp2 = 0.0
+        for g in grads:
+            gp2 += F.sum(g ** 2.0)
+        return gp2
+    # Product sum
+
+    def prod_sum(inputs0, inputs1):
+        out = 0.0
+        for inp0, inp1 in zip(inputs0, inputs1):
+            out += inp0 * nn.Variable(inp1.shape).apply(data=inp1)
+        return out
+    # Set inputs for the numerical gradients
+
+    def set_inputs(inputs0, vinputs):
+        begin = 0
+        for i in vinputs:
+            end = begin + i.size
+            if i.need_grad == True:
+                i.d = inputs0[begin:end].reshape(i.shape)
+            begin = end
+
+    # Gradient penalty on grads used for computing numerical gradients
+    def obj_func(inputs0, gp2, vinputs):
+        set_inputs(inputs0, vinputs)
+        gp2.forward()
+        return gp2.d.copy()
+
+    # # Half test
+    # if not disable_half_test:
+    #     finputs = create_variables(inputs, backward)
+    #     hinputs = create_variables(inputs, backward)
+    #     half_test(rng, func, finputs, hinputs, func_args,
+    #               func_kwargs, backward, ctx, func_name, atol=atol_half)
+
+    # Create input variables
+    vinputs = create_variables(inputs, backward)
+    # --- Forward test --- #
+    # Zero grads
+    zero_grads(vinputs)
+    # Forward/Backward on the forward graph
+    voutputs = [F.sigmoid(x) for x in force_list(
+        func(*(vinputs + func_args), **func_kwargs))]
+    agrad_outputs = create_grad_outputs(voutputs)
+    o = prod_sum(voutputs, agrad_outputs)
+    o.forward()
+    o.backward()  # clear_buffer=True)
+    # Grads
+    voutputs = voutputs
+    vinputs = list(filter(lambda vi: vi is not None, vinputs))
+    agrad_outputs = agrad_outputs
+    grads = nn.grad(voutputs, vinputs, agrad_outputs)
+    grads = list(filter(lambda x: x is not None, grads))
+    o = F.sink(*grads)
+    o.forward(clear_buffer=True)
+    # Check forward
+    for vi, go in zip(vinputs, grads):
+        if vi.need_grad is False:
+            continue
+        fgrads = vi.g
+        bgrads = go.d
+        assert np.allclose(fgrads, bgrads, atol=atol_f), str(
+            ArrayDiffStats(fgrads, bgrads))
+
+    # TODO: 1. Pass function argument directly to backward functions.
+    # TODO: 2. should be changed for the simplier form by simply testing BackwardFunction
+
+    # --- Backward (accum = False) test --- #
+    # Zero grads
+    zero_grads(vinputs)
+    # Compute analytical grads
+    gp2 = gradient_penalty2(grads)
+    gp2.forward()
+    gp2.backward(clear_buffer=True)
+    analytical_grads = np.concatenate(
+        [vi.g.copy().flatten() for vi in vinputs])
+    analytical_grads0 = analytical_grads
+    # Compute numerical grads
+    inputs0 = np.concatenate([inp.flatten()
+                              for inp in inputs if inp is not None])
+    numerical_grads = approx_fprime(inputs0, obj_func, dstep, gp2, vinputs)
+    # Check backward
+    assert np.allclose(analytical_grads, numerical_grads, atol=atol_b), \
+        str(ArrayDiffStats(analytical_grads, numerical_grads))
+
+    # --- Backward (accum = True) test --- #
+    # Random grads
+    rand_grads = [rng.randn(*vi.shape) for vi in vinputs]
+    fill_grads(vinputs, rand_grads)
+    # Compute analytical grads
+    gp2.forward()
+    gp2.backward(clear_buffer=True)
+
+    analytical_grads = np.concatenate(
+        [vi.g.copy().flatten() for vi in vinputs])
+    rand_grads = np.concatenate([rg.flatten() if isinstance(rg, np.ndarray) else np.array(rg).reshape((1, ))
+                                 for rg in rand_grads])
+    analytical_grads -= rand_grads
+    # Check backward
+    assert np.allclose(analytical_grads, analytical_grads0, atol=atol_accum), \
+        str(ArrayDiffStats(analytical_grads, analytical_grads0))

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -183,8 +183,8 @@ def compute_analytical_and_numerical_grad(f, inputs, outputs, inputs0,
 def cap_ignore_region(arr, region):
     assert len(region) == 2
     region = sorted(region)
-    arr = arr.copy()
-    arr[np.logical_and(arr > region[0], arr < region[0])] = region[0]
+    arr0 = arr.copy()
+    arr[np.logical_and(arr > region[0], arr < region[1])] = region[0]
     return arr
 
 
@@ -221,6 +221,7 @@ class ArrayDiffStats:
 
     def __str__(self):
         lines = [
+            '',
             '[diff]',
             str(self.diffstat),
             '[left]',

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -1,0 +1,185 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+import nnabla.parametric_functions as PF
+from nnabla.ext_utils import get_extension_context
+from nbla_test_utils import list_context
+
+# Proxy to get the appropriate context
+ctx_list = [ctx_fname[0] for ctx_fname in list_context('Convolution')]
+
+
+def SmallResNet(x, test=False):
+    h = x
+
+    def conv(x, maps=8, name="conv"):
+        h = x
+        with nn.parameter_scope(name):
+            h = PF.convolution(h, maps, (3, 3), (1, 1), with_bias=False)
+            h = PF.batch_normalization(h, batch_stat=not test)
+        with nn.parameter_scope("{}-shortcut".format(name)):
+            s = PF.convolution(h, maps, (3, 3), (1, 1), with_bias=False)
+            h = PF.batch_normalization(h, batch_stat=not test)
+        return F.relu(h + s)
+    h = conv(h, maps=8, name="conv1")
+    h = F.max_pooling(h, (2, 2))
+    h = conv(h, maps=16, name="conv2")
+    h = F.average_pooling(h, h.shape[2:])
+    h = PF.affine(h, 10)
+    return h
+
+
+@pytest.mark.parametrize("seed", [311])
+@pytest.mark.parametrize("ctx", ctx_list)
+@pytest.mark.parametrize("auto_forward", [True, False])
+@pytest.mark.parametrize("flag_grad_outputs", [True, False])
+def test_resnet_expansion(seed, ctx, auto_forward, flag_grad_outputs):
+    from nbla_test_utils import ArrayDiffStats
+    nn.clear_parameters()
+
+    # Settings
+    nn.set_default_context(ctx)
+    nn.set_auto_forward(auto_forward)
+    b, c, h, w = 4, 3, 32, 32
+    n_cls = 10
+    rng = np.random.RandomState(seed)
+
+    # Network
+    x = nn.Variable.from_numpy_array(rng.randn(b, c, h, w))
+    y = nn.Variable.from_numpy_array(rng.randint(0, n_cls, b).reshape(b, 1))
+    p = SmallResNet(x)
+    loss = F.mean(F.softmax_cross_entropy(p, y))
+
+    # Zerograd, Forward, Backward on the forward graph
+    inputs = nn.get_parameters().values()
+    [inp.grad.fill(0) for inp in inputs]
+    grad = nn.NdArray.from_numpy_array(
+        np.asarray(rng.randn())) if flag_grad_outputs else 1
+    if not auto_forward:
+        loss.forward()
+    loss.backward(grad)
+
+    # Grad
+    grad_outputs = grad if flag_grad_outputs else None
+    grads = nn.grad([loss], inputs, [grad_outputs])
+    if not auto_forward:
+        F.sink(*grads, one_input_grad=1).forward()
+
+    # Check between results of var.bacwkard and nn.grad
+    backend = ctx.backend[0].split(":")[0]
+    if backend == 'cuda':
+        pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
+    for inp, grad in zip(inputs, grads):
+        assert np.allclose(
+            inp.g, grad.d, atol=1e-6), str(ArrayDiffStats(inp.g, grad.d))
+
+
+@pytest.mark.parametrize("seed", [311])
+@pytest.mark.parametrize("ctx", ctx_list)
+@pytest.mark.parametrize("auto_forward", [True, False])
+def test_multiple_objectives(seed, ctx, auto_forward):
+    from nbla_test_utils import ArrayDiffStats
+
+    # Settings
+    nn.set_default_context(ctx)
+    nn.set_auto_forward(auto_forward)
+    b, c, h, w = 4, 3, 32, 32
+    n_cls = 10
+    rng = np.random.RandomState(seed)
+
+    # Objecive0
+    x0 = nn.Variable.from_numpy_array(
+        rng.randn(b, c, h, w)).apply(need_grad=True)
+    y0 = F.sigmoid(x0)
+    # Objecive1
+    x1 = nn.Variable.from_numpy_array(
+        rng.randn(b, c, h, w)).apply(need_grad=True)
+    y1 = F.tanh(x1)
+
+    # Zerograd, Forward, Backward on the forward graph
+    g0 = nn.NdArray.from_numpy_array(rng.randn(*x0.shape))
+    g1 = nn.NdArray.from_numpy_array(rng.randn(*x1.shape))
+    z = y0 * nn.Variable(g0.shape).apply(data=g0) + y1 * \
+        nn.Variable(g1.shape).apply(data=g1)
+    inputs = [x0, x1]
+    [inp.grad.fill(0) for inp in inputs]
+    if not auto_forward:
+        z.forward()
+    z.backward()
+
+    # Grad
+    inputs = [x0, x1]
+    outputs = [y0, y1]
+    grad_outputs = [g0, g1]
+    grads = nn.grad(outputs, inputs, grad_outputs)
+    if not auto_forward:
+        F.sink(*grads, one_input_grad=1).forward()
+
+    # Check between results of var.bacwkard and nn.grad
+    for inp, grad in zip(inputs, grads):
+        assert np.allclose(
+            inp.g, grad.d, atol=1e-6), str(ArrayDiffStats(inp.g, grad.d))
+
+
+@pytest.mark.parametrize("seed", [311])
+@pytest.mark.parametrize("ctx", ctx_list)
+@pytest.mark.parametrize("auto_forward", [True, False])
+@pytest.mark.parametrize("type_grad_outputs", [int, float, np.ndarray, nn.NdArray])
+def test_grad_outputs(seed, ctx, auto_forward, type_grad_outputs):
+    from nbla_test_utils import ArrayDiffStats
+
+    # Settings
+    nn.set_default_context(ctx)
+    nn.set_auto_forward(auto_forward)
+    b, c, h, w = 4, 3, 32, 32
+    n_cls = 10
+    rng = np.random.RandomState(seed)
+
+    x = nn.Variable.from_numpy_array(
+        rng.randn(b, c, h, w)).apply(need_grad=True)
+    y = F.sigmoid(x)
+
+    # Grad outputs
+    if type_grad_outputs == int:
+        g = rng.randint(-10, 10)
+    elif type_grad_outputs == float:
+        g = rng.randn()
+    elif type_grad_outputs == np.ndarray:
+        g = rng.randn(*y.shape)
+    elif type_grad_outputs == nn.NdArray:
+        g = nn.NdArray.from_numpy_array(rng.randn(*y.shape))
+
+    # Zerograd, Forward, Backward on the forward graph
+    inputs = [x]
+    [inp.grad.fill(0) for inp in inputs]
+    if not auto_forward:
+        y.forward()
+    y.backward(g)
+
+    # Grad
+    inputs = [x]
+    outputs = [y]
+    grad_outputs = [g]
+    grads = nn.grad(outputs, inputs, grad_outputs)
+    if not auto_forward:
+        F.sink(*grads, one_input_grad=1).forward()
+
+    # Check between results of var.bacwkard and nn.grad
+    for inp, grad in zip(inputs, grads):
+        assert np.allclose(
+            inp.g, grad.d, atol=1e-6), str(ArrayDiffStats(inp.g, grad.d))

--- a/src/nbla/function/generic/max_pooling_backward.cpp
+++ b/src/nbla/function/generic/max_pooling_backward.cpp
@@ -1,0 +1,237 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/function/max_pooling_backward.hpp>
+#include <nbla/variable.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+namespace nbla {
+
+using std::min;
+using std::max;
+using std::ceil;
+
+NBLA_REGISTER_FUNCTION_SOURCE(MaxPoolingBackward, const vector<int> &,
+                              const vector<int> &, bool, const vector<int> &,
+                              bool);
+
+namespace max_pooling_impl {
+
+template <typename TI, typename TO, int NDIM>
+inline const std::array<TO, NDIM> v2a(const std::vector<TI> &v,
+                                      const int skip = 0) {
+  std::array<TO, NDIM> a;
+  for (int i = 0; i < NDIM; i++)
+    a[i] = v.at(skip + i);
+  return a;
+}
+
+typedef std::array<int, 2> Array2D;
+typedef std::array<int, 3> Array3D;
+
+template <typename T>
+inline void forward_map(const T *x, T *y, int *m, const Array2D &x_stride,
+                        const Array2D &x_shape, const Array2D &y_shape,
+                        const Array2D &kernel, const Array2D &stride,
+                        const Array2D &pad) {
+  Array2D y_idx, pool_start, pool_end;
+
+  for (y_idx[0] = 0; y_idx[0] < y_shape[0]; ++y_idx[0]) {
+    for (y_idx[1] = 0; y_idx[1] < y_shape[1]; ++y_idx[1]) {
+      for (int a = 0; a < 2; a++) {
+        pool_start[a] = y_idx[a] * stride[a] - pad[a];
+        pool_end[a] = min(pool_start[a] + kernel[a], x_shape[a] + pad[a]);
+        pool_start[a] = max(pool_start[a], 0);
+        pool_end[a] = min(pool_end[a], x_shape[a]);
+      }
+      auto max_idx = pool_start[0] * x_stride[0] + pool_start[1];
+      auto max_val = x[max_idx];
+      for (int i0 = pool_start[0]; i0 < pool_end[0]; ++i0) {
+        for (int i1 = pool_start[1]; i1 < pool_end[1]; ++i1) {
+          auto idx = i0 * x_stride[0] + i1;
+          if (max_val < x[idx]) {
+            max_val = x[idx];
+            max_idx = idx;
+          }
+        }
+      }
+      *m++ = max_idx;
+      *y++ = max_val;
+    }
+  }
+}
+
+template <typename T>
+inline void forward_map(const T *x, T *y, int *m, const Array3D &x_stride,
+                        const Array3D &x_shape, const Array3D &y_shape,
+                        const Array3D &kernel, const Array3D &stride,
+                        const Array3D &pad) {
+  Array3D y_idx, pool_start, pool_end;
+
+  for (y_idx[0] = 0; y_idx[0] < y_shape[0]; ++y_idx[0]) {
+    for (y_idx[1] = 0; y_idx[1] < y_shape[1]; ++y_idx[1]) {
+      for (y_idx[2] = 0; y_idx[2] < y_shape[2]; ++y_idx[2]) {
+        for (int a = 0; a < 3; a++) {
+          pool_start[a] = y_idx[a] * stride[a] - pad[a];
+          pool_end[a] = min(pool_start[a] + kernel[a], x_shape[a] + pad[a]);
+          pool_start[a] = max(pool_start[a], 0);
+          pool_end[a] = min(pool_end[a], x_shape[a]);
+        }
+        auto max_idx = (pool_start[0] * x_stride[0] +
+                        pool_start[1] * x_stride[1] + pool_start[2]);
+        auto max_val = x[max_idx];
+        for (int i0 = pool_start[0]; i0 < pool_end[0]; ++i0) {
+          for (int i1 = pool_start[1]; i1 < pool_end[1]; ++i1) {
+            for (int i2 = pool_start[2]; i2 < pool_end[2]; ++i2) {
+              auto idx = i0 * x_stride[0] + i1 * x_stride[1] + i2;
+              if (max_val < x[idx]) {
+                max_val = x[idx];
+                max_idx = idx;
+              }
+            }
+          }
+        }
+        *m++ = max_idx;
+        *y++ = max_val;
+      }
+    }
+  }
+}
+
+template <typename T, bool accum>
+inline void backward_map(T *g_dy, const T *g_dx, const int *m, int n_map,
+                         const int x_map_size, const int y_map_size) {
+  while (n_map--) {
+    for (int k = 0; k < y_map_size; k++) {
+      if (accum)
+        g_dy[k] += g_dx[m[k]];
+      else
+        g_dy[k] = g_dx[m[k]];
+    }
+    g_dy += y_map_size;
+    g_dx += x_map_size;
+    m += y_map_size;
+  }
+}
+
+} // namespace max_pooling_impl
+
+template <typename T>
+void MaxPoolingBackward<T>::setup_impl(const Variables &inputs,
+                                       const Variables &outputs) {
+  outputs[0]->reshape(inputs[0]->shape(), true);
+}
+
+template <typename T>
+void MaxPoolingBackward<T>::forward_impl(const Variables &inputs,
+                                         const Variables &outputs) {
+  NBLA_ERROR(error_code::not_implemented,
+             "Do not call MaxPoolingBackward::forward. \n"
+             "This is the temporal function to support the double backward of "
+             "the max pooling. \n"
+             "Directly call the backward method.");
+}
+
+using nbla::max_pooling_impl::v2a;
+using nbla::max_pooling_impl::Array2D;
+using nbla::max_pooling_impl::Array3D;
+using nbla::max_pooling_impl::forward_map;
+using nbla::max_pooling_impl::backward_map;
+
+template <typename T>
+void MaxPoolingBackward<T>::backward_impl(const Variables &inputs,
+                                          const Variables &outputs,
+                                          const vector<bool> &propagate_down,
+                                          const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+
+  // w.r.t. x
+  if (propagate_down[0]) {
+    if (!accum[0]) {
+      inputs[0]->grad()->zero();
+    }
+  }
+
+  // w.r.t. dy
+  if (propagate_down[1]) {
+
+    // Dummy output and Index
+    Variable yv;
+    Variable max_idx;
+    yv.reshape(inputs[1]->shape(), true);
+    max_idx.reshape(inputs[1]->shape(), true);
+
+    // Once create indices
+    auto x = inputs[0]->get_data_pointer<T>(this->ctx_);
+    auto y = yv.cast_data_and_get_pointer<T>(this->ctx_, true);
+    auto m = max_idx.cast_data_and_get_pointer<int>(
+        this->ctx_, false); // read and write in this function
+
+    const Shape_t &inshape = inputs[0]->shape();
+    const Shape_t &outshape = inputs[1]->shape();
+    const Shape_t &instrides = inputs[0]->strides();
+    const Shape_t &outstrides = inputs[1]->strides();
+    const int s = inshape.size() - this->kernel_.size();
+    const int x_map_size = (s == 0) ? inputs[0]->size() : instrides[s - 1];
+    const int y_map_size = (s == 0) ? inputs[1]->size() : outstrides[s - 1];
+    int n_map = inputs[0]->size() / x_map_size;
+
+    if (this->kernel_.size() == 2) {
+      const auto x_stride = v2a<Size_t, int, 2>(instrides, s);
+      const auto x_shape = v2a<Size_t, int, 2>(inshape, s);
+      const auto y_shape = v2a<Size_t, int, 2>(outshape, s);
+      const auto kernel = v2a<int, int, 2>(this->kernel_);
+      const auto stride = v2a<int, int, 2>(this->stride_);
+      const auto pad = v2a<int, int, 2>(this->pad_);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+      for (int n = 0; n < n_map; ++n) {
+        forward_map(x + n * x_map_size, y + n * y_map_size, m + n * y_map_size,
+                    x_stride, x_shape, y_shape, kernel, stride, pad);
+      }
+    }
+
+    else if (this->kernel_.size() == 3) {
+      const auto x_stride = v2a<Size_t, int, 3>(instrides, s);
+      const auto x_shape = v2a<Size_t, int, 3>(inshape, s);
+      const auto y_shape = v2a<Size_t, int, 3>(outshape, s);
+      const auto kernel = v2a<int, int, 3>(this->kernel_);
+      const auto stride = v2a<int, int, 3>(this->stride_);
+      const auto pad = v2a<int, int, 3>(this->pad_);
+#ifdef _OPENMP
+#pragma omp parallel for schedule(static)
+#endif
+      for (int n = 0; n < n_map; ++n) {
+        forward_map(x + n * x_map_size, y + n * y_map_size, m + n * y_map_size,
+                    x_stride, x_shape, y_shape, kernel, stride, pad);
+      }
+    }
+
+    // Map
+    auto g_dx = outputs[0]->get_grad_pointer<T>(this->ctx_);
+    auto g_dy = inputs[1]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[1]);
+    if (accum[1])
+      backward_map<T, true>(g_dy, g_dx, m, n_map, x_map_size, y_map_size);
+    else
+      backward_map<T, false>(g_dy, g_dx, m, n_map, x_map_size, y_map_size);
+  }
+}
+}


### PR DESCRIPTION
We support the double backward, i.e., the second-order gradients of outputs with respect to inputs like 

```python
grads = nn.grad(outputs, inputs)

# Manipulate {grads} as usual variables. 
```

Have a look at the documentation for details after the release.

Currently, the following functions support the double-backward.

* abs
* absolute_error
* add_scalar
* add2
* affine
* average_pooling
* batch_matmul
* batch_normalization
* binary_cross_entropy
* broadcast
* categorical_cross_entropy
* ceil
* celu
* concatenate
* convolution
* crelu
* deconvolution
* div2
* dropout
* embed
* epsilon_insensitive_loss
* exp
* floor
* hard_sigmoid
* hard_tanh
* huber_loss
* identity
* interpolate
* leaky_relu
* log
* log_sigmoid
* log_softmax
* max
* max_pooling
* maximum_scalar
* maximum2
* mean
* min
* minimum_scalar
* minimum2
* mul_scalar
* mul2
* pad
* pow_scalar
* pow2
* prelu
* r_div_scalar
* r_pow_scalar
* r_sub_scalar
* relu
* relu6
* reshape
* round
* selu
* sigmoid
* sigmoid_cross_entropy
* slice
* softmax
* softmax_cross_entropy
* softplus
* split
* squared_error
* stack
* sub2
* sum
* sum_pooling
* swish
* tanh
* transpose
* unpooling

The double-backward of each function is now implemented in the python-layer using PythonFunction, we plan to move it to the C++/CUDA layer at a certain time.

Many thanks for reviewers @TE-andrewshin @TE-AkioHayakawa @TE-TakuyaNarihira @TE-TakuyaYashima @TE-NaokiIde @TE-StefanUhlich @TE-FabienCardinaux @TE-StephenTiedemann @TE-JavierAlonsoGarcia @TE-LukasMauch, especially @TE-TakuyaNarihira @TE-StefanUhlich @TE-LukasMauch.
