### PR TITLE
Use dtype of RHS in NdArray.data setter

### DIFF
--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -421,6 +421,8 @@ cdef class Variable:
         modification of the returned ndarray will affect the data of the
         NNabla array.
         This method can be called as a setter to set the value held by this variable.
+        Refer to the documentation of the setter `nnabla._nd_array.NdArray.data`
+        for detailed behvaiors of the setter.
 
         Args:
             value(:obj:`numpy.ndarray`) (optional)
@@ -442,6 +444,8 @@ cdef class Variable:
         modification of the returned ndarray will affect the data of the
         NNabla array.
         This method can be called as a setter to set the gradient held by this variable.        
+        Refer to the documentation of the setter `nnabla._nd_array.NdArray.data`
+        for detailed behvaiors of the setter.
 
         Args:
             value(:obj:`numpy.ndarray`)

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -432,7 +432,7 @@ cdef class Variable:
 
     @d.setter
     def d(self, value):
-        self.data.data[...] = value
+        self.data.data = value
 
     @property
     def g(self):
@@ -453,7 +453,7 @@ cdef class Variable:
 
     @g.setter
     def g(self, value):
-        self.grad.data[...] = value
+        self.grad.data = value
 
     @property
     def parent(self):

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -74,7 +74,7 @@ cdef vector[NdArrayPtr] list_to_vector_nd_array_force(varlist):
         vec[i] = (<NdArray> v).arr
     return vec
 
-cdef vector[NdArrayPtr] list_to_vector_nd_array(varlist):
+cdef vector[NdArrayPtr] list_to_vector_nd_array(varlist) except *:
     cdef vector[NdArrayPtr] vec
     cdef int i
     cdef int size
@@ -84,7 +84,7 @@ cdef vector[NdArrayPtr] list_to_vector_nd_array(varlist):
         vec[i] = (<NdArray?> varlist[i]).arr
     return vec
 
-cdef vector[CgVariablePtr] list_to_vector_cg_variable(varlist):
+cdef vector[CgVariablePtr] list_to_vector_cg_variable(varlist) except *:
     cdef vector[CgVariablePtr] vec
     cdef int i
     cdef int size
@@ -94,7 +94,7 @@ cdef vector[CgVariablePtr] list_to_vector_cg_variable(varlist):
         vec[i] = (<_Variable?> varlist[i]).var
     return vec
 
-cdef vector[CVariable*] list_to_vector_variable_p(varlist):
+cdef vector[CVariable*] list_to_vector_variable_p(varlist) except *:
     cdef vector[CVariable*] vec
     cdef int i
     cdef int size
@@ -104,7 +104,7 @@ cdef vector[CVariable*] list_to_vector_variable_p(varlist):
         vec[i] = (<_Variable?> varlist[i]).varp.variable().get()
     return vec
 
-cdef vector[cpp_bool] variables_to_prop_down_flags(varlist):
+cdef vector[cpp_bool] variables_to_prop_down_flags(varlist) except *:
     cdef int i
     cdef int size = len(varlist)
     cdef vector[cpp_bool] ret

--- a/python/src/nnabla/logger.py
+++ b/python/src/nnabla/logger.py
@@ -23,6 +23,7 @@ You can use the logger as follows:
 
     logger.debug('Log message(DEBUG)')
     logger.info('Log message(INFO)')
+    logger.warn('Log message(WARNING)')
     logger.error('Log message(ERROR)')
     logger.critical('Log message(CRITICAL)')
 

--- a/python/src/nnabla/parametric_functions.py
+++ b/python/src/nnabla/parametric_functions.py
@@ -3161,7 +3161,7 @@ def min_max_quantized_affine(inp, n_outmaps,
                                         ste_fine_grained=ste_fine_grained_b,
                                         eps=eps,
                                         fix_parameters=fix_parameters,
-                                        outputs=[b_q],
+                                        outputs=[b_q.data],
                                         name="min_max_quantize_b")
             real_b_q.persistent = True
         else:

--- a/python/test/communicator/test_all_reduce.py
+++ b/python/test/communicator/test_all_reduce.py
@@ -114,7 +114,7 @@ def test_all_reduce_skip_by_zero(seed, inplace, division, comm_nccl_opts):
     # modify the grad values in rank 0
     if comm.rank == 0:
         for g in get_grads(xs):
-            g.data = 0
+            g.data = 1
     comm.all_reduce(get_grads(xs), division=division, inplace=inplace)
     for g in get_grads(xs):
         assert not g.zeroing

--- a/python/test/function/test_clip_by_value.py
+++ b/python/test/function/test_clip_by_value.py
@@ -41,6 +41,4 @@ def test_clip_by_value_forward(seed, shape):
     with nn.auto_forward(True):
         y = F.clip_by_value(x, min_, max_)
     y_ref = ref_clip_by_value(x_data, min_data, max_data)
-    print(y.d)
-    print(y_ref)
     assert_allclose(y.d, y_ref)

--- a/python/test/function/test_max_pooling.py
+++ b/python/test/function/test_max_pooling.py
@@ -44,7 +44,6 @@ def ref_max_pooling_3d(x, kernel, stride, ignore_border, pad):
     y = np.vstack(y)
     if x.ndim == 3:
         y = np.squeeze(y, 1)
-    print(y.reshape(x.shape[:-4] + y.shape[1:]).shape)
     return y.reshape(x.shape[:-4] + y.shape[1:])
 
 

