### PR TITLE
Improve the speed of transpose function

### DIFF
--- a/include/nbla/function/transpose.hpp
+++ b/include/nbla/function/transpose.hpp
@@ -45,10 +45,8 @@ template <typename T>
 class Transpose : public BaseFunction<const vector<int> &> {
 protected:
   vector<int> axes_;
-  Variable v_axes_;
-  Variable v_x_strides_;
-  Variable v_y_strides_;
-  Variable v_y_shape_;
+  Shape_t x_shape_, x_strides_, x_strides_transposed_;
+  Shape_t y_shape_, y_strides_, y_strides_transposed_;
 
 public:
   Transpose(const Context &ctx, const vector<int> &axes)

--- a/python/test/function/test_transpose.py
+++ b/python/test/function/test_transpose.py
@@ -26,11 +26,17 @@ def ref_transpose(x, axes):
 
 @pytest.mark.parametrize("ctx, func_name", ctxs)
 @pytest.mark.parametrize("seed", [313])
-@pytest.mark.parametrize("inshape, axes",
-                         [((11, 13, 7), (2, 1, 0)),
-                          ((3, 7, 4, 5), (3, 0, 1, 2)),
-                          ((4, 2, 5, 2, 3), (3, 0, 1, 2, 4)),
-                          ((4, 2, 3, 2, 3, 3), (5, 3, 0, 1, 2, 4))])
+@pytest.mark.parametrize("inshape, axes", [
+    ((10,), (0,)),
+    ((10, 11), (0, 1)),
+    ((10, 11), (1, 0)),
+    ((11, 13, 7), (0, 2, 1)),
+    ((11, 13, 7), (2, 1, 0)),
+    ((3, 7, 4, 5), (3, 0, 1, 2)),
+    ((4, 2, 5, 2, 3), (3, 0, 1, 2, 4)),
+    ((4, 2, 3, 2, 3, 3), (5, 3, 0, 1, 2, 4)),
+    ((4, 4, 4, 4, 4), (4, 3, 2, 1, 0)),
+])
 def test_transpose_forward_backward(seed, inshape, axes, ctx, func_name):
     from nbla_test_utils import function_tester
     rng = np.random.RandomState(seed)
@@ -42,11 +48,13 @@ def test_transpose_forward_backward(seed, inshape, axes, ctx, func_name):
 
 @pytest.mark.parametrize("ctx, func_name", ctxs)
 @pytest.mark.parametrize("seed", [313])
-@pytest.mark.parametrize("inshape, axes",
-                         [((11, 13, 7), (2, 1, 0)),
-                          ((3, 7, 4, 5), (3, 0, 1, 2)),
-                          ((4, 2, 5, 2, 3), (3, 0, 1, 2, 4)),
-                          ((4, 2, 3, 2, 3, 3), (5, 3, 0, 1, 2, 4))])
+@pytest.mark.parametrize("inshape, axes", [
+    ((11, 13, 7), (2, 1, 0)),
+    ((3, 7, 4, 5), (3, 0, 1, 2)),
+    ((4, 2, 5, 2, 3), (3, 0, 1, 2, 4)),
+    ((4, 2, 3, 2, 3, 3), (5, 3, 0, 1, 2, 4)),
+    ((4, 4, 4, 4, 4), (4, 3, 2, 1, 0)),
+])
 def test_transpose_double_backward(seed, inshape, axes, ctx, func_name):
     from nbla_test_utils import backward_function_tester
     rng = np.random.RandomState(seed)


### PR DESCRIPTION
This PR improves the speed of the transpose function by using an ND index increment function to avoid division and modulo operations while iterating. It also reduces the in/out shape and transpose axes internally to combine no-transposed successive axes.