### PR TITLE
Feature/20190812 skip all reduce if zeroing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@
 /python/src/nnabla/_nd_array.cpp
 /python/src/nnabla/_variable.cpp
 /python/src/nnabla/_version.py
+/python/src/nnabla/backward_functions.py
 /python/src/nnabla/clibtest
 /python/src/nnabla/communicator.cpp
 /python/src/nnabla/cpp_graph_example

--- a/include/nbla/solver.hpp
+++ b/include/nbla/solver.hpp
@@ -70,18 +70,15 @@ public:
   };
 
 protected:
-  /** Struct for storing both parameter Variable and update status of gradient.
+  /** Struct for storing a parameter variable.
+
+      @note The previous implementation had another member variable in this
+            struct to manage update status of a parameter. Now it doesn't.
    */
   struct Params {
     /** Shared pointer to parameter Variable.
      */
     VariablePtr p;
-
-    /** Modification count of p.grad_, which tells whether or not the grad
-     * region
-     * is modified after the previous update.
-     */
-    size_t at;
   };
 
   unordered_map<string, SolverState> states_; ///< Hash map of states

--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -131,7 +131,10 @@ public:
   /** Get whether or not it fills array values obtained in cast/get call later.
 
       This is provided to determine gradient accumulation flags in our
-     computation graph engine.
+     computation graph engine, as well as to determine whether or not solver and
+     communicator execute their operations by depending on whether gradients are
+     updated.
+
    */
   bool zeroing() const;
 

--- a/python/setup.py
+++ b/python/setup.py
@@ -250,6 +250,7 @@ if __name__ == '__main__':
                 'nnabla.models.imagenet',
                 'nnabla.models.object_detection',
                 'nnabla.models.semantic_segmentation',
+                'nnabla.testing',
                 'nnabla.utils',
                 'nnabla.utils.cli',
                 'nnabla.utils.converter',

--- a/python/src/nnabla/_nd_array.pxd
+++ b/python/src/nnabla/_nd_array.pxd
@@ -32,6 +32,7 @@ cdef extern from "nbla/synced_array.hpp" namespace "nbla":
         void zero() except+
         void fill(float value) except+
         size_t modification_count() except+
+        cpp_bool zeroing() const
 
     ctypedef shared_ptr[CSyncedArray] SyncedArrayPtr
 

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -339,6 +339,11 @@ cdef class NdArray:
         self.arrp.fill(value)
 
     @property
