### PR TITLE
Fix bug in graph engine for shared variable

### DIFF
--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -226,9 +226,12 @@ class Grad(object):
                 if inp not in wrt_inputs or inp.need_grad == False:
                     continue
                 idx = wrt_inputs.index(inp)
-                grads[idx] = grad_out
+                if grads[idx] is None:
+                    grads[idx] = grad_out
+                else:
+                    grads[idx] += grad_out  # accum at leaf
                 if bind_grad_output:
-                    inp.grad = grad_out.data
+                    inp.grad = grads[idx].data
 
             # Propagate down
             for inp in f.inputs:

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -40,10 +40,12 @@ def SmallResNet(x, test=False, shared=False):
     h = conv(h, maps=4, name="conv1")
     h = F.max_pooling(h, (2, 2))
     h = conv(h, maps=4, name="conv2")
-    h = conv(h, maps=8, name="conv3") if not shared else conv(h, maps=4, name="conv2")
+    h = conv(h, maps=8, name="conv3") if not shared else conv(
+        h, maps=4, name="conv2")
     h = F.average_pooling(h, h.shape[2:])
     h = PF.affine(h, 10)
     return h
+
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
@@ -89,8 +91,6 @@ def test_resnet_expansion(seed, ctx, auto_forward, flag_grad_outputs, shared):
         assert_allclose(
             inp.g, grad.d, atol=1e-6)
 
-    # Clean up
-    nn.set_auto_forward(False)
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
@@ -137,8 +137,6 @@ def test_multiple_objectives(seed, ctx, auto_forward):
         assert_allclose(
             inp.g, grad.d, atol=1e-6)
 
-    # Clean up
-    nn.set_auto_forward(False)
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
@@ -187,9 +185,6 @@ def test_grad_outputs(seed, ctx, auto_forward, type_grad_outputs):
         assert_allclose(
             inp.g, grad.d, atol=1e-6)
 
-    # Clean up
-    nn.set_auto_forward(False)
-
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
@@ -202,6 +197,7 @@ def test_shared_leaf_variable_basic_arithmetics(seed, ctx, auto_forward):
             return 3 * np.ones_like(x)
         if derivate == 2:
             return np.zeros_like(x)
+
     def sub(x, derivate=0):
         if derivate == 0:
             return x - x - x
@@ -209,6 +205,7 @@ def test_shared_leaf_variable_basic_arithmetics(seed, ctx, auto_forward):
             return -1 * np.ones_like(x)
         if derivate == 2:
             return np.zeros_like(x)
+
     def mul(x, derivate=0):
         if derivate == 0:
             return x * x * x
@@ -216,6 +213,7 @@ def test_shared_leaf_variable_basic_arithmetics(seed, ctx, auto_forward):
             return 3 * x ** 2
         if derivate == 2:
             return 6 * x
+
     def div(x, derivate=0):
         if derivate == 0:
             return x / x / x
@@ -241,6 +239,3 @@ def test_shared_leaf_variable_basic_arithmetics(seed, ctx, auto_forward):
         # Second-order gradient
         dy_dx[0].backward()
         assert_allclose(x.g, math_type(xd, 2))
-        
-    # Clean up
-    nn.set_auto_forward(False)

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -88,6 +88,8 @@ def test_resnet_expansion(seed, ctx, auto_forward, flag_grad_outputs):
         assert_allclose(
             inp.g, grad.d, atol=1e-6)
 
+    # Clean up
+    nn.set_auto_forward(False)
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
@@ -134,6 +136,8 @@ def test_multiple_objectives(seed, ctx, auto_forward):
         assert_allclose(
             inp.g, grad.d, atol=1e-6)
 
+    # Clean up
+    nn.set_auto_forward(False)
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
@@ -181,3 +185,7 @@ def test_grad_outputs(seed, ctx, auto_forward, type_grad_outputs):
     for inp, grad in zip(inputs, grads):
         assert_allclose(
             inp.g, grad.d, atol=1e-6)
+
+    # Clean up
+    nn.set_auto_forward(False)
+

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -68,7 +68,7 @@ def test_resnet_expansion(seed, ctx, auto_forward, flag_grad_outputs, shared):
 
     # Zerograd, Forward, Backward on the forward graph
     inputs = nn.get_parameters().values()
-    [inp.grad.fill(0) for inp in inputs]
+    [inp.grad.zero() for inp in inputs]
     grad = nn.NdArray.from_numpy_array(
         np.asarray(rng.randn())) if flag_grad_outputs else 1
     if not auto_forward:
@@ -119,7 +119,7 @@ def test_multiple_objectives(seed, ctx, auto_forward):
     z = y0 * nn.Variable(g0.shape).apply(data=g0) + y1 * \
         nn.Variable(g1.shape).apply(data=g1)
     inputs = [x0, x1]
-    [inp.grad.fill(0) for inp in inputs]
+    [inp.grad.zero() for inp in inputs]
     if not auto_forward:
         z.forward()
     z.backward()
