### PR TITLE
Exit with 0 when no tests in pytest

### DIFF
--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -169,4 +169,4 @@ nnabla-test-local: nnabla-install
 	@cd $(BUILD_DIRECTORY_WHEEL) \
 	&& PATH=$(PYTEST_PATH_EXTRA):$(PATH) \
 	LD_LIBRARY_PATH=$(PYTEST_LD_LIBRARY_PATH_EXTRA):$(LD_LIBRARY_PATH) \
-	python -m pytest $(NNABLA_DIRECTORY)/python/test
+	$(NNABLA_DIRECTORY)/build-tools/make/pytest.sh $(NNABLA_DIRECTORY)/python/test

--- a/build-tools/make/pytest.sh
+++ b/build-tools/make/pytest.sh
@@ -1,0 +1,4 @@
+#! /bin/sh
+
+python -m pytest $@ \
+    || ( ret=$?; [ $ret -eq 5 ] && (echo "No test is executed." ; exit 0) || exit $ret )


### PR DESCRIPTION
When we specify a filter option to `-k` to pytest, and no test is performed, PyTest exits with a code 5. This is problematic when we execute multiple pytests in our test scripts. For example, if the first pytest fails due to a filter option, the second test is not performed. This PR wraps pytest command with a shell script which modifies an exit code 5 to 0 to avoid this issue.