--- a/python/test/function/test_random_choice.py
+++ b/python/test/function/test_random_choice.py
@@ -34,12 +34,13 @@ def test_random_choice_with_replacement(ctx, func_name, seed):
         y = F.random_choice(x, w, shape=[trials], replace=True, seed=seed)
     hist_nn, _ = np.histogram(y.d)
     hist_np, _ = np.histogram(np.random.choice(
-        x.d, trials, True, w.d / w.d.sum()))
+        x.d, trials, True, w.d / np.float32(w.d.sum())))
     assert_allclose(hist_nn / trials, hist_np / trials, atol=1e-2)
-    x.g = w.g = 0
+    x.grad.zero()
+    w.grad.zero()
     y.backward()
-    assert_allclose(x.g / trials, w.d / w.d.sum(), atol=1e-2)
-    assert_allclose(w.g / trials, w.d / w.d.sum(), atol=1e-2)
+    assert_allclose(x.g / trials, w.d / np.float32(w.d.sum()), atol=1e-2)
+    assert_allclose(w.g / trials, w.d / np.float32(w.d.sum()), atol=1e-2)
 
     x = nn.Variable.from_numpy_array(np.array([[1, 2, 3], [-1, -2, -3]]))
     w = nn.Variable.from_numpy_array(np.array([[1, 1, 1], [10, 10, 10]]))
@@ -53,7 +54,8 @@ def test_random_choice_with_replacement(ctx, func_name, seed):
     w.d = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
     with nn.context_scope(ctx), nn.auto_forward(True):
         y = F.random_choice(x, w, shape=[10], replace=True, seed=seed)
-    x.g = w.g = 0
+    x.grad.zero()
+    w.grad.zero()
     y.backward(1)
     assert np.all(x.g == np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
     assert np.all(w.g == np.array([[10, 0, 0], [0, 10, 0], [0, 0, 10]]))
@@ -72,5 +74,5 @@ def test_random_choice_without_replacement(ctx, func_name, seed):
     r = np.zeros((repeats, w.size)).astype(np.int32)
     for i in range(repeats):
         y.forward()
-        r[i] = y.d
+        r[i] = y.d.copy()
     assert np.all(np.bincount(r.flatten()) == x.size * [repeats])

--- a/python/test/test_nd_array.py
+++ b/python/test/test_nd_array.py
@@ -16,6 +16,8 @@ import numpy as np
 
 import nnabla as nn
 
+import pytest
+
 
 def test_nd_array():
     shape = [2, 3, 4]
@@ -51,3 +53,25 @@ def test_copy_from():
     with nn.context_scope(get_extension_context('cpu', dtype='float')):
         dst.copy_from(src, use_current_context=True)
     assert dst.dtype == np.float32
+
+
+@pytest.mark.parametrize("value", [
+    1,
+    1.3,
+    np.array(np.zeros((2, 3))),
+    np.arange(6).reshape(2, 3)])
+def test_nd_array_data(value):
+    shape = (2, 3)
+
+    # Use default dtype (float32) in getter
+    a = nn.NdArray(shape)
+    with pytest.raises(Exception):
+        _ = a.dtype
+    _ = a.data
+    assert a.dtype == np.float32
+
+    # Use value dtype in setter
+    a = nn.NdArray(shape)
+    a.data = value
+    assert a.dtype == np.asarray(value).dtype
+    assert a.data.dtype == np.asarray(value).dtype

--- a/python/test/test_nd_array.py
+++ b/python/test/test_nd_array.py
@@ -73,5 +73,9 @@ def test_nd_array_data(value):
     # Use value dtype in setter
     a = nn.NdArray(shape)
     a.data = value
-    assert a.dtype == np.asarray(value).dtype
-    assert a.data.dtype == np.asarray(value).dtype
+    if not np.isscalar(value) or \
+       (np.dtype(type(value)).kind != 'f' and value > (1 << 53)):
+        assert a.dtype == np.asarray(value).dtype
+        assert a.data.dtype == np.asarray(value).dtype
+    else:
+        assert a.data.dtype == np.float32

--- a/python/test/test_save_load_parameters.py
+++ b/python/test/test_save_load_parameters.py
@@ -50,5 +50,7 @@ def test_save_load_parameters():
         for (n1, p1), (n2, p2) in zip(sorted(param1.items()), sorted(par2.items())):
             assert n1 == n2
             assert np.all(p1.d == p2.d)
-            assert p1.data.dtype == p2.data.dtype
+            if par2 is not param3:
+                # NOTE: data is automatically casted to fp32 in Protobuf
+                assert p1.data.dtype == p2.data.dtype
             assert p1.need_grad == p2.need_grad


### PR DESCRIPTION
Previously, there was an issue that an array with any dtype is automatically converted to fp32 at the first call of `.data` property in an instance of `NdArray`.

```python
a = np.arange(10)  # int64
b = NdArray(a.shape)
b.data = a  # b.dtype becomes float32 
```
By this change, the setter uses a dtype of RHS as following.
```python
b.data = a # b.dtype becomes int64
```

There is an exception where `zero()` or `fill(rhs)` is invoked if a scalar with a float or an integer <= 2^53 (as value to be filled is maintained as float64) is given.

Additionally, resolved the following;
* Remove unnecessary prints in testing
* Properly raises an exception in function call, and fix min-max quantize affine