+    def zeroing(self):
+        '''Checking if the array is not modified after calling `zero()`.'''
+        return self.arrp.array().get().zeroing()
+
+    @property
     def dtype(self):
         """
         Get dtype.

--- a/python/src/nnabla/testing/__init__.py
+++ b/python/src/nnabla/testing/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,15 +13,14 @@
 # limitations under the License.
 
 import numpy as np
-from nnabla.testing import assert_allclose
 
 
-def scheduler_tester(scheduler, ref_scheduler, max_iter, scheduler_args=[], atol=1e-6):
-    # Create scheduler
-    s = scheduler(*scheduler_args)
-    ref_s = ref_scheduler(*scheduler_args)
+def assert_allclose(actual, desired, rtol=1e-5, atol=1e-6, equal_nan=True,
+                    err_msg='', verbose=True):
+    '''A wrapper of `numpy.testing.assert_allclose`.
 
-    # Check learning rate
-    lr = [s.get_learning_rate(iter) for iter in range(max_iter)]
-    ref_lr = [ref_s.get_learning_rate(iter) for iter in range(max_iter)]
-    assert_allclose(lr, ref_lr, atol=atol)
+    Using default values for `rtol` and `atol` that are consistent with
+    `numpy.allclose`.
+    '''
+    np.testing.assert_allclose(actual, desired, rtol=rtol, atol=atol,
+                               equal_nan=equal_nan, err_msg=err_msg, verbose=verbose)

--- a/python/test/communicator/test_all_gather.py
+++ b/python/test/communicator/test_all_gather.py
@@ -16,6 +16,7 @@ import pytest
 import nnabla as nn
 import nnabla.parametric_functions as PF
 import nnabla.communicators as C
+from nnabla.testing import assert_allclose
 import numpy as np
 
 
@@ -57,4 +58,4 @@ def test_all_gather(seed, comm_nccl_opts):
 
     # Check
     for y, ref in zip(y_list, refs):
-        assert np.allclose(y.d, ref, rtol=1e-3, atol=1e-6)
+        assert_allclose(y.d, ref, rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_all_reduce.py
+++ b/python/test/communicator/test_all_reduce.py
@@ -16,6 +16,7 @@ import pytest
 import nnabla as nn
 import nnabla.parametric_functions as PF
 import numpy as np
+from nnabla.testing import assert_allclose
 
 from six.moves import reduce
 
@@ -67,4 +68,4 @@ def test_all_reduce(seed, inplace, division, comm_nccl_opts):
 
     # Check
     for x, ref in zip(x_list, refs):
-        assert np.allclose(x.d, ref, rtol=1e-3, atol=1e-6)
+        assert_allclose(x.d, ref, rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_all_reduce.py
+++ b/python/test/communicator/test_all_reduce.py
@@ -21,6 +21,15 @@ from nnabla.testing import assert_allclose
 from six.moves import reduce
 
 
+def check_comm_nccl_opts(comm_nccl_opts):
+    if comm_nccl_opts is None:
+        pytest.skip(
+            "Communicator test is disabled. You can turn it on by an option `--test-communicator`.")
+    if len(comm_nccl_opts.devices) < 2:
+        pytest.skip(
+            "Communicator test is disabled. Use more than 1 gpus.")
+
+
 def ref_all_reduce(x_data_list, size, division):
     f = reduce(lambda x, y: x + y, np.arange(size)) + size
     results = []
@@ -36,12 +45,7 @@ def ref_all_reduce(x_data_list, size, division):
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("division", [True, False])
 def test_all_reduce(seed, inplace, division, comm_nccl_opts):
-    if comm_nccl_opts is None:
-        pytest.skip(
-            "Communicator test is disabled. You can turn it on by an option `--test-communicator`.")
-    if len(comm_nccl_opts.devices) < 2:
-        pytest.skip(
-            "Communicator test is disabled. Use more than 1 gpus.")
+    check_comm_nccl_opts(comm_nccl_opts)
 
     comm = comm_nccl_opts.comm
     device_id = int(comm_nccl_opts.device_id)
@@ -69,3 +73,81 @@ def test_all_reduce(seed, inplace, division, comm_nccl_opts):
     # Check
     for x, ref in zip(x_list, refs):
         assert_allclose(x.d, ref, rtol=1e-3, atol=1e-6)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inplace", [True, False])
+@pytest.mark.parametrize("division", [True, False])
+def test_all_reduce_skip_by_zero(seed, inplace, division, comm_nccl_opts):
+    '''
+    Checking the behavior that all_reduce is skipped if NdArray is set as zeroing
+    by NdArray.zero().
+    '''
+    check_comm_nccl_opts(comm_nccl_opts)
+
+    comm = comm_nccl_opts.comm
+    device_id = int(comm_nccl_opts.device_id)
+    n_devices = len(comm_nccl_opts.devices)
+
+    xs = [nn.Variable((2, 3, 4), need_grad=True),
+          nn.Variable((2, 3), need_grad=True)]
+
+    # Fill data as 1
+    for x in xs:
+        x.data.fill(1)
+
+    def get_grads(aa):
+        return [a.grad for a in aa]
+
+    def zero_grads(aa):
+        for a in aa:
+            a.grad.zero()
+
+    # A. Allreduce is not performed as all arrays are not updated.
+    zero_grads(xs)
+    comm.all_reduce(get_grads(xs), division=division, inplace=inplace)
+    for g in get_grads(xs):
+        assert g.zeroing
+
+    # B. All reduce is performed as any of arrays is updated.
+    zero_grads(xs)
+    # modify the grad values in rank 0
+    if comm.rank == 0:
+        for g in get_grads(xs):
+            g.data = 0
+    comm.all_reduce(get_grads(xs), division=division, inplace=inplace)
+    for g in get_grads(xs):
+        assert not g.zeroing
+
+    # Construct a graph for allreduce during backward
+    import nnabla.functions as F
+    y = sum([F.sum(F.relu(x)) for x in xs])
+
+    def execute_allreduce_during_backward(performed):
+        y.forward(clear_no_need_grad=True)
+        comm_callback = comm.all_reduce_callback(
+            get_grads(xs), 1024 * 1024 * 2, division=division)
+        zero_grads(xs)
+        y.backward(
+            None, clear_buffer=True,
+            communicator_callbacks=comm_callback
+        )
+        for g in get_grads(xs):
+            assert g.zeroing != performed
+
+    # C-1. performing allreduce during backward
+    execute_allreduce_during_backward(True)
+
+    # C-2. not performing allreduce during backward
+    for x in xs:
+        x.need_grad = False
+    execute_allreduce_during_backward(False)
+
+    # C-3. performing allreduce during backward
+    # NOTE: It's not supported because callbacks over devices are not
+    # consistently callled due to skipping backward operation on
+    # variables not requiring gradients.
+    # if comm.rank == 0:
+    #     for x in xs:
+    #         x.need_grad = True
+    # execute_allreduce_during_backward(True)

--- a/python/test/communicator/test_all_reduce_callback.py
+++ b/python/test/communicator/test_all_reduce_callback.py
@@ -19,6 +19,7 @@ import nnabla.parametric_functions as PF
 import nnabla.communicators as C
 import numpy as np
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 
 @pytest.mark.parametrize("seed", [313])
@@ -73,4 +74,4 @@ def test_all_reduce_callback(seed, pack_size, division, comm_nccl_opts):
 
     # Check
     for x, ref in zip(x_list1, x_list2):
-        assert np.allclose(x.g, ref.g)
+        assert_allclose(x.g, ref.g)

--- a/python/test/communicator/test_bcast.py
+++ b/python/test/communicator/test_bcast.py
@@ -17,6 +17,7 @@ import nnabla as nn
 import nnabla.parametric_functions as PF
 import nnabla.communicators as C
 import numpy as np
+from nnabla.testing import assert_allclose
 
 
 def ref_bcast(x_data_list, src):
@@ -61,4 +62,4 @@ def test_bcast(seed, src, inplace, comm_nccl_opts):
 
     # Check
     for x, ref in zip(x_list, refs):
-        assert np.allclose(x.d, ref, rtol=1e-3, atol=1e-6)
+        assert_allclose(x.d, ref, rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_comm_reduce.py
+++ b/python/test/communicator/test_comm_reduce.py
@@ -17,6 +17,7 @@ import nnabla as nn
 import nnabla.parametric_functions as PF
 import nnabla.communicators as C
 import numpy as np
+from nnabla.testing import assert_allclose
 
 from six.moves import reduce
 
@@ -72,4 +73,4 @@ def test_reduce(seed, dst, inplace, division, comm_nccl_opts):
 
         # Check
         for x, ref in zip(x_list, refs):
-            assert np.allclose(x.d, ref, rtol=1e-3, atol=1e-6)
+            assert_allclose(x.d, ref, rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_data_parallel_communicator.py
+++ b/python/test/communicator/test_data_parallel_communicator.py
@@ -17,6 +17,7 @@ import nnabla as nn
 import nnabla.parametric_functions as PF
 import nnabla.communicators as C
 import numpy as np
+from nnabla.testing import assert_allclose
 
 
 def test_data_parallel_communicator(comm_nccl_opts):
@@ -85,4 +86,4 @@ def test_data_parallel_communicator(comm_nccl_opts):
             params = nn.get_parameters()
             for i, elm in enumerate(params.items()):
                 k, v = elm
-                assert np.allclose(ref_grads[i], v.g, atol=atol)
+                assert_allclose(ref_grads[i], v.g, atol=atol)

--- a/python/test/communicator/test_new_group.py
+++ b/python/test/communicator/test_new_group.py
@@ -31,12 +31,7 @@ def test_new_group(seed, comm_nccl_opts):
         pytest.skip("{} is supported in CUDA device".format(
             sys._getframe().f_code.co_name))
 
-    n_devices = nnabla_ext.cuda.init.get_device_count()
-    if n_devices < 2:
-        pytest.skip("Number of cuda devices in this machine is less than 2.")
-
-    if n_devices != comm_nccl_opts.comm.size:
-        pytest.skip("Number of cuda devices is not same as that of processes.")
+    n_devices = comm_nccl_opts.comm.size
 
     # Reference
     rng = np.random.RandomState(seed)

--- a/python/test/communicator/test_reduce_scatter.py
+++ b/python/test/communicator/test_reduce_scatter.py
@@ -17,6 +17,7 @@ import nnabla as nn
 import nnabla.parametric_functions as PF
 import nnabla.communicators as C
 import numpy as np
+from nnabla.testing import assert_allclose
 
 from six.moves import reduce
 
@@ -66,4 +67,4 @@ def test_reduce_scatter(seed, division, comm_nccl_opts):
     refs = ref_reduce_scatter(x_data_list, n_devices, division)
 
     # Check
-    assert np.allclose(x.d, refs[device_id], rtol=1e-3, atol=1e-6)
+    assert_allclose(x.d, refs[device_id], rtol=1e-3, atol=1e-6)

--- a/python/test/communicator/test_sync_batch_normalization.py
+++ b/python/test/communicator/test_sync_batch_normalization.py
@@ -18,6 +18,7 @@ import nnabla as nn
 import nnabla.parametric_functions as PF
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('SyncBatchNormalization')
 
@@ -192,7 +193,7 @@ def test_sync_batch_normalization_forward_backward(seed, axis, decay_rate, eps, 
             with nn.context_scope(ctx), nn.auto_forward():
                 y = F.sync_batch_normalization(
                     *(vinputs + [comm, "world", axes, decay_rate, eps, batch_stat, output_stat]))
-            assert np.allclose(vinputs[0].d, inputs[0])
+            assert_allclose(vinputs[0].d, inputs[0])
 
     # Check if running mean and var works.
     vinputs = []
@@ -207,5 +208,5 @@ def test_sync_batch_normalization_forward_backward(seed, axis, decay_rate, eps, 
         with nn.context_scope(ctx), nn.auto_forward():
             y = F.sync_batch_normalization(
                 *(vinputs + [comm, "world", axes, decay_rate, eps, batch_stat, output_stat]))
-        assert np.allclose(vinputs[3].d, inputs[3])
-        assert np.allclose(vinputs[4].d, inputs[4], atol=1e-3)
+        assert_allclose(vinputs[3].d, inputs[3])
+        assert_allclose(vinputs[4].d, inputs[4], atol=1e-3)

--- a/python/test/cpp/test_mnist_runtime.py
+++ b/python/test/cpp/test_mnist_runtime.py
@@ -19,6 +19,7 @@ import nnabla.functions as F
 import nnabla.parametric_functions as PF
 import nnabla.utils.save
 import nnabla.utils.load
+from nnabla.testing import assert_allclose
 
 import numpy as np
 import os
@@ -73,4 +74,4 @@ def test_examples_cpp_mnist_runtime(tmpdir, nnabla_examples_root, batch_size):
     img = imread(pgm_file, grayscale=True)
     x.d = img
     y.forward()
-    assert np.allclose(y.d.flatten(), cpp_result)
+    assert_allclose(y.d.flatten(), cpp_result)

--- a/python/test/cpp/test_nbla.py
+++ b/python/test/cpp/test_nbla.py
@@ -20,6 +20,7 @@ import nnabla.functions as F
 import nnabla.parametric_functions as PF
 import nnabla.utils.save
 import nnabla.utils.load
+from nnabla.testing import assert_allclose
 
 import numpy as np
 import os
@@ -84,7 +85,7 @@ def check_nbla_infer(tmpdir, x, y, batch_size, on_memory):
     # D. Compare
     y3 = np.fromfile(output_bin.strpath + '_0.bin',
                      dtype=np.float32).reshape(y2.shape)
-    assert np.allclose(y2.d, y3)
+    assert_allclose(y2.d, y3)
 
 
 @pytest.mark.parametrize('batch_size', [1, 4])

--- a/python/test/function/test_assign.py
+++ b/python/test/function/test_assign.py
@@ -21,6 +21,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('Assign')
 
@@ -38,9 +39,9 @@ def test_assign_forward_backward(seed, ctx, func_name):
     assign.forward()
 
     # destination variable should be equal to source variable
-    assert np.allclose(dst.d, src.d)
+    assert_allclose(dst.d, src.d)
     # output variable of assign function should be equal to soure variable
-    assert np.allclose(assign.d, src.d)
+    assert_allclose(assign.d, src.d)
 
     dummy = assign + rng.rand()
 

--- a/python/test/function/test_batch_normalization.py
+++ b/python/test/function/test_batch_normalization.py
@@ -19,6 +19,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('BatchNormalization')
 
@@ -92,8 +93,8 @@ def test_batch_normalization_forward_backward(seed, axis, decay_rate, eps,
         with nn.context_scope(ctx), nn.auto_forward():
             y = F.batch_normalization(
                 *(vinputs + [axes, decay_rate, eps, batch_stat, output_stat]))
-        assert np.allclose(vinputs[3].d, inputs[3], atol=1e-7)
-        assert np.allclose(vinputs[4].d, inputs[4])
+        assert_allclose(vinputs[3].d, inputs[3], atol=1e-7)
+        assert_allclose(vinputs[4].d, inputs[4])
 
     # Check if global stat mode works
     batch_stat = False
@@ -104,7 +105,7 @@ def test_batch_normalization_forward_backward(seed, axis, decay_rate, eps,
     with nn.context_scope(ctx), nn.auto_forward():
         y = F.batch_normalization(
             *(vinputs + [axes, decay_rate, eps, batch_stat, output_stat]))
-    assert np.allclose(ref_y, y.d, atol=1e-6)
+    assert_allclose(ref_y, y.d, atol=1e-6)
 
 
 def ref_batch_normalization_for_multiple_axes(x, beta, gamma, rmean, rvar, axes, decay_rate,
@@ -166,7 +167,7 @@ def test_batch_normalization_for_multiple_axes_forward_backward(seed, axes, deca
     with nn.context_scope(ctx), nn.auto_forward():
         y = F.batch_normalization(
             *(vinputs + [axes, decay_rate, eps, batch_stat, output_stat]))
-    assert np.allclose(ref_y, y.d, atol=1e-6)
+    assert_allclose(ref_y, y.d, atol=1e-6)
 
 
 @pytest.mark.parametrize("seed", [313])

--- a/python/test/function/test_binary_error.py
+++ b/python/test/function/test_binary_error.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('BinaryError')
 
@@ -49,4 +50,4 @@ def test_binary_error_forward(seed, ctx, func_name):
     res = y.d
 
     atol_f = 1e-6
-    assert np.allclose(ref, res, atol=atol_f)
+    assert_allclose(ref, res, atol=atol_f)

--- a/python/test/function/test_clip_by_norm.py
+++ b/python/test/function/test_clip_by_norm.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 
 def ref_clip_by_norm(x, clip_norm, axis):
@@ -43,13 +44,13 @@ def test_clip_by_norm_forward(seed, shape, clip_norm_type, clip_norm_value, x_va
                 with nn.auto_forward(True):
                     y = F.clip_by_norm(x, clip_norm, axis)
                 y_ref = ref_clip_by_norm(x_data, clip_norm_value, axis=axis)
-                assert np.allclose(y.d, y_ref)
+                assert_allclose(y.d, y_ref)
         else:
             if clip_norm_value > 0:
                 with nn.auto_forward(True):
                     y = F.clip_by_norm(x, clip_norm, axis)
                 y_ref = ref_clip_by_norm(x_data, clip_norm_value, axis=axis)
-                assert np.allclose(y.d, y_ref)
+                assert_allclose(y.d, y_ref)
             else:
                 with pytest.raises(ValueError):
                     y = F.clip_by_norm(x, clip_norm, axis)

--- a/python/test/function/test_clip_by_value.py
+++ b/python/test/function/test_clip_by_value.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 
 def ref_clip_by_value(x, min_, max_):
@@ -42,4 +43,4 @@ def test_clip_by_value_forward(seed, shape):
     y_ref = ref_clip_by_value(x_data, min_data, max_data)
     print(y.d)
     print(y_ref)
-    assert np.allclose(y.d, y_ref)
+    assert_allclose(y.d, y_ref)

--- a/python/test/function/test_confusion_matrix.py
+++ b/python/test/function/test_confusion_matrix.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('ConfusionMatrix')
 
@@ -61,4 +62,4 @@ def test_confusion_matrix_forward(seed, ctx, axis, func_name):
     res = y.d
 
     atol_f = 1e-6
-    assert np.allclose(ref, res, atol=atol_f)
+    assert_allclose(ref, res, atol=atol_f)

--- a/python/test/function/test_dropout.py
+++ b/python/test/function/test_dropout.py
@@ -18,6 +18,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('Dropout')
 
@@ -39,7 +40,7 @@ def test_dropout_forward_backward(p, seed, ctx, func_name):
         o = F.dropout(i, p)
     scale = 1. / (1. - p)
     mask = o.d != 0
-    assert np.allclose(o.d, i.d * mask * scale)
+    assert_allclose(o.d, i.d * mask * scale)
     assert o.parent.name == func_name
 
     # NNabla backward
@@ -50,13 +51,13 @@ def test_dropout_forward_backward(p, seed, ctx, func_name):
     ref_grad = o_grad * mask * scale
 
     # Verify
-    assert np.allclose(i.g, orig_grad + ref_grad)
+    assert_allclose(i.g, orig_grad + ref_grad)
 
     # Check if accum option works
     i.g[...] = 1
     o.g = o_grad
     o.parent.backward([i], [o], [False])
-    assert np.allclose(i.g, ref_grad)
+    assert_allclose(i.g, ref_grad)
 
     # Check accum=False with NaN gradient
     i.g = np.float32('nan')
@@ -94,4 +95,4 @@ def test_dropout_double_backward(p, seed, ctx, func_name):
     g_dy = grad.parent.inputs[1].g
     scale = 1. / (1. - p)
     mask = dout.d != 0
-    assert np.allclose(g_dy, mask * scale)
+    assert_allclose(g_dy, mask * scale)

--- a/python/test/function/test_fused_batch_normalization.py
+++ b/python/test/function/test_fused_batch_normalization.py
@@ -19,6 +19,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('FusedBatchNormalization')
 cpu_context = nn.Context(["cpu:float"])
@@ -158,8 +159,8 @@ def test_fused_batch_normalization_forward_backward(seed, axis, decay_rate, eps,
         with nn.context_scope(ctx), nn.auto_forward():
             y = F.fused_batch_normalization(
                 *(vinputs + [axes, decay_rate, eps, batch_stat, nonlinearity, output_stat]))
-        assert np.allclose(vinputs[3].d, inputs[3])
-        assert np.allclose(vinputs[4].d, inputs[4], atol=1e-3)
+        assert_allclose(vinputs[3].d, inputs[3])
+        assert_allclose(vinputs[4].d, inputs[4], atol=1e-3)
 
     # Check if global stat mode works
     batch_stat = False
@@ -170,4 +171,4 @@ def test_fused_batch_normalization_forward_backward(seed, axis, decay_rate, eps,
     with nn.context_scope(ctx), nn.auto_forward():
         y = F.fused_batch_normalization(
             *(vinputs + [axes, decay_rate, eps, batch_stat, nonlinearity, output_stat]))
-    assert np.allclose(ref_y, y.d, atol=1e-6)
+    assert_allclose(ref_y, y.d, atol=1e-6)

--- a/python/test/function/test_group_normalization.py
+++ b/python/test/function/test_group_normalization.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
+from nnabla.testing import assert_allclose
 
 from nnabla.normalization_functions import _force_list, _get_axes_excluding
 
@@ -73,11 +74,11 @@ def test_group_normalization_forward_backward(seed, num_groups, x_shape, batch_a
 
         for o, r in zip(output, ref):
             assert o.shape == r.shape
-            assert np.allclose(o.d, r, atol=1e-2, rtol=1e-5)
+            assert_allclose(o.d, r, atol=1e-2, rtol=1e-5)
 
     else:
         output.forward()
         output.backward()
 
         assert output.shape == ref.shape
-        assert np.allclose(output.d, ref, atol=1e-2, rtol=1e-5)
+        assert_allclose(output.d, ref, atol=1e-2, rtol=1e-5)

--- a/python/test/function/test_instance_normalization.py
+++ b/python/test/function/test_instance_normalization.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
+from nnabla.testing import assert_allclose
 
 from nnabla.normalization_functions import _force_list, _get_axes_excluding
 
@@ -58,11 +59,11 @@ def test_instance_normalization_forward_backward(seed, x_shape, batch_axis, chan
 
         for o, r in zip(output, ref):
             assert o.shape == r.shape
-            assert np.allclose(o.d, r, atol=1e-2, rtol=1e-5)
+            assert_allclose(o.d, r, atol=1e-2, rtol=1e-5)
 
     else:
         output.forward()
         output.backward()
 
         assert output.shape == ref.shape
-        assert np.allclose(output.d, ref, atol=1e-2, rtol=1e-5)
+        assert_allclose(output.d, ref, atol=1e-2, rtol=1e-5)

--- a/python/test/function/test_layer_normalization.py
+++ b/python/test/function/test_layer_normalization.py
@@ -2,6 +2,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
+from nnabla.testing import assert_allclose
 
 from nnabla.normalization_functions import _force_list, _get_axes_excluding
 
@@ -56,10 +57,10 @@ def test_layer_normalization_forward_backward(seed, x_shape, batch_axis, output_
 
         for o, r in zip(output, ref):
             assert o.shape == r.shape
-            assert np.allclose(o.d, r, atol=1e-2, rtol=1e-5)
+            assert_allclose(o.d, r, atol=1e-2, rtol=1e-5)
 
     else:
         output.forward()
         output.backward()
 
-        assert np.allclose(output.d, ref, atol=1e-2, rtol=1e-5)
+        assert_allclose(output.d, ref, atol=1e-2, rtol=1e-5)

--- a/python/test/function/test_mean_subtraction.py
+++ b/python/test/function/test_mean_subtraction.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('MeanSubtraction')
 
@@ -63,11 +64,11 @@ def test_mean_subtraction_forward_backward(seed, inshape, base_axis, ctx, func_n
             y = F.mean_subtraction(*(vinputs + [base_axis, batch_stat]))
         # print('vinput[1].d', vinputs[1].d, vinputs[2].d)
         # print('inputs[1]', inputs[1], inputs[2])
-        assert np.allclose(vinputs[1].d, inputs[1])
+        assert_allclose(vinputs[1].d, inputs[1])
 
     # Check if global stat mode works
     batch_stat = False
     ref_y = ref_mean_subtraction(*(inputs + [base_axis, batch_stat]))
     with nn.auto_forward():
         y = F.mean_subtraction(*(vinputs + [base_axis, batch_stat]))
-    assert np.allclose(ref_y, y.d)
+    assert_allclose(ref_y, y.d)

--- a/python/test/function/test_one_hot.py
+++ b/python/test/function/test_one_hot.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('OneHot')
 
@@ -51,5 +52,5 @@ def test_one_hot_forward(seed, inshape, shape, ctx, func_name):
         with nn.context_scope(ctx), nn.auto_forward():
             o = F.one_hot(vinput, shape)
         r = ref_one_hot(input, shape)
-        assert np.allclose(o.d, r)
+        assert_allclose(o.d, r)
         assert func_name == o.parent.name

--- a/python/test/function/test_random_choice.py
+++ b/python/test/function/test_random_choice.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('RandomChoice')
 
@@ -34,11 +35,11 @@ def test_random_choice_with_replacement(ctx, func_name, seed):
     hist_nn, _ = np.histogram(y.d)
     hist_np, _ = np.histogram(np.random.choice(
         x.d, trials, True, w.d / w.d.sum()))
-    assert np.allclose(hist_nn / trials, hist_np / trials, atol=1e-2)
+    assert_allclose(hist_nn / trials, hist_np / trials, atol=1e-2)
     x.g = w.g = 0
     y.backward()
-    assert np.allclose(x.g / trials, w.d / w.d.sum(), atol=1e-2)
-    assert np.allclose(w.g / trials, w.d / w.d.sum(), atol=1e-2)
+    assert_allclose(x.g / trials, w.d / w.d.sum(), atol=1e-2)
+    assert_allclose(w.g / trials, w.d / w.d.sum(), atol=1e-2)
 
     x = nn.Variable.from_numpy_array(np.array([[1, 2, 3], [-1, -2, -3]]))
     w = nn.Variable.from_numpy_array(np.array([[1, 1, 1], [10, 10, 10]]))

--- a/python/test/function/test_random_crop.py
+++ b/python/test/function/test_random_crop.py
@@ -19,6 +19,7 @@ from scipy.stats import pearsonr
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('RandomCrop')
 
@@ -70,7 +71,7 @@ def test_random_crop_forward_backward(seed, inshape, shape, ctx, func_name):
     i.g[...] = 1
     o.g = o_grad
     o.parent.backward([i], [o], [False])
-    assert np.allclose(i.g, ref_grad, atol=1e-6)
+    assert_allclose(i.g, ref_grad, atol=1e-6)
 
     # Check if need_grad works
     i.g[...] = 0

--- a/python/test/function/test_random_flip.py
+++ b/python/test/function/test_random_flip.py
@@ -18,6 +18,7 @@ import nnabla as nn
 import nnabla.functions as F
 from test_flip import ref_flip
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('RandomFlip')
 
@@ -50,13 +51,13 @@ def test_random_flip_forward_backward(seed, axes, ctx, func_name):
         ref_grad = ref_flip(o_grad, axes)
     else:
         ref_grad = o_grad
-    assert np.allclose(i.g, orig_grad + ref_grad)
+    assert_allclose(i.g, orig_grad + ref_grad)
 
     # Check if accum option works
     i.g[...] = 1
     o.g = o_grad
     o.parent.backward([i], [o], [False])
-    assert np.allclose(i.g, ref_grad)
+    assert_allclose(i.g, ref_grad)
 
     # Check accum=False with NaN gradient
     i.g = np.float32('nan')

--- a/python/test/function/test_random_shift.py
+++ b/python/test/function/test_random_shift.py
@@ -20,6 +20,7 @@ from scipy.stats import pearsonr
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('RandomShift')
 
@@ -52,7 +53,7 @@ def test_random_shift_forward_backward(seed, inshape, shifts, border_mode, ctx, 
     for result, shift_range in zip(result_shifts, shifts):
         assert abs(result) <= shift_range
 
-    assert np.allclose(o.d, ref)
+    assert_allclose(o.d, ref)
     assert o.parent.name == func_name
 
     # Skipping Backward check
@@ -72,7 +73,7 @@ def test_random_shift_forward_backward(seed, inshape, shifts, border_mode, ctx, 
     i.g[...] = 1
     o.g = o_grad
     o.parent.backward([i], [o], [False])
-    assert np.allclose(i.g, ref_grad, atol=1e-6)
+    assert_allclose(i.g, ref_grad, atol=1e-6)
 
     # Check if need_grad works
     i.g[...] = 0

--- a/python/test/function/test_reduction.py
+++ b/python/test/function/test_reduction.py
@@ -16,6 +16,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
+from nnabla.testing import assert_allclose
 
 
 from nbla_test_utils import (function_tester, list_context,
@@ -87,7 +88,7 @@ def test_max_with_index(seed, ctx, func_name, inshape, axis, keepdims):
     x = nn.Variable.from_numpy_array(x)
     with nn.context_scope(ctx), nn.auto_forward(True):
         val, idx = F.max(x, axis, keepdims, with_index=True)
-    assert np.allclose(val.d, np.amax(x.d, axis, keepdims=keepdims))
+    assert_allclose(val.d, np.amax(x.d, axis, keepdims=keepdims))
     shape = [a for i, a in enumerate(x.d.shape) if i not in axis] + [-1]
     assert np.all(idx.d == x.d.reshape(*shape).argmax(-1).reshape(idx.d.shape))
     with nn.context_scope(ctx), nn.auto_forward(True):
@@ -108,7 +109,7 @@ def test_min_with_index(seed, ctx, func_name, inshape, axis, keepdims):
     x = nn.Variable.from_numpy_array(x)
     with nn.context_scope(ctx), nn.auto_forward(True):
         val, idx = F.min(x, axis, keepdims, with_index=True)
-    assert np.allclose(val.d, np.amin(x.d, axis, keepdims=keepdims))
+    assert_allclose(val.d, np.amin(x.d, axis, keepdims=keepdims))
     shape = [a for i, a in enumerate(x.d.shape) if i not in axis] + [-1]
     assert np.all(idx.d == x.d.reshape(*shape).argmin(-1).reshape(idx.d.shape))
     with nn.context_scope(ctx), nn.auto_forward(True):

--- a/python/test/function/test_sink.py
+++ b/python/test/function/test_sink.py
@@ -16,6 +16,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
+from nnabla.testing import assert_allclose
 
 
 @pytest.mark.parametrize("seed", [313])
@@ -80,4 +81,4 @@ def test_sink(seed):
     # Compute with sink
     v.grad.zero()
     dummy.backward()
-    assert np.allclose(v.g, gv)
+    assert_allclose(v.g, gv)

--- a/python/test/function/test_slice.py
+++ b/python/test/function/test_slice.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context, function_tester
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('Slice')
 
@@ -67,7 +68,7 @@ def test_slice_forward_special(seed, inshape, start, stop, step, ctx, fname):
         x_key = F.slice(x, start, stop, step)
         x_key.forward()
 
-    assert np.allclose(x_data_key, x_key.d)
+    assert_allclose(x_data_key, x_key.d)
 
 
 @pytest.mark.parametrize("ctx, fname", ctxs)

--- a/python/test/function/test_top_n_error.py
+++ b/python/test/function/test_top_n_error.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('TopNError')
 
@@ -63,4 +64,4 @@ def test_top_n_error_forward(seed, axis, n, ctx, func_name):
     res = y.d
 
     atol_f = 1e-6
-    assert np.allclose(ref, res, atol=atol_f)
+    assert_allclose(ref, res, atol=atol_f)

--- a/python/test/function/test_unlink.py
+++ b/python/test/function/test_unlink.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('Unlink')
 
@@ -43,9 +44,9 @@ def test_unlink_forward_backward(seed, shape, ctx, func_name):
     res = y.d
 
     atol_f = 1e-6
-    assert np.allclose(ref, res, atol=atol_f)
+    assert_allclose(ref, res, atol=atol_f)
 
     atol_b = 1e-6
     ref = np.zeros(shape)
     res = x.g
-    assert np.allclose(ref, res, atol=atol_b)
+    assert_allclose(ref, res, atol=atol_b)

--- a/python/test/function/test_vat_noise.py
+++ b/python/test/function/test_vat_noise.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('VATNoise')
 
@@ -48,9 +49,9 @@ def test_vat_noise(seed, base_axis, shape, eps, ctx, func_name):
     res = y.d
 
     atol_f = 1e-6
-    assert np.allclose(ref, res, atol=atol_f)
+    assert_allclose(ref, res, atol=atol_f)
 
     atol_b = 1e-6
     ref = np.ones(shape) * eps
     res = w.d
-    assert np.allclose(ref, res, atol=atol_b)
+    assert_allclose(ref, res, atol=atol_b)

--- a/python/test/function/test_weight_standardization.py
+++ b/python/test/function/test_weight_standardization.py
@@ -3,6 +3,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 import nnabla.parametric_functions as PF
+from nnabla.testing import assert_allclose
 
 from nnabla.normalization_functions import _get_axes_excluding
 
@@ -46,13 +47,13 @@ def test_weight_standardization_forward_backward(rng, w_shape, channel_axis, out
 
         for o, r in zip(output, ref):
             assert o.shape == r.shape
-            assert np.allclose(o.d, r, atol=1e-2, rtol=1e-5)
+            assert_allclose(o.d, r, atol=1e-2, rtol=1e-5)
 
     else:
         output.forward()
         output.backward()
 
-        assert np.allclose(output.d, ref, atol=1e-2, rtol=1e-5)
+        assert_allclose(output.d, ref, atol=1e-2, rtol=1e-5)
 
 
 @pytest.mark.parametrize("function , channel_axis, kwargs, param_name",
@@ -87,5 +88,5 @@ def test_apply_weight_standardization(rng, function, channel_axis, kwargs, param
     ref_w_standardized = ref_weight_standardization(
         w, channel_axis, eps, output_stat)
 
-    assert np.allclose(w_standardized, ref_w_standardized,
-                       atol=1e-02, rtol=1e-5)
+    assert_allclose(w_standardized, ref_w_standardized,
+                    atol=1e-02, rtol=1e-5)

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -19,6 +19,7 @@ import nnabla as nn
 import nnabla.ext_utils as ext_utils
 import nnabla.functions as F
 import nnabla.utils.converter
+from nnabla.testing import assert_allclose
 import numpy
 import numpy as np
 from numpy.core import function_base
@@ -301,14 +302,12 @@ def half_test(rng, func, finputs, hinputs, func_args, func_kwargs, backward, ctx
     # 5. Check if output values are close between function data types.
     for ff, hh in zip(y_f, y_h):
         # TODO: set tol param
-        assert np.allclose(ff, hh, atol=atol), "Checking forward half: " + str(
-            ArrayDiffStats(ff, hh))
+        assert_allclose(ff, hh, atol=atol)
     if True not in backward:
         return
     for ff, hh in zip(g_f, g_h):
         # TODO: set tol param
-        assert np.allclose(ff, hh, atol=atol), "Checking backward half: " + str(
-            ArrayDiffStats(ff, hh))
+        assert_allclose(ff, hh, atol=atol)
 
 
 def create_function_nnp(inputs, outputs, func_name, func_args, func_kwargs):
@@ -530,8 +529,7 @@ def function_tester(rng, func, ref_func, inputs,
     assert len(o) == len(refs)
     for i, ref in enumerate(refs):
         res = o[i].d
-        assert np.allclose(ref, res, atol=atol_f), str(
-            ArrayDiffStats(ref, res))
+        assert_allclose(ref, res, atol=atol_f)
 
     # Checking function name
     try:
@@ -579,8 +577,7 @@ def function_tester(rng, func, ref_func, inputs,
         doutputs = [o_.g for o_ in o]
         ngrads = ref_grad(*(rinputs + doutputs + func_args), **func_kwargs)
 
-    assert np.allclose(ngrads, agrads, atol=atol_b), str(
-        ArrayDiffStats(ngrads, agrads))
+    assert_allclose(ngrads, agrads, atol=atol_b)
 
     # Check if need_grad works
     for v, b in zip(vinputs, backward):
@@ -630,8 +627,8 @@ def function_tester(rng, func, ref_func, inputs,
         v.g = rng.randn(*v.shape)
         f.forward(finputs, o)
         f.backward(finputs, o, accum)
-        assert np.allclose(
-            v.g, true_g, atol=atol_accum), str(ArrayDiffStats(v.g, true_g))
+        assert_allclose(
+            v.g, true_g, atol=atol_accum)
 
         # Check accum=False with NaN gradient
         v.g = np.float32('nan')
@@ -666,7 +663,7 @@ def inplace_function_test_helper(inputs, func, func_args=[], func_kwargs={}, ctx
     l_i.backward()
     grads_i = [inp.g.copy() for inp in inputs]
     for g, g_i in zip(grads, grads_i):
-        assert np.allclose(g, g_i), str(ArrayDiffStats(g, g_i))
+        assert_allclose(g, g_i)
 
 
 def convert_to_float2_array(x_complex, dtype=np.float32):
@@ -808,8 +805,7 @@ def backward_function_tester(rng, func, ref_func, inputs,
             continue
         fgrads = vi.g
         bgrads = go.d
-        assert np.allclose(fgrads, bgrads, atol=atol_f), str(
-            ArrayDiffStats(fgrads, bgrads))
+        assert_allclose(fgrads, bgrads, atol=atol_f)
 
     # TODO: 1. Pass function argument directly to backward functions.
     # TODO: 2. should be changed for the simplier form by simply testing BackwardFunction
@@ -829,8 +825,7 @@ def backward_function_tester(rng, func, ref_func, inputs,
                               for inp in inputs if inp is not None])
     numerical_grads = approx_fprime(inputs0, obj_func, dstep, gp2, vinputs)
     # Check backward
-    assert np.allclose(analytical_grads, numerical_grads, atol=atol_b), \
-        str(ArrayDiffStats(analytical_grads, numerical_grads))
+    assert_allclose(analytical_grads, numerical_grads, atol=atol_b)
 
     # --- Backward (accum = True) test --- #
     # Random grads
@@ -846,5 +841,5 @@ def backward_function_tester(rng, func, ref_func, inputs,
                                  for rg in rand_grads])
     analytical_grads -= rand_grads
     # Check backward
-    assert np.allclose(analytical_grads, analytical_grads0, atol=atol_accum), \
-        str(ArrayDiffStats(analytical_grads, analytical_grads0))
+    assert_allclose(
+        analytical_grads, analytical_grads0, atol=atol_accum)

--- a/python/test/solver/solver_test_utils.py
+++ b/python/test/solver/solver_test_utils.py
@@ -15,6 +15,8 @@
 from six import iteritems
 
 import nnabla as nn
+import nnabla.solvers as S
+from nnabla.testing import assert_allclose
 import numpy as np
 from collections import OrderedDict
 import os
@@ -74,10 +76,10 @@ def solver_tester(rng, solver, ref_solver, solver_args=[], solver_kwargs={},
     params_ = s.get_parameters()
     for k0, v0 in iteritems(ref_s.params):
         v1 = params_[k0]
-        assert np.allclose(v0, v1.d, atol=atol)
+        assert_allclose(v0, v1.d, atol=atol)
     for k1, v1 in iteritems(params_):
         v0 = ref_s.params[k1]
-        assert np.allclose(v0, v1.d, atol=atol)
+        assert_allclose(v0, v1.d, atol=atol)
 
     # Check weight decay.
     grad_copy = OrderedDict([(k, p.g.copy())
@@ -85,7 +87,7 @@ def solver_tester(rng, solver, ref_solver, solver_args=[], solver_kwargs={},
     s.weight_decay(decay)
     ref_s.weight_decay(grad_copy, decay)
     for p, ref_p in zip(params.values(), grad_copy.values()):
-        assert np.allclose(ref_p, p.g, atol=atol)
+        assert_allclose(ref_p, p.g, atol=atol)
 
     # Check solver udpate.
     for i in range(num_itr):
@@ -97,7 +99,7 @@ def solver_tester(rng, solver, ref_solver, solver_args=[], solver_kwargs={},
         ref_s.update(grads)
         # update check
         for p, ref_p in zip(params.values(), ref_s.params.values()):
-            assert np.allclose(ref_p, p.d, atol=atol)
+            assert_allclose(ref_p, p.d, atol=atol)
         # iteration state incrementaion check
         for state in s.get_states().values():
             assert state.t == (i + 1)
@@ -127,7 +129,7 @@ def solver_tester(rng, solver, ref_solver, solver_args=[], solver_kwargs={},
         p.g *= scale
     s.scale_grad(1. / scale)
     for ref, p in zip(ref_grad, params.values()):
-        assert np.allclose(ref, p.g, atol=1e-4)
+        assert_allclose(ref, p.g, atol=1e-4)
 
     # Save/Load Test
     def test_save_load(s, name):
@@ -148,7 +150,7 @@ def solver_tester(rng, solver, ref_solver, solver_args=[], solver_kwargs={},
             s1 = states1[k0]
             for sname, vx0 in iteritems(s0.pstate):
                 vx1 = s1.pstate[sname]
-                assert np.allclose(vx0.d, vx1.d)
+                assert_allclose(vx0.d, vx1.d)
             assert s1.t == s0.t
     test_save_load(s, "states.h5")
     test_save_load(s, "states.protobuf")

--- a/python/test/solver/test_solver.py
+++ b/python/test/solver/test_solver.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import nnabla as nn
+import nnabla.solvers as S
+import numpy as np
+from solver_test_utils import solver_tester, RefSolver
+from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
+
+
+def test_solver_zeroing():
+    xs = [nn.Variable([2, 3, 4], need_grad=True) for _ in range(3)]
+
+    s = S.Sgd(1)
+    s.set_parameters({str(i): x for i, x in enumerate(xs)})
+
+    for x in xs:
+        x.data.fill(1)
+        x.grad.zero()
+
+    s.weight_decay(1.0)
+    s.update()
+    for x in xs:
+        # Grad is not referenced since neither weight decay nor update is performed.
+        assert x.grad.zeroing
+        assert_allclose(x.d, 1)
+
+    for x in xs:
+        x.grad.fill(1)
+
+    s.weight_decay(0.1)
+    s.update()
+
+    for x in xs:
+        assert_allclose(x.d, 1 - (1 + 0.1))

--- a/python/test/test_forward_all.py
+++ b/python/test/test_forward_all.py
@@ -18,6 +18,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 import nnabla.parametric_functions as PF
+from nnabla.testing import assert_allclose
 
 
 def initialize_grad(parameters):
@@ -64,7 +65,7 @@ def test_graph_logreg(seed):
     from nbla_test_utils import \
         compute_analytical_and_numerical_grad_graph as grads
     agrad, ngrad = grads(L1, inputs, 1e-3, False)
-    assert np.allclose(ngrad, agrad, atol=1e-2)
+    assert_allclose(ngrad, agrad, atol=1e-2)
 
     # Backprop for z2
     # Diff should be initialized since they are always accumulated
@@ -78,7 +79,7 @@ def test_graph_logreg(seed):
     from nbla_test_utils import \
         compute_analytical_and_numerical_grad_graph as grads
     agrad, ngrad = grads(L2, inputs, 1e-3, False)
-    assert np.allclose(ngrad, agrad, atol=1e-2)
+    assert_allclose(ngrad, agrad, atol=1e-2)
 
 
 @pytest.mark.parametrize("seed", [311])
@@ -143,7 +144,7 @@ def test_graph_model(model, seed):
     from nbla_test_utils import \
         compute_analytical_and_numerical_grad_graph as grads
     agrad, ngrad = grads(L1, inputs, 1e-3, False)
-    assert np.allclose(ngrad, agrad, atol=1.05e-2)
+    assert_allclose(ngrad, agrad, atol=1.05e-2)
 
     # Backprop for L2
     # Diff should be initialized since they are always accumulated
@@ -155,7 +156,7 @@ def test_graph_model(model, seed):
     from nbla_test_utils import \
         compute_analytical_and_numerical_grad_graph as grads
     agrad, ngrad = grads(L2, inputs, 1e-3, False)
-    assert np.allclose(ngrad, agrad, atol=1.05e-2)
+    assert_allclose(ngrad, agrad, atol=1.05e-2)
 
 
 @pytest.mark.parametrize("seed", [311])
@@ -263,8 +264,8 @@ def test_graph_forward_clear_buffer(seed, clear_buffer):
 
     # check
     nn.forward_all([y1, y2], clear_buffer=clear_buffer)
-    assert np.allclose(y1.d, ref_y1)
-    assert np.allclose(y2.d, ref_y2)
+    assert_allclose(y1.d, ref_y1)
+    assert_allclose(y2.d, ref_y2)
 
 
 @pytest.mark.parametrize("seed", [311])
@@ -313,8 +314,8 @@ def test_graph_rewire(seed, clear_buffer):
 
     # Checking forward
     nn.forward_all([yb1, yb2, yc1, yc2], clear_no_need_grad=clear_buffer)
-    assert np.allclose(yb1.d, yc1.d)
-    assert np.allclose(yb2.d, yc2.d)
+    assert_allclose(yb1.d, yc1.d)
+    assert_allclose(yb2.d, yc2.d)
 
     # Checking backward for yb1 and yc1
     # for now, the first backward cannot be called with clear_buffer=True
@@ -324,9 +325,9 @@ def test_graph_rewire(seed, clear_buffer):
     zero_grad()
     yc1.backward(clear_buffer=False)
     gc = backup_params()
-    assert np.allclose(xa.d, xc.d)
+    assert_allclose(xa.d, xc.d)
     for b, c in zip(gb, gc):
-        assert np.allclose(b, c)
+        assert_allclose(b, c)
 
     # Checking backward for yb2 and yc2
     zero_grad()
@@ -335,6 +336,6 @@ def test_graph_rewire(seed, clear_buffer):
     zero_grad()
     yc2.backward(clear_buffer=clear_buffer)
     gc = backup_params()
-    assert np.allclose(xa.d, xc.d)
+    assert_allclose(xa.d, xc.d)
     for b, c in zip(gb, gc):
-        assert np.allclose(b, c)
+        assert_allclose(b, c)

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -19,6 +19,7 @@ import nnabla.functions as F
 import nnabla.parametric_functions as PF
 from nnabla.ext_utils import get_extension_context
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 # Proxy to get the appropriate context
 ctx_list = [ctx_fname[0] for ctx_fname in list_context('Convolution')]
@@ -49,7 +50,6 @@ def SmallResNet(x, test=False):
 @pytest.mark.parametrize("auto_forward", [True, False])
 @pytest.mark.parametrize("flag_grad_outputs", [True, False])
 def test_resnet_expansion(seed, ctx, auto_forward, flag_grad_outputs):
-    from nbla_test_utils import ArrayDiffStats
     nn.clear_parameters()
 
     # Settings
@@ -85,15 +85,14 @@ def test_resnet_expansion(seed, ctx, auto_forward, flag_grad_outputs):
     if backend == 'cuda':
         pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
     for inp, grad in zip(inputs, grads):
-        assert np.allclose(
-            inp.g, grad.d, atol=1e-6), str(ArrayDiffStats(inp.g, grad.d))
+        assert_allclose(
+            inp.g, grad.d, atol=1e-6)
 
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
 @pytest.mark.parametrize("auto_forward", [True, False])
 def test_multiple_objectives(seed, ctx, auto_forward):
-    from nbla_test_utils import ArrayDiffStats
 
     # Settings
     nn.set_default_context(ctx)
@@ -132,8 +131,8 @@ def test_multiple_objectives(seed, ctx, auto_forward):
 
     # Check between results of var.bacwkard and nn.grad
     for inp, grad in zip(inputs, grads):
-        assert np.allclose(
-            inp.g, grad.d, atol=1e-6), str(ArrayDiffStats(inp.g, grad.d))
+        assert_allclose(
+            inp.g, grad.d, atol=1e-6)
 
 
 @pytest.mark.parametrize("seed", [311])
@@ -141,7 +140,6 @@ def test_multiple_objectives(seed, ctx, auto_forward):
 @pytest.mark.parametrize("auto_forward", [True, False])
 @pytest.mark.parametrize("type_grad_outputs", [int, float, np.ndarray, nn.NdArray])
 def test_grad_outputs(seed, ctx, auto_forward, type_grad_outputs):
-    from nbla_test_utils import ArrayDiffStats
 
     # Settings
     nn.set_default_context(ctx)
@@ -181,5 +179,5 @@ def test_grad_outputs(seed, ctx, auto_forward, type_grad_outputs):
 
     # Check between results of var.bacwkard and nn.grad
     for inp, grad in zip(inputs, grads):
-        assert np.allclose(
-            inp.g, grad.d, atol=1e-6), str(ArrayDiffStats(inp.g, grad.d))
+        assert_allclose(
+            inp.g, grad.d, atol=1e-6)

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -18,6 +18,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 import nnabla.parametric_functions as PF
+from nnabla.testing import assert_allclose
 
 
 @pytest.mark.parametrize("seed", [313])
@@ -53,7 +54,7 @@ def test_graph_logreg(seed):
     from nbla_test_utils import \
         compute_analytical_and_numerical_grad_graph as grads
     agrad, ngrad = grads(L, inputs, 1e-3)
-    assert np.allclose(ngrad, agrad, atol=1e-2)
+    assert_allclose(ngrad, agrad, atol=1e-2)
 
 
 @pytest.mark.parametrize("seed", [311])
@@ -114,7 +115,7 @@ def test_graph_model(model, seed):
     from nbla_test_utils import \
         compute_analytical_and_numerical_grad_graph as grads
     agrad, ngrad = grads(L, inputs, 1e-3)
-    assert np.allclose(ngrad, agrad, atol=1.05e-2)
+    assert_allclose(ngrad, agrad, atol=1.05e-2)
 
 
 @pytest.mark.parametrize("seed", [311])
@@ -229,7 +230,7 @@ def test_graph_rewire(seed, clear_buffer):
     # Checking forward
     yb.forward(clear_no_need_grad=clear_buffer)
     yc.forward(clear_no_need_grad=clear_buffer)
-    assert np.allclose(yb.d, yc.d)
+    assert_allclose(yb.d, yc.d)
     # Checking backward
     zero_grad()
     yb.backward(clear_buffer=clear_buffer)
@@ -237,9 +238,9 @@ def test_graph_rewire(seed, clear_buffer):
     zero_grad()
     yc.backward(clear_buffer=clear_buffer)
     gc = backup_params()
-    assert np.allclose(xa.d, xc.d)
+    assert_allclose(xa.d, xc.d)
     for b, c in zip(gb, gc):
-        assert np.allclose(b, c)
+        assert_allclose(b, c)
 
 
 def test_deleted_outputs():
@@ -268,20 +269,20 @@ def test_function_hook():
     y.data.zero()
 
     def forward_pre_hook(f):
-        assert np.allclose(f.outputs[0].d, 0)
+        assert_allclose(f.outputs[0].d, 0)
 
     def forward_post_hook(f):
         if f.info.type_name == 'AddScalar':
-            assert np.allclose(f.outputs[0].d, 2)
+            assert_allclose(f.outputs[0].d, 2)
         if f.info.type_name == 'MulScalar':
-            assert np.allclose(f.outputs[0].d, 1)
+            assert_allclose(f.outputs[0].d, 1)
 
     def backward_pre_hook(f):
-        assert np.allclose(f.inputs[0].g, 0)
+        assert_allclose(f.inputs[0].g, 0)
 
     def backward_post_hook(f):
         # Both h and x grad will be 0.5
-        assert np.allclose(f.inputs[0].g, 0.5)
+        assert_allclose(f.inputs[0].g, 0.5)
 
     y.forward(function_pre_hook=forward_pre_hook,
               function_post_hook=forward_post_hook)

--- a/python/test/test_imperative.py
+++ b/python/test/test_imperative.py
@@ -15,6 +15,7 @@
 import numpy as np
 
 import nnabla as nn
+from nnabla.testing import assert_allclose
 
 
 def test_imperative_i1_o1():
@@ -22,7 +23,7 @@ def test_imperative_i1_o1():
     x = nn.NdArray([2, 3, 4])
     x.fill(1)
     x1 = F.add_scalar(x, 1)
-    assert np.allclose(x1.data, 2)
+    assert_allclose(x1.data, 2)
 
 
 def test_imperative_i2_o1():
@@ -32,7 +33,7 @@ def test_imperative_i2_o1():
     x0.fill(3)
     x1.fill(0.5)
     y = F.mul2(x0, x1)
-    assert np.allclose(y.data, 1.5)
+    assert_allclose(y.data, 1.5)
 
 
 def test_imperative_pf():

--- a/python/test/test_indexing.py
+++ b/python/test/test_indexing.py
@@ -15,6 +15,7 @@
 import pytest
 import numpy as np
 import nnabla as nn
+from nnabla.testing import assert_allclose
 
 
 class Key2Key:
@@ -204,8 +205,8 @@ def test_update_index_variable():
     i_nn = nn.Variable.from_numpy_array(i_np)
     y_nn = x_nn[i_nn]
     y_nn.forward()
-    assert np.allclose(y_nn.d, x_np[i_np])
+    assert_allclose(y_nn.d, x_np[i_np])
     i_np = np.random.choice(np.arange(20), 10)
     i_nn.d = i_np
     y_nn.forward()
-    assert np.allclose(y_nn.d, x_np[i_np])
+    assert_allclose(y_nn.d, x_np[i_np])

--- a/python/test/test_ndarray_arithmetic_ops.py
+++ b/python/test/test_ndarray_arithmetic_ops.py
@@ -18,6 +18,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
+from nnabla.testing import assert_allclose
 
 
 @pytest.mark.parametrize("seed", [313])
@@ -40,7 +41,7 @@ def test_ndarray_arithmetic_ops2(seed, op, x_var, y_var, shape):
         vy = nn.NdArray.from_numpy_array(vy_data)
     vz = eval("vx {0} vy".format(op))
     ref_z = eval("vx_data {0} vy_data".format(op))
-    assert np.allclose(ref_z, vz.data)
+    assert_allclose(ref_z, vz.data)
 
     if x_var:
         return
@@ -48,7 +49,7 @@ def test_ndarray_arithmetic_ops2(seed, op, x_var, y_var, shape):
     # Inplace test
     vx_bak = vx
     exec_("vx {0}= vy".format(op))
-    assert np.allclose(vx.data, vz.data)
+    assert_allclose(vx.data, vz.data)
     assert vx is vx_bak
 
 
@@ -63,12 +64,12 @@ def test_ndarray_arithmetic_scalar_ops(seed, op, shape):
         vx.data += - vx.data.min() + 1.0
     vz = eval("vx {0} a".format(op))
     ref_z = eval("vx.data {0} a".format(op))
-    assert np.allclose(ref_z, vz.data)
+    assert_allclose(ref_z, vz.data)
 
     # Inplace test
     vx_bak = vx
     exec_("vx {0}= a".format(op))
-    assert np.allclose(vx.data, vz.data)
+    assert_allclose(vx.data, vz.data)
     assert vx is vx_bak
 
 
@@ -83,7 +84,7 @@ def test_ndarray_arithmetic_scalar_rops(seed, op, shape):
         a = np.abs(a)
     vz = eval("a {0} vx".format(op))
     ref_z = eval("a {0} vx.data".format(op))
-    assert np.allclose(ref_z, vz.data)
+    assert_allclose(ref_z, vz.data)
 
 
 @pytest.mark.parametrize("seed", [313, 314])
@@ -94,4 +95,4 @@ def test_ndarray_arithmetic_unary_ops(seed, op, shape):
     vx = nn.NdArray.from_numpy_array(rng.randn(*shape).astype(np.float32))
     vz = eval("{0} vx".format(op))
     ref_z = eval("{0} vx.data".format(op))
-    assert np.allclose(ref_z, vz.data)
+    assert_allclose(ref_z, vz.data)

--- a/python/test/test_nnp_graph.py
+++ b/python/test/test_nnp_graph.py
@@ -18,6 +18,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 import nnabla.parametric_functions as PF
+from nnabla.testing import assert_allclose
 
 
 @pytest.mark.parametrize("seed", [313])
@@ -60,8 +61,7 @@ def test_nnp_graph(seed, tmpdir):
     x2.d = d
     y.forward(clear_buffer=True)
     y2.forward(clear_buffer=True)
-    from nbla_test_utils import ArrayDiffStats
-    assert np.allclose(y.d, y2.d), str(ArrayDiffStats(y.d, y2.d))
+    assert_allclose(y.d, y2.d)
 
 
 def check_nnp_graph_save_load(tmpdir, x, y, batch_size, variable_batch_size):
@@ -110,7 +110,7 @@ def test_nnp_graph_reshape(tmpdir, variable_batch_size, batch_size, shape):
     shape2[0] = batch_size
     x2.d = np.random.randn(*x2.shape)
     y2.forward()
-    assert np.allclose(y2.d, x2.d.reshape(shape2))
+    assert_allclose(y2.d, x2.d.reshape(shape2))
 
 
 @pytest.mark.parametrize('variable_batch_size', [False, True])

--- a/python/test/test_parametric_functions.py
+++ b/python/test/test_parametric_functions.py
@@ -18,6 +18,7 @@ import nnabla as nn
 import nnabla.functions as F
 import nnabla.parametric_functions as PF
 import nnabla.initializer as I
+from nnabla.testing import assert_allclose
 
 
 @pytest.fixture(scope='function')
@@ -110,14 +111,14 @@ def test_pf_affine_execution(g_rng, inshape, n_outmaps, base_axis, w_init, b_ini
     assert w.need_grad
     assert y.parent.inputs[1].need_grad == (not fix_parameters)
     if isinstance(w_init, np.ndarray):
-        assert np.allclose(w_init, w.d)
+        assert_allclose(w_init, w.d)
     if with_bias:
         b = nn.get_parameters()['affine/b']
         assert b.shape == b_shape
         assert b.need_grad
         assert y.parent.inputs[2].need_grad == (not fix_parameters)
         if isinstance(b_init, np.ndarray):
-            assert np.allclose(b_init, b.d)
+            assert_allclose(b_init, b.d)
 
 
 @pytest.mark.parametrize("inshape, outmaps, kernel, pad, stride, dilation, group, base_axis", [
@@ -177,14 +178,14 @@ def test_pf_convolution_execution(g_rng, inshape, outmaps, kernel, pad, stride, 
     assert w.need_grad
     assert y.parent.inputs[1].need_grad == (not fix_parameters)
     if isinstance(w_init, np.ndarray):
-        assert np.allclose(w_init, w.d)
+        assert_allclose(w_init, w.d)
     if with_bias:
         b = nn.get_parameters()['conv/b']
         assert b.shape == b_shape
         assert b.need_grad
         assert y.parent.inputs[2].need_grad == (not fix_parameters)
         if isinstance(b_init, np.ndarray):
-            assert np.allclose(b_init, b.d)
+            assert_allclose(b_init, b.d)
 
 
 def _get_bn_parameter_shape(inshape, axes):
@@ -237,15 +238,15 @@ def test_pf_batch_normalization_execution(
     h = y[0] if output_stat else y
     _, b, g, m, v = h.parent.inputs
     if param_init:
-        assert np.allclose(b.d, beta_init)
-        assert np.allclose(g.d, gamma_init)
-        assert np.allclose(m.d, mean_init)
-        assert np.allclose(v.d, var_init)
+        assert_allclose(b.d, beta_init)
+        assert_allclose(g.d, gamma_init)
+        assert_allclose(m.d, mean_init)
+        assert_allclose(v.d, var_init)
     else:
-        assert np.allclose(b.d, 0)
-        assert np.allclose(g.d, 1)
-        assert np.allclose(m.d, 0)
-        assert np.allclose(v.d, 1)
+        assert_allclose(b.d, 0)
+        assert_allclose(g.d, 1)
+        assert_allclose(m.d, 0)
+        assert_allclose(v.d, 1)
 
     # Check execution
     if output_stat:
@@ -345,15 +346,15 @@ def test_pf_fused_batch_normalization_execution(
     else:
         _, b, g, m, v = h.parent.inputs
     if param_init:
-        assert np.allclose(b.d, beta_init)
-        assert np.allclose(g.d, gamma_init)
-        assert np.allclose(m.d, mean_init)
-        assert np.allclose(v.d, var_init)
+        assert_allclose(b.d, beta_init)
+        assert_allclose(g.d, gamma_init)
+        assert_allclose(m.d, mean_init)
+        assert_allclose(v.d, var_init)
     else:
-        assert np.allclose(b.d, 0)
-        assert np.allclose(g.d, 1)
-        assert np.allclose(m.d, 0)
-        assert np.allclose(v.d, 1)
+        assert_allclose(b.d, 0)
+        assert_allclose(g.d, 1)
+        assert_allclose(m.d, 0)
+        assert_allclose(v.d, 1)
 
     # Check execution
     if output_stat:
@@ -458,7 +459,7 @@ def test_pf_spectral_norm_execution(g_rng, w_shape, dim, itr, test, u_init):
     # Check values
     w_sn_numpy = spectral_norm_numpy(
         w.d, dim, itr, test=test, u_init_d=u_init_d)
-    assert np.allclose(w_sn_numpy, w_sn.d, atol=1e-2, rtol=1e-5)
+    assert_allclose(w_sn_numpy, w_sn.d, atol=1e-2, rtol=1e-5)
 
     # Check args (cannot since this is the functions composite)
 
@@ -524,8 +525,8 @@ def test_pf_layer_normalization(g_rng, inshape, batch_axis, output_stat, fix_par
     h = y[0]
     b = h.parent.inputs[1]
     g = h.parent.inputs[0].parent.inputs[1]
-    assert np.allclose(b.d, beta_init)
-    assert np.allclose(g.d, gamma_init)
+    assert_allclose(b.d, beta_init)
+    assert_allclose(g.d, gamma_init)
 
     # Check execution
     forward_backward_all(*y)
@@ -537,7 +538,7 @@ def test_pf_layer_normalization(g_rng, inshape, batch_axis, output_stat, fix_par
         ref = [ref]
 
     for i in range(len(ref)):
-        assert np.allclose(y[i].d, ref[i], atol=1e-2, rtol=1e-5)
+        assert_allclose(y[i].d, ref[i], atol=1e-2, rtol=1e-5)
 
     # Check created parameters
     assert len(nn.get_parameters()) == 2
@@ -616,8 +617,8 @@ def test_pf_instance_normalization(g_rng, inshape, batch_axis, channel_axis, out
     h = y[0]
     b = h.parent.inputs[1]
     g = h.parent.inputs[0].parent.inputs[1]
-    assert np.allclose(b.d, beta_init)
-    assert np.allclose(g.d, gamma_init)
+    assert_allclose(b.d, beta_init)
+    assert_allclose(g.d, gamma_init)
 
     # Check execution
     forward_backward_all(*y)
@@ -629,7 +630,7 @@ def test_pf_instance_normalization(g_rng, inshape, batch_axis, channel_axis, out
         ref = [ref]
 
     for i in range(len(ref)):
-        assert np.allclose(y[i].d, ref[i], atol=1e-2, rtol=1e-5)
+        assert_allclose(y[i].d, ref[i], atol=1e-2, rtol=1e-5)
 
     # Check created parameters
     assert len(nn.get_parameters()) == 2
@@ -721,8 +722,8 @@ def test_pf_group_normalization(g_rng, num_groups, inshape, batch_axis, channel_
     h = y[0]
     b = h.parent.inputs[0].parent.inputs[1]
     g = h.parent.inputs[0].parent.inputs[0].parent.inputs[1]
-    assert np.allclose(b.d, beta_init)
-    assert np.allclose(g.d, gamma_init)
+    assert_allclose(b.d, beta_init)
+    assert_allclose(g.d, gamma_init)
 
     # Check execution
     forward_backward_all(*y)
@@ -734,7 +735,7 @@ def test_pf_group_normalization(g_rng, num_groups, inshape, batch_axis, channel_
         ref = [ref]
 
     for i in range(len(ref)):
-        assert np.allclose(y[i].d, ref[i], atol=1e-2, rtol=1e-5)
+        assert_allclose(y[i].d, ref[i], atol=1e-2, rtol=1e-5)
 
     # Check created parameters
     assert len(nn.get_parameters()) == 2
@@ -825,14 +826,14 @@ def test_pf_rnn_execution(g_rng, inshape, w0_init, w_init, b_init, num_layers, n
         assert w0.need_grad
         assert y.parent.inputs[2].need_grad == (not fix_parameters)
         if isinstance(w0_init, np.ndarray):
-            assert np.allclose(w0_init, w0.d)
+            assert_allclose(w0_init, w0.d)
         if num_layers > 1:
             w = nn.get_parameters()['rnn/weight']
             assert w.shape == w_shape
             assert w.need_grad
             assert y.parent.inputs[3].need_grad == (not fix_parameters)
             if isinstance(w_init, np.ndarray):
-                assert np.allclose(w_init, w.d)
+                assert_allclose(w_init, w.d)
         if with_bias:
             b = nn.get_parameters()['rnn/bias']
             assert b.shape == b_shape
@@ -842,7 +843,7 @@ def test_pf_rnn_execution(g_rng, inshape, w0_init, w_init, b_init, num_layers, n
             else:
                 assert y.parent.inputs[3].need_grad == (not fix_parameters)
             if isinstance(b_init, np.ndarray):
-                assert np.allclose(b_init, b.d)
+                assert_allclose(b_init, b.d)
 
 
 ctxs = list_context('GRU')
@@ -915,14 +916,14 @@ def test_pf_gru_execution(g_rng, inshape, w0_init, w_init, b_init, num_layers, d
         assert w0.need_grad
         assert y.parent.inputs[2].need_grad == (not fix_parameters)
         if isinstance(w0_init, np.ndarray):
-            assert np.allclose(w0_init, w0.d)
+            assert_allclose(w0_init, w0.d)
         if num_layers > 1:
             w = nn.get_parameters()['gru/weight']
             assert w.shape == w_shape
             assert w.need_grad
             assert y.parent.inputs[3].need_grad == (not fix_parameters)
             if isinstance(w_init, np.ndarray):
-                assert np.allclose(w_init, w.d)
+                assert_allclose(w_init, w.d)
         if with_bias:
             b = nn.get_parameters()['gru/bias']
             assert b.shape == b_shape
@@ -932,7 +933,7 @@ def test_pf_gru_execution(g_rng, inshape, w0_init, w_init, b_init, num_layers, d
             else:
                 assert y.parent.inputs[3].need_grad == (not fix_parameters)
             if isinstance(b_init, np.ndarray):
-                assert np.allclose(b_init, b.d)
+                assert_allclose(b_init, b.d)
 
 
 ctxs = list_context('LSTM')
@@ -1008,14 +1009,14 @@ def test_pf_lstm_execution(g_rng, inshape, w0_init, w_init, b_init, num_layers, 
         assert w0.need_grad
         assert y.parent.inputs[3].need_grad == (not fix_parameters)
         if isinstance(w0_init, np.ndarray):
-            assert np.allclose(w0_init, w0.d)
+            assert_allclose(w0_init, w0.d)
         if num_layers > 1:
             w = nn.get_parameters()['lstm/weight']
             assert w.shape == w_shape
             assert w.need_grad
             assert y.parent.inputs[4].need_grad == (not fix_parameters)
             if isinstance(w_init, np.ndarray):
-                assert np.allclose(w_init, w.d)
+                assert_allclose(w_init, w.d)
         if with_bias:
             b = nn.get_parameters()['lstm/bias']
             assert b.shape == b_shape
@@ -1025,7 +1026,7 @@ def test_pf_lstm_execution(g_rng, inshape, w0_init, w_init, b_init, num_layers, 
             else:
                 assert y.parent.inputs[4].need_grad == (not fix_parameters)
             if isinstance(b_init, np.ndarray):
-                assert np.allclose(b_init, b.d)
+                assert_allclose(b_init, b.d)
 
 
 @pytest.mark.parametrize("inshape", [(8, 2, 2, 2), (16, 1, 8)])
@@ -1068,7 +1069,7 @@ def test_pf_prelu_execution(g_rng, inshape, base_axis, shared, slope_init, fix_p
     assert slope.need_grad
     assert y.parent.inputs[1].need_grad == (not fix_parameters)
     if isinstance(slope_init, np.ndarray):
-        assert np.allclose(slope_init, slope.d)
+        assert_allclose(slope_init, slope.d)
 
 
 # TODO: Test all parametric functions.

--- a/python/test/test_variable.py
+++ b/python/test/test_variable.py
@@ -16,6 +16,7 @@ import pytest
 import numpy as np
 
 import nnabla as nn
+from nnabla.testing import assert_allclose
 
 
 def test_manip():
@@ -134,11 +135,11 @@ def test_persistent():
     x3.persistent = True
     x.data.zero()
     y.forward(clear_buffer=True)
-    assert np.allclose(x3.d, 3)
+    assert_allclose(x3.d, 3)
     y.forward(clear_no_need_grad=True)
     y.backward(clear_buffer=True)
-    assert np.allclose(x3.d, 3)
-    assert np.allclose(x3.g, 1)
+    assert_allclose(x3.d, 3)
+    assert_allclose(x3.g, 1)
 
 
 def test_name():

--- a/python/test/test_variable_arithmetic_ops.py
+++ b/python/test/test_variable_arithmetic_ops.py
@@ -16,6 +16,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
+from nnabla.testing import assert_allclose
 
 
 @pytest.mark.parametrize("seed", [313])
@@ -30,7 +31,7 @@ def test_variable_arithmetic_ops2(seed, op):
     with nn.auto_forward():
         vz = eval("vx {0} vy".format(op))
         ref_z = eval("vx.d {0} vy.d".format(op))
-        assert np.allclose(ref_z, vz.d)
+        assert_allclose(ref_z, vz.d)
 
 
 @pytest.mark.parametrize("seed", [313, 314])
@@ -44,7 +45,7 @@ def test_variable_arithmetic_scalar_ops(seed, op):
     with nn.auto_forward():
         vz = eval("vx {0} a".format(op))
         ref_z = eval("vx.d {0} a".format(op))
-        assert np.allclose(ref_z, vz.d)
+        assert_allclose(ref_z, vz.d)
 
 
 @pytest.mark.parametrize("seed", [313, 314])
@@ -58,7 +59,7 @@ def test_variable_arithmetic_scalar_rops(seed, op):
     with nn.auto_forward():
         vz = eval("a {0} vx".format(op))
         ref_z = eval("a {0} vx.d".format(op))
-        assert np.allclose(ref_z, vz.d)
+        assert_allclose(ref_z, vz.d)
 
 
 @pytest.mark.parametrize("seed", [313, 314])
@@ -69,4 +70,4 @@ def test_variable_arithmetic_unary_ops(seed, op):
     with nn.auto_forward():
         vz = eval("{0} vx".format(op))
         ref_z = eval("{0} vx.d".format(op))
-        assert np.allclose(ref_z, vz.d)
+        assert_allclose(ref_z, vz.d)

--- a/python/test/utils/conversion/test_conversion.py
+++ b/python/test/utils/conversion/test_conversion.py
@@ -19,6 +19,8 @@ import shutil
 import pytest
 import nnabla
 import nnabla.utils.load as nnload
+from nnabla.testing import assert_allclose
+
 import numpy as np
 CAFFE2_AVAILABLE = False
 try:
@@ -163,7 +165,7 @@ def convert_onnx_to_nnp_and_compare(
         print(backend_out, nnout)
     assert backend_out.shape == nnout.shape
     if compare_values:
-        assert np.allclose(backend_out, nnout, atol=atol)
+        assert_allclose(backend_out, nnout, atol=atol)
         import_result[func_name] = 'OK'
 
 
@@ -245,7 +247,7 @@ def convert_nnp_to_onnx_and_compare(
             print(backend_out, nnout)
         assert backend_out.shape == nnout.shape
         if compare_values:
-            assert np.allclose(backend_out, nnout, atol=atol)
+            assert_allclose(backend_out, nnout, atol=atol)
             export_result[func_name][opset] = 'OK'
         onnxdir.remove()
 

--- a/python/test/utils/test_graph_converters/graph_converter_test_utils.py
+++ b/python/test/utils/test_graph_converters/graph_converter_test_utils.py
@@ -25,6 +25,8 @@ from nnabla.ext_utils import get_extension_context
 
 import nnabla.experimental.graph_converters as GC
 
+from nnabla.testing import assert_allclose
+
 # -------
 # Testers
 # -------
@@ -65,7 +67,7 @@ def value_tester(vleaf_ref, vleaf_act, rtol=1e-04, atol=1e-05):
     print(np.abs(vleaf_ref.d - vleaf_act.d))
     print("--- Sign Diff ----")
     print(np.sign(vleaf_ref.d) - np.sign(vleaf_act.d))
-    assert np.allclose(vleaf_ref.d, vleaf_act.d, rtol=rtol, atol=atol)
+    assert_allclose(vleaf_ref.d, vleaf_act.d, rtol=rtol, atol=atol)
 
 # -------
 # Helpers

--- a/python/test/utils/test_image_utils.py
+++ b/python/test/utils/test_image_utils.py
@@ -19,6 +19,7 @@ import numpy as np
 
 from nnabla.utils import image_utils
 from nnabla.logger import logger
+from nnabla.testing import assert_allclose
 
 SIZE = (8, 8, 3)
 
@@ -99,7 +100,7 @@ def test_minmax_auto_scale(img, as_uint16):
     # check if correctly scaled up
     reverted = image_utils.common.rescale_pixel_intensity(rescaled, rescaled.min(), rescaled.max(),
                                                           img.min(), img.max(), img.dtype)
-    assert np.allclose(img, reverted, atol=1 / 2 ** 4)
+    assert_allclose(img, reverted, atol=1 / 2 ** 4)
 
 
 @pytest.mark.parametrize("backend", ["pil", "pypng", "cv2"])
@@ -177,7 +178,7 @@ def test_imsave_and_imread(tmpdir, backend, grayscale, size, channel_first, as_u
         scaler = get_scale_factor(img, auto_scale, as_uint16)
         dtype = img.dtype if img.dtype in [np.uint8, np.uint16] else np.float32
 
-        assert np.allclose(
+        assert_allclose(
             (img.astype(dtype) * scaler).astype(read_image.dtype), read_image)
 
 

--- a/src/nbla/solver.cpp
+++ b/src/nbla/solver.cpp
@@ -68,7 +68,7 @@ void Solver::set_parameters(const vector<pair<string, VariablePtr>> &params,
         remove_state_impl(kv.first);
       }
     }
-    params_.insert({kv.first, {kv.second, 0}});
+    params_.insert({kv.first, {kv.second}});
     set_state_impl(kv.first, kv.second);
   }
 }
@@ -118,14 +118,13 @@ void Solver::zero_grad() {
   for (auto &kv : params_) {
     SyncedArrayPtr g = kv.second.p->grad()->array();
     g->zero();
-    kv.second.at = g->modification_count();
   }
 }
 
 void Solver::update() {
   for (auto &kv : params_) {
     SyncedArrayPtr g = kv.second.p->grad()->array();
-    if (kv.second.at == g->modification_count()) {
+    if (g->zeroing()) {
       // The gradient is not computed. Skip.
       continue;
     }
@@ -138,7 +137,7 @@ void Solver::weight_decay(float decay_rate) {
     return;
   for (auto &kv : params_) {
     SyncedArrayPtr g = kv.second.p->grad()->array();
-    if (kv.second.at == g->modification_count()) {
+    if (g->zeroing()) {
       // The gradient is not computed. Skip.
       continue;
     }
@@ -149,7 +148,7 @@ void Solver::weight_decay(float decay_rate) {
 bool Solver::check_inf_grad() {
   for (auto &kv : params_) {
     SyncedArrayPtr g = kv.second.p->grad()->array();
-    if (kv.second.at == g->modification_count()) {
+    if (g->zeroing()) {
       // The gradient is not computed. Skip.
       continue;
     }
@@ -164,7 +163,7 @@ bool Solver::check_inf_grad() {
 bool Solver::check_nan_grad() {
   for (auto &kv : params_) {
     SyncedArrayPtr g = kv.second.p->grad()->array();
-    if (kv.second.at == g->modification_count()) {
+    if (g->zeroing()) {
       // The gradient is not computed. Skip.
       continue;
     }
@@ -179,7 +178,7 @@ bool Solver::check_nan_grad() {
 bool Solver::check_inf_or_nan_grad() {
   for (auto &kv : params_) {
     SyncedArrayPtr g = kv.second.p->grad()->array();
-    if (kv.second.at == g->modification_count()) {
+    if (g->zeroing()) {
       // The gradient is not computed. Skip.
       continue;
     }
@@ -194,7 +193,7 @@ bool Solver::check_inf_or_nan_grad() {
 void Solver::scale_grad(float scale) {
   for (auto &kv : params_) {
     SyncedArrayPtr g = kv.second.p->grad()->array();
-    if (kv.second.at == g->modification_count()) {
+    if (g->zeroing()) {
       // The gradient is not computed. Skip.
       continue;
     }


### PR DESCRIPTION
Coupled with sony/nnabla-ext-cuda#181, this PR changes the behavior of all reduce by skipping the operation when arrays are not updated after calling `.zero()`. The advantages of this change are;

* Save the redundant communication and computation for all reduce of zero arrays
* Fixing a undesired behavior in solver's update & weight decay. The update & weight decay are performed only if the gradient arrays are updated. The previous implementation always executes all reduce, which causes unnecessary modifications of zero arrays. In the end, the solver's operations are  performed undesirably. I will elaborate on this in the following.

Suppose that there are some parameter variables in a graph which don't require gradient (i.e., `need_grad=False`). **User must think that the parameters are fixed during training**. Also, there are all reduce operations for gradients before calling weight decay (`weight_decay(wd)`). In the previous implementation, allreduce will be performed regardless the need_grad flags in a graph (i.e., gradients are not computed during backward and left as `zeroing()==True` before allreduce), which results in the updated gradients (they are considered as updated in solver.weight_decay). Then, the weight decay is performed, and the gradient becomes non-zero, then **the parameter is modified by `update()` unintentionally**. One may think it can be handled by passing parameter variables obtained by  `nn.get_parameters(grad_only=True)`  to the allreduce function as it returns only variables which require gradient computation (`need_grad=True`). But, it can't because the `nn.get_parameters` returns parameters maintained in global, and `need_grad` flags of the parameter variables in global are fixed as default values determined by parametric function implementations (e.g., convolution weights and biases are always `True`, while running mean and variance of BN are always `False`). Even if you create a computation graph with modified need_grad flags (e.g. by using `fix_parameters` option in a `parametric_functions` function), the change doesn't affect the returning variables of `nn.get_parameters`. We may have to add a way to obtain trainable parameters from a computation graph to make sure the parameters are not updated during training. However, this is kind of a design issue. At this moment, I fix it just by skipping allreduce when gradients are not computed during backward.