### PR TITLE
Fix min-max-quantize

### DIFF
--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -2997,18 +2997,20 @@ def min_max_quantize(x, ql_min=0, ql_max=255, decay=0.999, x_min_max=False, ema=
         Benoit Jacob, Skirmantas Kligys, Bo Chen, Menglong Zhu, Matthew Tang, Andrew Howard, Hartwig Adam, and Dmitry Kalenichenko, "Quantization and Training of Neural Networks for Efficient Integer-Arithmetic-Only Inference", https://arxiv.org/abs/1712.05877
 
     """
-    def force_to_variable(qv):
-        if isinstance(qv, (int, float)):
-            reshape = [1 for _ in range(x.ndim)]
-            qv = nn.Variable.from_numpy_array(
-                np.array(qv).reshape(reshape)).apply(persistent=True)
-        return qv
-    ql_min = force_to_variable(ql_min)
-    ql_max = force_to_variable(ql_max)
-
+    # ql_min and ql_max
+    if isinstance(ql_min, (int, float)):
+        reshape = [1 for _ in range(x.ndim)]
+        ql_min = np.array(ql_min).reshape(reshape)
+        ql_min = get_parameter_or_create(
+            "ql_min", reshape, ql_min, False, False)
+    if isinstance(ql_max, (int, float)):
+        reshape = [1 for _ in range(x.ndim)]
+        ql_max = np.array(ql_max).reshape(reshape)
+        ql_max = get_parameter_or_create(
+            "ql_max", reshape, ql_max, False, False)
+    # qr_min and qr_max
     qr_min_init = qr_min_init if qr_min_init else ConstantInitializer(-6.0)
     qr_max_init = qr_max_init if qr_max_init else ConstantInitializer(6.0)
-
     shape = ql_min.shape
     qr_min = get_parameter_or_create(
         "qr_min", shape, qr_min_init, not (x_min_max and ema), not fix_parameters)

--- a/python/test/test_parametric_functions.py
+++ b/python/test/test_parametric_functions.py
@@ -1114,10 +1114,12 @@ def test_pf_min_max_quantize_execution(g_rng, inshape, q_min, q_max, decay, x_mi
     assert args['ema'] == ema
 
     # Check created parameters
-    assert len(nn.get_parameters(grad_only=False)) == 2
+    assert len(nn.get_parameters(grad_only=False)) == 4
     ema_min = nn.get_parameters(grad_only=False)['min_max_quantize/qr_min']
     ema_max = nn.get_parameters(grad_only=False)['min_max_quantize/qr_max']
-    assert ema_min.shape == ema_max.shape
+    ql_min = nn.get_parameters(grad_only=False)['min_max_quantize/ql_min']
+    ql_max = nn.get_parameters(grad_only=False)['min_max_quantize/ql_max']
+    assert ema_min.shape == ema_max.shape and ema_max.shape == ql_min.shape and ql_min.shape == ql_max.shape
 
 
 @pytest.mark.parametrize("inshape", [(8, 2, 2, 2), (16, 1, 8)])
@@ -1206,16 +1208,20 @@ def test_pf_min_max_quantized_affine_execution(g_rng, inshape, n_outmaps, base_a
         if isinstance(b_init, np.ndarray):
             assert np.allclose(b_init, b.d)
     # quantization-related parameters
-    assert len(nn.get_parameters(grad_only=False)) == 4 + int(with_bias) * 4
+    assert len(nn.get_parameters(grad_only=False)) == 6 + int(with_bias) * 6
     for k in nn.get_parameters(grad_only=False).keys():
         assert k in ['min_max_quantized_affine/W',
                      'min_max_quantized_affine/W_q',
                      'min_max_quantized_affine/min_max_quantize_w/min_max_quantize/qr_min',
                      'min_max_quantized_affine/min_max_quantize_w/min_max_quantize/qr_max',
+                     'min_max_quantized_affine/min_max_quantize_w/min_max_quantize/ql_min',
+                     'min_max_quantized_affine/min_max_quantize_w/min_max_quantize/ql_max',
                      'min_max_quantized_affine/b',
                      'min_max_quantized_affine/b_q',
                      'min_max_quantized_affine/min_max_quantize_b/min_max_quantize/qr_min',
-                     'min_max_quantized_affine/min_max_quantize_b/min_max_quantize/qr_max']
+                     'min_max_quantized_affine/min_max_quantize_b/min_max_quantize/qr_max',
+                     'min_max_quantized_affine/min_max_quantize_b/min_max_quantize/ql_min',
+                     'min_max_quantized_affine/min_max_quantize_b/min_max_quantize/ql_max']
 
 
 @pytest.mark.parametrize("inshape, outmaps, kernel, pad, stride, dilation, group, base_axis", [
@@ -1314,15 +1320,19 @@ def test_pf_min_max_quantized_convolution_execution(g_rng, inshape, outmaps,
         if isinstance(b_init, np.ndarray):
             assert np.allclose(b_init, b.d)
     # quantization-related parameters
-    assert len(nn.get_parameters(grad_only=False)) == 4 + int(with_bias) * 4
+    assert len(nn.get_parameters(grad_only=False)) == 6 + int(with_bias) * 6
     for k in nn.get_parameters(grad_only=False).keys():
         assert k in ['min_max_quantized_conv/W',
                      'min_max_quantized_conv/W_q',
                      'min_max_quantized_conv/min_max_quantize_w/min_max_quantize/qr_min',
                      'min_max_quantized_conv/min_max_quantize_w/min_max_quantize/qr_max',
+                     'min_max_quantized_conv/min_max_quantize_w/min_max_quantize/ql_min',
+                     'min_max_quantized_conv/min_max_quantize_w/min_max_quantize/ql_max',
                      'min_max_quantized_conv/b',
                      'min_max_quantized_conv/b_q',
                      'min_max_quantized_conv/min_max_quantize_b/min_max_quantize/qr_min',
-                     'min_max_quantized_conv/min_max_quantize_b/min_max_quantize/qr_max']
+                     'min_max_quantized_conv/min_max_quantize_b/min_max_quantize/qr_max',
+                     'min_max_quantized_conv/min_max_quantize_b/min_max_quantize/ql_min',
+                     'min_max_quantized_conv/min_max_quantize_b/min_max_quantize/ql_max']
 
 # TODO: Test all parametric functions.


### PR DESCRIPTION
Now, ql_min and ql_max are registered as parameters when saving as NNP, which prevents from treating the first axis as the batch dimension.