@@ -169,7 +169,7 @@ def test_grad_outputs(seed, ctx, auto_forward, type_grad_outputs):
 
     # Zerograd, Forward, Backward on the forward graph
     inputs = [x]
-    [inp.grad.fill(0) for inp in inputs]
+    [inp.grad.zero() for inp in inputs]
     if not auto_forward:
         y.forward()
     y.backward(g)
@@ -231,7 +231,7 @@ def test_shared_leaf_variable_basic_arithmetics(seed, ctx, auto_forward):
     for math_type in [add, sub, mul, div]:
         xd = np.random.randn(2, 3) + 0.5
         x = nn.Variable.from_numpy_array(xd).apply(need_grad=True)
-        x.grad.fill(0)
+        x.grad.zero()
         y = math_type(x)
         # First-order gradient
         dy_dx = nn.grad([y], [x])

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -79,18 +79,18 @@ def test_graph_model(model, seed):
             z3 = PF.affine(z2, 5)
     elif model == "recurrent":
         with nn.parameter_scope('fc1'):
-            z = PF.affine(x, 4)
+            z = PF.affine(x, 8)
             z2 = F.relu(z, inplace=True)
         h = z2
         for _ in range(2):
             with nn.parameter_scope('fc2'):
-                h = PF.affine(h, 4)
+                h = PF.affine(h, 8)
                 h = F.relu(h, inplace=True)
         with nn.parameter_scope('fc3'):
             z3 = PF.affine(h, 5)
     elif model == "convolution":
         with nn.parameter_scope('conv1'):
-            z = PF.convolution(x, 16, (2, 2))
+            z = PF.convolution(x, 3, (2, 2))
             z2 = F.relu(z, inplace=True)
         with nn.parameter_scope('fc2'):
             z3 = PF.affine(z2, 5)
@@ -294,6 +294,7 @@ def test_function_hook():
     # Just calling test
     nn.forward_all((y, z), function_pre_hook=lambda f: None,
                    function_post_hook=lambda f: None)
+
 
 @pytest.mark.parametrize("seed", [313])
 def test_shared_variable_on_same_function(seed):

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -294,3 +294,14 @@ def test_function_hook():
     # Just calling test
     nn.forward_all((y, z), function_pre_hook=lambda f: None,
                    function_post_hook=lambda f: None)
+
+@pytest.mark.parametrize("seed", [313])
+def test_shared_variable_on_same_function(seed):
+    rng = np.random.RandomState(313)
+    xd = rng.randn(2, 3)
+    x = nn.Variable.from_numpy_array(xd).apply(need_grad=True)
+    x.grad.zero()
+    y = x * x * x
+    y.forward()
+    y.backward()
+    assert_allclose(x.g, 3 * xd ** 2)

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -235,7 +235,8 @@ class BackwardCallback {
       if (!inputs[i]->need_grad_state())
         continue;
 
-      // If memset with 0 is reserved, accum is not used. For shared case, the first is only non-accum.
+      // If memset with 0 is reserved, accum is not used. For shared case, the
+      // first is only non-accum.
       auto array = inputs[i]->variable()->grad()->array();
       if (array->zeroing()) {
         bool input_shared = false;

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -235,11 +235,23 @@ class BackwardCallback {
       if (!inputs[i]->need_grad_state())
         continue;
 
-      // If memset with 0 is reserved, accum is not used.
-      if (inputs[i]->variable()->grad()->array()->zeroing()) {
-        continue;
+      // If memset with 0 is reserved, accum is not used. For shared case, the first is only non-accum.
+      auto array = inputs[i]->variable()->grad()->array();
+      if (array->zeroing()) {
+        bool input_shared = false;
+        for (int j = 0; j < inputs.size(); j++) {
+          if (i == j) {
+            continue;
+          }
+          if (inputs[j]->variable()->grad()->array() == array) {
+            input_shared = true;
+            break;
+          }
+        }
+        if (!input_shared) {
+          continue;
+        }
       }
-
       // First visit gradients in intermediate layers are copied.
       if (inputs[i]->parent() && first_visit_flags[i]) {
         continue;


### PR DESCRIPTION
Two bug fixes:

1. no accumulation of gradients for any shared variable, of which grad.zero is called, into a same function instance
2. no accumulation of a shared and leaf variable into any function instance when using nn.grad

With this bug fixes, the following examples works as expected.

Ex.1 
```python
x = nn.Variable.from_numpy_array(np.ones((2, 3))).apply(need_grad=True)
x.grad.zero()
y = x * x * x
y.forward()
y.backward()
print(x.g)  # 3 * x ** 2
```

Ex. 2
```python
x = nn.Variable.from_numpy_array(np.ones((2, 3))).apply(need_grad=True)
y = x * x * x
x.grad.zero()
dy_dx = nn.grad([y], [x])
dy_dx[0].forward()
print(dy_dx[0].d)  # 3 * x ** 2
dy_dx[0].backward()
print(x.g)  # 6 * x
```