### PR TITLE
Min-max quantization

### DIFF
--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -420,6 +420,9 @@ INQConvolution:
 FixedPointQuantize:
   float: [float]
   half: [Half]
+MinMaxQuantize:
+  float: [float]
+  half: [Half]
 Pow2Quantize:
   float: [float]
   half: [Half]

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -5142,6 +5142,135 @@ Quantization Neural Network Layers:
     function_ids:
       BifB: 113
     c_runtime: not support
+  MinMaxQuantize:
+    snake_name: min_max_quantize
+    doc: |+
+      This function uniformly quantizes values in the range of min and max quantization levels.
+       
+      Min-max quantization is defined as the following equation
+       
+      .. math::
+       
+          y = round \left(\frac{\min(\max(x, m), M) - m}{scale} \right) \times scale + m, 
+       
+      where the :math:`scale` is defined as 
+       
+      .. math::
+       
+          scale = \frac{M - m}{M_q - m_q}, 
+       
+      and 
+       
+      .. math::
+       
+          m_q = ql_{min}, \\
+          M_q = ql_{max}, \\
+          m = qr_{min}, \\
+          M = qr_{max}.
+       
+      In the backward pass when using `ste_fine_grained` as false,
+       
+          .. math::
+       
+            \frac{\partial q_i}{\partial x_i} = 1.
+       
+       
+      In the backward pass when using `ste_fine_grained` as true,
+       
+          .. math::
+       
+             \frac{\partial q_i}{\partial x_i}= \left\{
+           \begin{array}{ll}
+             0 & if \ \ \ x_i > M \\
+             1 & if \ \ m \le x_i \le M \\
+             0 & if \ \ x_i < m \\
+           \end{array} \right..
+       
+      :math:`qr_{min}` and :math:`qr_{max}` are treaded as follows.
+       
+          * `x_min_max` is `True` and `ema` is `True`: 
+            Exponential moving average are computed for each :math:`min(x)` and :math:`max(x)` 
+            then stored in :math:`qr_{min}` and :math:`qr_{max}`.
+          * `x_min_max` is `True` and `ema` is `False`:
+            :math:`min(x)` and :math:`max(x)` are computed then stored in :math:`qr_{min}` and :math:`qr_{max}`.
+          * `x_min_max` is `False` and `ema` is `True`:
+            Exponential moving average stored in :math:`qr_{min}` and :math:`qr_{max}` are used.
+          * `x_min_max` is `False` and `ema` is `False`
+            Gradients of :math:`qr_{min}` and :math:`qr_{max}` are computed in the backward pass.
+       
+      More precisely, in inference of the min-max quantization, one has to consider *zero-point (zp)*
+      which corresponds
+      to the real value 0, and its data type is an integer. *zero-point* is defined as 
+       
+          .. math::
+       
+             && zp_f = ql_{min} -\frac{qr_{min}}{scale}, \\
+             && zp = \left\{
+           \begin{array}{ll}
+             ql_{max} & if \ \ \ zp_f >= ql_{max} \\
+             round(zp_f) & if \ \ otherwise \\
+             ql_{min}  & if \ \ zp_f <= ql_{min} \\
+           \end{array} \right..
+       
+      Accordingly, in order to simulate quantization effect of *zero-point*, 
+      during both forward and backward pass, :math:`qr_{min}` and :math:`qr_{max}` are adjusted as follows,
+       
+          .. math::
+           
+             qr_{min}^{adj} = ql_{min} - zp * scale, \\
+             qr_{max}^{adj} = ql_{max} - zp * scale.
+       
+      These operations are often called *nudge*. 
+       
+      Finally, in the formulas of the min-max quantization, :math:`m` and :math:`M` are replaced by
+      :math:`qr_{min}^{adj}` and :math:`qr_{max}^{adj}` respectively.
+
+      .. note::
+
+      	Quantized values are stored as floating point number, since this function is for simulation purposes.
+
+    inputs:
+      x:
+        doc: N-D array innput.
+      qr_min:
+        doc: Minimum value for the quantization range, modified during forward execution
+          when x_min_max is True.
+      qr_max:
+        doc: Maximum value for the quantization range, modified during forward execution
+          when x_min_max is True.
+      ql_min:
+        doc: Minimum value for the quantization level, typically 0.
+      ql_max:
+        doc: Maximum value for the quantization level, typically 255.
+    arguments:
+      decay:
+        doc: Decay rate for the exponential moving average.
+        type: float
+        default: '0.999'
+      x_min_max:
+        doc: Use the min and max of x to compute quantization ranges.
+        type: bool
+        default: 'False'
+      ema:
+        doc: Use the exponential moving average for the min and max quantization ranges.
+        type: bool
+        default: 'False'
+      ste_fine_grained:
+        doc: Straight Through Estimator is fine-grained or not.
+        type: bool
+        default: 'True'
+      eps:
+        doc: Epsilon, or small value to ensure :math:`qr_{max} - qr_{min}` must be
+          greater than the epsilon.
+        type: float
+        default: '0.01'
+    outputs:
+      y:
+        doc: N-D array.
+    c_runtime: not support
+    function_ids:
+      fBBB: 273
+      fBBBf: 274
   Pow2Quantize:
     snake_name: pow2_quantize
     doc: |2+

--- a/doc/python/api/function.rst
+++ b/doc/python/api/function.rst
@@ -247,6 +247,7 @@ Quantized Neural Network Layers
 .. autofunction:: binary_weight_affine
 .. autofunction:: binary_weight_convolution
 .. autofunction:: fixed_point_quantize
+.. autofunction:: min_max_quantize
 .. autofunction:: pow2_quantize
 .. autofunction:: prune
 		  

--- a/doc/python/api/parametric_function.rst
+++ b/doc/python/api/parametric_function.rst
@@ -96,10 +96,13 @@ Here is the list of parametric functions.
 
 .. autofunction:: fixed_point_quantized_affine
 .. autofunction:: fixed_point_quantized_convolution
+.. autofunction:: min_max_quantized_affine
+.. autofunction:: min_max_quantized_convolution
 .. autofunction:: pow2_quantized_affine
 .. autofunction:: pow2_quantized_convolution
 .. autofunction:: pruned_affine
 .. autofunction:: pruned_convolution
+.. autofunction:: min_max_quantize
 
 .. autofunction:: lstm_cell
 

--- a/include/nbla/function/min_max_quantize.hpp
+++ b/include/nbla/function/min_max_quantize.hpp
@@ -1,0 +1,115 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// fixed_point_quantize.hpp
+#ifndef NBLA_FUNCTION_MIN_MAX_QUANTIZE_HPP
+#define NBLA_FUNCTION_MIN_MAX_QUANTIZE_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(MinMaxQuantize, float, bool, bool, bool, float);
+
+/** MinMaxQuantize quantizes values in integer representation.
+
+Inputs:
+- N-D array of input
+- N-D array of minimum quantization range (modified during forward execution)
+- N-D array of maximum quantization range (modified during forward execution)
+- N-D array of minimum quantization level
+- N-D array of maximum quantization level
+execution)
+
+@tparam T Data type for computation.
+
+@param decay Decay rate for the exponential moving average.
+@param x_min_max Use the min and max of x to compute quantization ranges.
+@param ema Use the exponential moving average for the min and max quantization.
+ranges.
+@param ste_fine_grained Straight Through Estimator is fine-grained or not.
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class MinMaxQuantize : public BaseFunction<float, bool, bool, bool, float> {
+protected:
+  float decay_;
+  bool x_min_max_;
+  bool ema_;
+  bool ste_fine_grained_;
+  float eps_;
+  shared_ptr<Function> identity_;
+  shared_ptr<Function> round_;
+  shared_ptr<Function> add2_;
+  shared_ptr<Function> sub2_;
+  shared_ptr<Function> mul2_;
+  shared_ptr<Function> div2_;
+  shared_ptr<Function> minimum2_;
+  shared_ptr<Function> maximum2_;
+  shared_ptr<Function> mul_scalar_;
+  shared_ptr<Function> mul_scalar2_;
+  shared_ptr<Function> min_;
+  shared_ptr<Function> max_;
+  shared_ptr<Function> broadcast_;
+  shared_ptr<Function> greater_equal_;
+  shared_ptr<Function> less_equal_;
+  shared_ptr<Function> greater_;
+  shared_ptr<Function> less_;
+  shared_ptr<Function> sum_;
+  VariablePtr scale_sptr_;
+
+public:
+  MinMaxQuantize(const Context &ctx, float decay, bool x_min_max, bool ema,
+                 bool ste_fine_grained, float eps)
+      : BaseFunction(ctx, decay, x_min_max, ema, ste_fine_grained, eps),
+        decay_(decay), x_min_max_(x_min_max), ema_(ema),
+        ste_fine_grained_(ste_fine_grained), eps_(eps) {}
+  virtual ~MinMaxQuantize() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_MinMaxQuantize(ctx_, decay_, x_min_max_, ema_,
+                                 ste_fine_grained_, eps_);
+  }
+  virtual int min_inputs() { return 5; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>(),
+                          get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "MinMaxQuantize"; }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+  NBLA_API virtual void nudge_range(Variable *qr_min, Variable *qr_max);
+  NBLA_API virtual void nudge_qr_min_max(Variable *qr_min, Variable *qr_max,
+                                         Variable *ql_min, Variable *ql_max,
+                                         Variable *scale,
+                                         Variable *qr_min_nudged,
+                                         Variable *qr_max_nudged);
+};
+}
+#endif

--- a/python/src/nnabla/backward_function/min_max_quantize.py
+++ b/python/src/nnabla/backward_function/min_max_quantize.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class MinMaxQuantizeBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'MinMaxQuantizeBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of MinMaxQuantizeBackward class is not implemented.")

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -2975,7 +2975,7 @@ class LSTMCell:
 
 
 @parametric_function_api("spectral-norm", [
-    ('W_sn', 'Spectral Normalized Weight matrix.', 'w.shape', False),
+    ('W_sn', 'Spectral Normalized Weight matrix', 'w.shape', False),
     ('u', 'singular vector', '(w.shape[dim], )', False),
 ])
 def spectral_norm(w, dim=0, itr=1, eps=1e-12, test=False, u_init=None, fix_parameters=True):

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -156,7 +156,7 @@ def affine(inp, n_outmaps,
         apply_b (function): Lambda, function, or callable object applied to the bias.
 
     Returns:
-        :class:`~nnabla.Variable`: :math:`(B + 1)`-D array. (:math:`M_0 \\times \ldots \\times M_{B-1} \\times L`)f
+        :class:`~nnabla.Variable`: :math:`(B + 1)`-D array. (:math:`M_0 \\times \ldots \\times M_{B-1} \\times L`)
 
     """
     if not hasattr(n_outmaps, '__iter__'):

--- a/python/test/function/test_min_max_quantize.py
+++ b/python/test/function/test_min_max_quantize.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('MinMaxQuantize')
+
+
+def ref_min_max_quantize(x, qr_min, qr_max, ql_min, ql_max,
+                         decay, x_min_max, ema, ste_fine_grained, eps,
+                         quantize):
+    if not quantize:
+        return x
+
+    # min-max
+    raxes = tuple([i for i, s in enumerate(ql_min.shape) if s == 1])
+    x_min = np.min(x, raxes, keepdims=True)
+    x_max = np.max(x, raxes, keepdims=True)
+    if x_min_max and ema:
+        qr_min = decay * qr_min + (1.0 - decay) * x_min
+        qr_max = decay * qr_max + (1.0 - decay) * x_max
+    elif x_min_max and not ema:
+        qr_min = x_min
+        qr_max = x_max
+    # scale
+    scale = (qr_max - qr_min) / (ql_max - ql_min)
+    # nudge scale
+    if np.any(qr_max - qr_min < eps):
+        qr_max[qr_max - qr_min < eps] = qr_min + eps
+    # nudge min-max
+    zero_point_from_min = ql_min - qr_min / scale
+    zero_point_nudged = np.round(zero_point_from_min)
+    if np.any(zero_point_from_min <= ql_min):
+        zero_point_nudged[zero_point_from_min <=
+                          ql_min] = q_min[zero_point_from_min <= ql_min]
+    if np.any(zero_point_from_min >= ql_max):
+        zero_point_nudged[zero_point_from_min >=
+                          ql_max] = q_max[zero_point_from_min >= ql_max]
+    qr_min_nudged = (ql_min - zero_point_nudged) * scale
+    qr_max_nudged = (ql_max - zero_point_nudged) * scale
+    x_q = np.round((np.clip(x, qr_min_nudged, qr_max_nudged) - qr_min_nudged) /
+                   scale) * scale + qr_min_nudged
+    return x_q
+
+
+def ref_grad_min_max_quantize(x, qr_min, qr_max, ql_min, ql_max, dy,
+                              decay, x_min_max, ema, ste_fine_grained, eps,
+                              quantize):
+    if not quantize:
+        return dy.flatten()
+
+    # min-max
+    raxes = tuple([i for i, s in enumerate(ql_min.shape) if s == 1])
+    x_min = np.min(x, raxes, keepdims=True)
+    x_max = np.max(x, raxes, keepdims=True)
+    if x_min_max and ema:
+        qr_min = decay * qr_min + (1.0 - decay) * x_min
+        qr_max = decay * qr_max + (1.0 - decay) * x_max
+    elif x_min_max and not ema:
+        qr_min = x_min
+        qr_max = x_max
+    elif not x_min_max and ema:
+        pass
+    # scale
+    scale = (qr_max - qr_min) / (ql_max - ql_min)
+    # nudge scale
+    if np.any(qr_max - qr_min < eps):
+        qr_max[qr_max - qr_min < eps] = qr_min + eps
+    # nudge min-max
+    zero_point_from_min = ql_min - qr_min / scale
+    zero_point_nudged = np.round(zero_point_from_min)
+    if np.any(zero_point_from_min <= ql_min):
+        zero_point_nudged[zero_point_from_min <=
+                          ql_min] = q_min[zero_point_from_min <= ql_min]
+    if np.any(zero_point_from_min >= ql_max):
+        zero_point_nudged[zero_point_from_min >=
+                          ql_max] = q_max[zero_point_from_min >= ql_max]
+    qr_min_nudged = (ql_min - zero_point_nudged) * scale
+    qr_max_nudged = (ql_max - zero_point_nudged) * scale
+
+    # STE
+    dy0 = dy.copy()
+    if ste_fine_grained:
+        dy = dy0 * (x >= qr_min_nudged) * (x <= qr_max_nudged)
+    if x_min_max or ema:
+        return dy.flatten()
+    else:  # train qr_min and qr_max
+        d_qr_min = np.sum(dy0 * (x < qr_min_nudged), raxes, keepdims=True)
+        d_qr_max = np.sum(dy0 * (x > qr_max_nudged), raxes, keepdims=True)
+        return np.concatenate([dy.flatten(), d_qr_min.flatten(), d_qr_max.flatten()])
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("x_shape, q_shape", [  # per-tensor (per-layer)
+                                              ((4, 8, 16, 16), (1, 1, 1, 1)),
+                                              # per-channel (channel-first) for activation
+                                              ((4, 8, 16, 16), (1, 8, 1, 1)),
+                                              # per-channel (channel-first) for weights
+                                              ((16, 8, 3, 3), (16, 1, 1, 1)),
+                                              ])
+@pytest.mark.parametrize("decay", [0.999, 0.9])
+@pytest.mark.parametrize("x_min_max", [True, False])
+@pytest.mark.parametrize("ema", [True, False])
+@pytest.mark.parametrize("ste_fine_grained", [True, False])
+@pytest.mark.parametrize("eps", [0.01])
+@pytest.mark.parametrize("quantize", [True, False])
+def test_min_max_quantize_forward_backward(seed, x_shape, q_shape,
+                                           decay, x_min_max, ema, ste_fine_grained,
+                                           eps,
+                                           quantize,
+                                           ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, \
+        function_tester
+    rng = np.random.RandomState(seed)
+    # Inputs
+    x = rng.randn(*x_shape)
+    qr_min = -0.5 * rng.rand(*q_shape)
+    qr_max = +0.5 * rng.rand(*q_shape)
+    ql_min = np.zeros(q_shape)
+    ql_max = np.ones(q_shape) * 255
+    inputs = [x, qr_min, qr_max, ql_min, ql_max]
+    func_args = [decay, x_min_max, ema, ste_fine_grained, eps, quantize]
+
+    # No quantization
+    if not quantize:
+        vinputs = [nn.Variable.from_numpy_array(xd) for xd in inputs]
+        v = vinputs[0]
+        with nn.context_scope(ctx):
+            o = F.min_max_quantize(*(vinputs + func_args))
+        np.allclose(o.d, v.d)
+        return
+    # x_min_max and ema
+    # function_tester does not work in this combination
+    # when comparing gradients between true_g = v.g - g_init (accum=True) and g (accum=False)
+    # since forward changes the exponential moving averages
+    if x_min_max and ema:
+        from nbla_test_utils import ArrayDiffStats
+        vinputs = [nn.Variable.from_numpy_array(xd) for xd in inputs]
+        vinputs[0].need_grad = True
+        with nn.context_scope(ctx):
+            y = F.min_max_quantize(*(vinputs + func_args))
+        # forward check
+        y.forward()
+        y_ref = ref_min_max_quantize(x, qr_min, qr_max, ql_min, ql_max,
+                                     decay, x_min_max, ema, ste_fine_grained, eps,
+                                     quantize)
+        assert np.allclose(y_ref, y.d, atol=1e-5), ArrayDiffStats(y_ref, y.d)
+        # backward check (accum=False)
+        xv = vinputs[0]
+        xv.grad.zero()
+        dy = rng.randn(*y.shape)
+        y.backward(dy)
+        gx_ref = ref_grad_min_max_quantize(x, qr_min, qr_max, ql_min, ql_max, dy,
+                                           decay, x_min_max, ema, ste_fine_grained, eps,
+                                           quantize)
+        ag = xv.g.copy()
+        assert np.allclose(gx_ref, ag.flatten(),
+                           atol=1e-5), ArrayDiffStats(gx_ref, ag.flatten())
+        # backward check (accum=True)
+        y.backward(dy)
+        assert np.allclose(ag * 2.0, xv.g.copy(),
+                           atol=1e-5), ArrayDiffStats(ag * 2.0, xv.g.copy())
+        return
+    # General tests
+    backward = [True, False, False, False, False, False] if x_min_max or ema \
+        else [True, True, True, False, False, False]
+    function_tester(rng,
+                    F.min_max_quantize,
+                    ref_min_max_quantize,
+                    inputs,
+                    func_args=func_args,
+                    atol_b=1e-3, backward=backward,
+                    ctx=ctx, func_name=func_name,
+                    disable_half_test=True,
+                    ref_grad=ref_grad_min_max_quantize)

--- a/src/nbla/function/generic/min_max_quantize.cpp
+++ b/src/nbla/function/generic/min_max_quantize.cpp
@@ -1,0 +1,432 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/add2.hpp>
+#include <nbla/function/add_scalar.hpp>
+#include <nbla/function/broadcast.hpp>
+#include <nbla/function/div2.hpp>
+#include <nbla/function/greater.hpp>
+#include <nbla/function/greater_equal.hpp>
+#include <nbla/function/identity.hpp>
+#include <nbla/function/less.hpp>
+#include <nbla/function/less_equal.hpp>
+#include <nbla/function/max.hpp>
+#include <nbla/function/maximum2.hpp>
+#include <nbla/function/min.hpp>
+#include <nbla/function/min_max_quantize.hpp>
+#include <nbla/function/minimum2.hpp>
+#include <nbla/function/mul2.hpp>
+#include <nbla/function/mul_scalar.hpp>
+#include <nbla/function/round.hpp>
+#include <nbla/function/sub2.hpp>
+#include <nbla/function/sum.hpp>
+
+#include <nbla/variable.hpp>
+#include <numeric>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(MinMaxQuantize, float, bool, bool, bool, float);
+
+template <typename T>
+void MinMaxQuantize<T>::setup_impl(const Variables &inputs,
+                                   const Variables &outputs) {
+  // Check shape and dimensions
+  auto x = inputs[0];
+  auto qr_min = inputs[1];
+  auto qr_max = inputs[2];
+  auto ql_min = inputs[3];
+  auto ql_max = inputs[4];
+
+  // dimension check
+  auto ndims = {ql_min->ndim(), ql_max->ndim(), qr_min->ndim(), qr_max->ndim()};
+
+  NBLA_CHECK(std::equal(ndims.begin(), ndims.end() - 1, ndims.begin() + 1),
+             error_code::value, "All input dimensions must be same.",
+             "inputs[0] = %d, inputs[1] = %d, inputs[2] = %d, inputs[3] = %d, "
+             "inputs[4] = %d.",
+             x->ndim(), ql_min->ndim(), ql_max->ndim(), qr_min->ndim(),
+             qr_max->ndim());
+  // shape check
+  auto shapes = {ql_min->shape(), ql_max->shape(), qr_min->shape(),
+                 qr_max->shape()};
+  NBLA_CHECK(std::equal(shapes.begin(), shapes.end() - 1, shapes.begin() + 1),
+             error_code::value, "All shapes among ql_min, ql_max, qr_min, and "
+                                "qr_max must be same.");
+  // non-broadcast dimension check
+  vector<int> none_axes;
+  for (int i = 0; i < ql_min->ndim(); i++) {
+    if (ql_min->shape()[i] != 1)
+      none_axes.push_back(i);
+  }
+  NBLA_CHECK(std::all_of(none_axes.begin(), none_axes.end(),
+                         [x, ql_min](int a) {
+                           return x->shape()[a] == ql_min->shape()[a];
+                         }),
+             error_code::value, "x.shape and ql_min.shape must be same except "
+                                "for i-th dimension where ql_min.shape[i] == "
+                                "1.");
+
+  // Copy and cast reduction axes for Min and Max
+  vector<int> axes;
+  for (int i = 0; i < ql_min->ndim(); i++) {
+    if (ql_min->shape()[i] == 1)
+      axes.push_back(i);
+  }
+  // Compute broadcast shape
+  std::vector<int> bshape(x->shape().size());
+  for (int i = 0; i < x->shape().size(); i++) {
+    bshape[i] = x->shape()[i];
+  }
+  // Create functions needed to compute the min-max quantization
+  identity_ = create_Identity(this->ctx_);
+  round_ = create_Round(this->ctx_);
+  add2_ = create_Add2(this->ctx_, false);
+  sub2_ = create_Sub2(this->ctx_);
+  mul2_ = create_Mul2(this->ctx_);
+  div2_ = create_Div2(this->ctx_);
+  minimum2_ = create_Minimum2(this->ctx_);
+  maximum2_ = create_Maximum2(this->ctx_);
+  mul_scalar_ = create_MulScalar(this->ctx_, (T)(decay_));
+  mul_scalar2_ = create_MulScalar(this->ctx_, (T)(1.0 - decay_));
+  min_ = create_Min(this->ctx_, axes, true, false, false);
+  max_ = create_Max(this->ctx_, axes, true, false, false);
+  broadcast_ = create_Broadcast(this->ctx_, bshape);
+  if (ste_fine_grained_) {
+    // pass gradient among min <= x <= max
+    greater_equal_ = create_GreaterEqual(this->ctx_);
+    less_equal_ = create_LessEqual(this->ctx_);
+  }
+  if (!x_min_max_ && !ema_) {
+    greater_ = create_Greater(this->ctx_);
+    less_ = create_Less(this->ctx_);
+    sum_ = create_Sum(this->ctx_, axes, true);
+  }
+
+  // `setup` method is called in the forward passs for re-using the functions
+  // and intermediate variable
+
+  // Reshape output
+  outputs[0]->reshape(x->shape(), true);
+  scale_sptr_ = make_shared<Variable>(ql_min->shape());
+}
+
+template <typename T>
+void MinMaxQuantize<T>::forward_impl(const Variables &inputs,
+                                     const Variables &outputs) {
+  // Variables
+  auto x = inputs[0];
+  auto qr_min = inputs[1];
+  auto qr_max = inputs[2];
+  auto ql_min = inputs[3];
+  auto ql_max = inputs[4];
+  auto scale = scale_sptr_.get();
+  auto x_q = outputs[0];
+
+  // Intermediate variable to be re-used
+  auto iv_sptr = make_shared<Variable>(x->shape());
+  auto iv = iv_sptr.get();
+
+  /*
+    Step-by-step computation:
+    - if x_min_max is true,
+      - x_min = min(x)
+      - x_max = max(x)
+    - if both x_min_max and ema is true,
+      - ema(qr_min) = decay * qr_min_old + (1.0 - decay) * x_min
+      - ema(qr_max) = decay * qr_max_old + (1.0 - decay) * x_max
+    - scale = {qr_max - qr_min} / {ql_max - ql_min}
+    - x_q = round( { min(max(x, qr_min), qr_max) - qr_min } / {s}) * s + qr_min
+   */
+
+  // min(x) and ema(qr_min) = decay * qr_min_old + (1.0 - decay) * x_min
+  // working with shape of qr_min
+  if (x_min_max_ && ema_) {
+    min_->setup(Variables{x}, Variables{iv});
+    min_->forward(Variables{x}, Variables{iv});
+    mul_scalar2_->setup(Variables{iv}, Variables{iv});
+    mul_scalar2_->forward(Variables{iv}, Variables{iv});
+    mul_scalar_->setup(Variables{qr_min}, Variables{qr_min});
+    mul_scalar_->forward(Variables{qr_min}, Variables{qr_min});
+    add2_->setup(Variables{qr_min, iv}, Variables{qr_min});
+    add2_->forward(Variables{qr_min, iv}, Variables{qr_min});
+  } else if (x_min_max_ && !ema_) {
+    min_->setup(Variables{x}, Variables{qr_min});
+    min_->forward(Variables{x}, Variables{qr_min});
+  }
+
+  // max(x) and ema(qr_max) = decay * qr_max_old + (1.0 - decay) * x_max
+  // working with shape of qr_min
+  if (x_min_max_ && ema_) {
+    max_->setup(Variables{x}, Variables{iv});
+    max_->forward(Variables{x}, Variables{iv});
+    mul_scalar2_->setup(Variables{iv}, Variables{iv});
+    mul_scalar2_->forward(Variables{iv}, Variables{iv});
+    mul_scalar_->setup(Variables{qr_max}, Variables{qr_max});
+    mul_scalar_->forward(Variables{qr_max}, Variables{qr_max});
+    add2_->setup(Variables{qr_max, iv}, Variables{qr_max});
+    add2_->forward(Variables{qr_max, iv}, Variables{qr_max});
+  } else if (x_min_max_ && !ema_) {
+    max_->setup(Variables{x}, Variables{qr_max});
+    max_->forward(Variables{x}, Variables{qr_max});
+  }
+
+  // TODO: optimize by writing down, naitve implementation is faster. Also we
+  // have to write down in extensions.
+
+  // ensure `qr_max - qr_min` of the scale should be greater than epsilon
+  nudge_range(qr_min, qr_max);
+
+  // scale = (qr_max - qr_min) / (ql_max - ql_min)
+  // working with shape of qr_min
+  sub2_->setup(Variables{qr_max, qr_min}, Variables{scale});
+  sub2_->forward(Variables{qr_max, qr_min}, Variables{scale});
+  sub2_->setup(Variables{ql_max, ql_min}, Variables{iv});
+  sub2_->forward(Variables{ql_max, ql_min}, Variables{iv});
+  div2_->setup(Variables{scale, iv}, Variables{scale});
+  div2_->forward(Variables{scale, iv}, Variables{scale});
+
+  // nudge qr_min and qr_max
+  auto qr_min_nudged_sptr = make_shared<Variable>(qr_min->shape());
+  auto qr_min_nudged = qr_min_nudged_sptr.get();
+  auto qr_max_nudged_sptr = make_shared<Variable>(qr_max->shape());
+  auto qr_max_nudged = qr_max_nudged_sptr.get();
+  nudge_qr_min_max(qr_min, qr_max, ql_min, ql_max, scale, qr_min_nudged,
+                   qr_max_nudged);
+
+  // broadcast
+  auto _qr_min_sptr = make_shared<Variable>(x->shape());
+  auto _qr_min = _qr_min_sptr.get();
+  auto _qr_max_sptr = make_shared<Variable>(x->shape());
+  auto _qr_max = _qr_max_sptr.get();
+  auto _scale_sptr = make_shared<Variable>(x->shape());
+  auto _scale = _scale_sptr.get();
+  broadcast_->setup(Variables{qr_min_nudged}, Variables{_qr_min});
+  broadcast_->forward(Variables{qr_min_nudged}, Variables{_qr_min});
+  broadcast_->setup(Variables{qr_max_nudged}, Variables{_qr_max});
+  broadcast_->forward(Variables{qr_max_nudged}, Variables{_qr_max});
+  broadcast_->setup(Variables{scale}, Variables{_scale});
+  broadcast_->forward(Variables{scale}, Variables{_scale});
+
+  // x_q = min(max(x, qr_min), qr_max)
+  // working with shape of x
+  maximum2_->setup(Variables{x, _qr_min}, Variables{x_q});
+  maximum2_->forward(Variables{x, _qr_min}, Variables{x_q});
+  minimum2_->setup(Variables{x_q, _qr_max}, Variables{x_q});
+  minimum2_->forward(Variables{x_q, _qr_max}, Variables{x_q});
+
+  // x_q = round( (x_q - qr_min) / scale ) * scale + qr_min
+  // working with shape of x
+  sub2_->setup(Variables{x_q, _qr_min}, Variables{x_q});
+  sub2_->forward(Variables{x_q, _qr_min}, Variables{x_q});
+  div2_->setup(Variables{x_q, _scale}, Variables{x_q});
+  div2_->forward(Variables{x_q, _scale}, Variables{x_q});
+  round_->setup(Variables{x_q}, Variables{x_q});
+  round_->forward(Variables{x_q}, Variables{x_q});
+  mul2_->setup(Variables{x_q, _scale}, Variables{x_q});
+  mul2_->forward(Variables{x_q, _scale}, Variables{x_q});
+  add2_->setup(Variables{x_q, _qr_min}, Variables{x_q});
+  add2_->forward(Variables{x_q, _qr_min}, Variables{x_q});
+}
+
+template <typename T>
+void MinMaxQuantize<T>::backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum) {
+  // The backward_impl is coupling with the forward_impl
+  NBLA_CHECK(
+      !(propagate_down[3] || propagate_down[4]), error_code::value,
+      "Backward to x(inputs[0]), qr_min(inputs[1]), and/or qr_max(inputs[2])"
+      "are only allowed.");
+  auto x = inputs[0];
+  auto qr_min = inputs[1];
+  auto qr_max = inputs[2];
+  auto ql_min = inputs[3];
+  auto ql_max = inputs[4];
+  auto scale = scale_sptr_.get();
+  auto y = outputs[0];
+
+  // scale is already nudged in forward_impl
+  // nudge qr_min and qr_max
+  auto qr_min_nudged_sptr = make_shared<Variable>(qr_min->shape());
+  auto qr_min_nudged = qr_min_nudged_sptr.get();
+  auto qr_max_nudged_sptr = make_shared<Variable>(qr_max->shape());
+  auto qr_max_nudged = qr_max_nudged_sptr.get();
+  nudge_qr_min_max(qr_min, qr_max, ql_min, ql_max, scale, qr_min_nudged,
+                   qr_max_nudged);
+
+  // broadcast first
+  auto _qr_min_sptr = make_shared<Variable>(x->shape());
+  auto _qr_min = _qr_min_sptr.get();
+  auto _qr_max_sptr = make_shared<Variable>(x->shape());
+  auto _qr_max = _qr_max_sptr.get();
+  if (ste_fine_grained_ || !x_min_max_) {
+    broadcast_->setup(Variables{qr_min_nudged}, Variables{_qr_min});
+    broadcast_->forward(Variables{qr_min_nudged}, Variables{_qr_min});
+    broadcast_->setup(Variables{qr_max_nudged}, Variables{_qr_max});
+    broadcast_->forward(Variables{qr_max_nudged}, Variables{_qr_max});
+  }
+
+  // w.r.t. x
+  if (propagate_down[0]) {
+    auto g_x_sptr = make_shared<Variable>(x->shape());
+    auto g_y_sptr = make_shared<Variable>(y->shape());
+    g_x_sptr->set_data(x->grad());
+    g_y_sptr->set_data(y->grad());
+    auto g_x = g_x_sptr.get();
+    auto g_y = g_y_sptr.get();
+    if (ste_fine_grained_) {
+      // mask
+      auto iv0_sptr = make_shared<Variable>(x->shape());
+      auto iv0 = iv0_sptr.get();
+      auto iv1_sptr = make_shared<Variable>(x->shape());
+      auto iv1 = iv1_sptr.get();
+      greater_equal_->setup(Variables{x, _qr_min}, Variables{iv0});
+      greater_equal_->forward(Variables{x, _qr_min}, Variables{iv0});
+      less_equal_->setup(Variables{x, _qr_max}, Variables{iv1});
+      less_equal_->forward(Variables{x, _qr_max}, Variables{iv1});
+      auto mask_sptr = make_shared<Variable>(x->shape());
+      auto mask = mask_sptr.get();
+      mul2_->setup(Variables{iv0, iv1}, Variables{mask});
+      mul2_->forward(Variables{iv0, iv1}, Variables{mask});
+      // mul mask
+      mul2_->setup(Variables{mask, g_y}, Variables{mask});
+      mul2_->forward(Variables{mask, g_y}, Variables{mask});
+      if (accum[0]) {
+        add2_->setup(Variables{mask, g_x}, Variables{g_x});
+        add2_->forward(Variables{mask, g_x}, Variables{g_x});
+      } else {
+        identity_->setup(Variables{mask}, Variables{g_x});
+        identity_->forward(Variables{mask}, Variables{g_x});
+      }
+    } else {
+      if (accum[0]) {
+        add2_->setup(Variables{g_y, g_x}, Variables{g_x});
+        add2_->forward(Variables{g_y, g_x}, Variables{g_x});
+      } else {
+        identity_->setup(Variables{g_y}, Variables{g_x});
+        identity_->forward(Variables{g_y}, Variables{g_x});
+      }
+    }
+  }
+
+  if (x_min_max_ || ema_)
+    return;
+
+  auto iv_sptr0 = make_shared<Variable>(x->shape());
+  auto iv0 = iv_sptr0.get();
+  auto iv_sptr1 = make_shared<Variable>(qr_min->shape());
+  auto iv1 = iv_sptr1.get();
+  // w.r.t. qr_min
+  if (propagate_down[1]) {
+    // Compute sum(mask * g_y)
+    // mask
+    auto mask_sptr = make_shared<Variable>(x->shape());
+    auto mask = mask_sptr.get();
+    less_->setup(Variables{x, _qr_min}, Variables{mask});
+    less_->forward(Variables{x, _qr_min}, Variables{mask});
+    auto g_y_sptr = make_shared<Variable>(y->shape());
+    auto g_y = g_y_sptr.get();
+    g_y_sptr->set_data(y->grad());
+    // mul mask
+    mul2_->setup(Variables{mask, g_y}, Variables{iv0});
+    mul2_->forward(Variables{mask, g_y}, Variables{iv0});
+    // reduce
+    sum_->setup(Variables{iv0}, Variables{iv1});
+    sum_->forward(Variables{iv0}, Variables{iv1});
+    auto g_qr_min_sptr = make_shared<Variable>(qr_min->shape());
+    auto g_qr_min = g_qr_min_sptr.get();
+    g_qr_min_sptr->set_data(qr_min->grad());
+    if (accum[1]) {
+      add2_->setup(Variables{g_qr_min, iv1}, Variables{g_qr_min});
+      add2_->forward(Variables{g_qr_min, iv1}, Variables{g_qr_min});
+    } else {
+      identity_->setup(Variables{iv1}, Variables{g_qr_min});
+      identity_->forward(Variables{iv1}, Variables{g_qr_min});
+    }
+  }
+  // w.r.t. qr_max
+  if (propagate_down[2]) {
+    // Compute sum(mask * g_y)
+    // mask
+    auto mask_sptr = make_shared<Variable>(x->shape());
+    auto mask = mask_sptr.get();
+    greater_->setup(Variables{x, _qr_max}, Variables{mask});
+    greater_->forward(Variables{x, _qr_max}, Variables{mask});
+    auto g_y_sptr = make_shared<Variable>(y->shape());
+    auto g_y = g_y_sptr.get();
+    g_y_sptr->set_data(y->grad());
+    // mul mask
+    mul2_->setup(Variables{mask, g_y}, Variables{iv0});
+    mul2_->forward(Variables{mask, g_y}, Variables{iv0});
+    // reduce
+    sum_->setup(Variables{iv0}, Variables{iv1});
+    sum_->forward(Variables{iv0}, Variables{iv1});
+    auto g_qr_max_sptr = make_shared<Variable>(qr_max->shape());
+    auto g_qr_max = g_qr_max_sptr.get();
+    g_qr_max_sptr->set_data(qr_max->grad());
+    if (accum[2]) {
+      add2_->setup(Variables{g_qr_max, iv1}, Variables{g_qr_max});
+      add2_->forward(Variables{g_qr_max, iv1}, Variables{g_qr_max});
+    } else {
+      identity_->setup(Variables{iv1}, Variables{g_qr_max});
+      identity_->forward(Variables{iv1}, Variables{g_qr_max});
+    }
+  }
+}
+
+template <typename T>
+void MinMaxQuantize<T>::nudge_range(Variable *qr_min, Variable *qr_max) {
+  const T *qr_min_data = qr_min->get_data_pointer<T>(ctx_);
+  T *qr_max_data = qr_max->cast_data_and_get_pointer<T>(ctx_);
+  for (int i = 0; i < qr_min->size(); ++i) {
+    if (qr_max_data[i] - qr_min_data[i] < this->eps_) {
+      qr_max_data[i] = qr_min_data[i] + this->eps_;
+    }
+  }
+}
+template <typename T>
+void MinMaxQuantize<T>::nudge_qr_min_max(Variable *qr_min, Variable *qr_max,
+                                         Variable *ql_min, Variable *ql_max,
+                                         Variable *scale,
+                                         Variable *qr_min_nudged,
+                                         Variable *qr_max_nudged) {
+  auto qr_min_data = qr_min->get_data_pointer<T>(ctx_);
+  auto qr_max_data = qr_max->get_data_pointer<T>(ctx_);
+  auto ql_min_data = ql_min->get_data_pointer<T>(ctx_);
+  auto ql_max_data = ql_max->get_data_pointer<T>(ctx_);
+  auto scale_data = scale->get_data_pointer<T>(ctx_);
+  auto qr_min_nudged_data = qr_min_nudged->cast_data_and_get_pointer<T>(ctx_);
+  auto qr_max_nudged_data = qr_max_nudged->cast_data_and_get_pointer<T>(ctx_);
+
+  T zero_point_nudged = T(0);
+  for (int i = 0; i < qr_min->size(); ++i) {
+    auto zero_point_from_min = ql_min_data[i] - qr_min_data[i] / scale_data[i];
+    if (zero_point_from_min <= ql_min_data[i]) {
+      zero_point_nudged = ql_min_data[i];
+    } else if (zero_point_from_min >= ql_max_data[i]) {
+      zero_point_nudged = ql_max_data[i];
+    } else {
+      zero_point_nudged = std::round(zero_point_from_min);
+    }
+    qr_min_nudged_data[i] =
+        (ql_min_data[i] - zero_point_nudged) * scale_data[i];
+    qr_max_nudged_data[i] =
+        (ql_max_data[i] - zero_point_nudged) * scale_data[i];
+  }
+}
+}


### PR DESCRIPTION
The following four functions are added.

1. nnabla.functions.min_max_quantize
2. nnabla.parametric_functions.min_max_quantize
3. nnabla.parametric_functions.min_max_quantized_affine
4. nnabla.parametric_functions.min_max_quantized_convolution

1 is implemented by the composite functions in C++-layer
2 is the wrapper function like the `F.fixed_point_quantize`
3 and 4 are the parametric versions like `F.fixed_point_quantized_affine` and `F.fixed_point_quantized_convolution`