### PR TITLE
Allow clip_by_value to get scalar values as threshold

### DIFF
--- a/python/test/function/test_clip_by_value.py
+++ b/python/test/function/test_clip_by_value.py
@@ -21,8 +21,13 @@ from nnabla.testing import assert_allclose
 
 
 def ref_clip_by_value(x, min_, max_):
+    if np.isscalar(min_):
+        min_ = min_ * np.ones(x.shape)
     min_idx = np.where(x < min_)
     x[min_idx] = min_[min_idx]
+
+    if np.isscalar(max_):
+        max_ = max_ * np.ones(x.shape)
     max_idx = np.where(x > max_)
     x[max_idx] = max_[max_idx]
     return x
@@ -30,15 +35,33 @@ def ref_clip_by_value(x, min_, max_):
 
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("shape", [(2, 8, 8, 8), (2, 3)])
-def test_clip_by_value_forward(seed, shape):
+@pytest.mark.parametrize("dtype", [nn.Variable, nn.NdArray, float, np.array])
+def test_clip_by_value_forward(seed, shape, dtype):
+    def convert(value):
+        converter = dtype if dtype in (
+            float, np.array) else dtype.from_numpy_array
+        return converter(value)
     rng = np.random.RandomState(seed)
     x_data = rng.randn(*shape)
-    min_data = rng.randn(*shape)
-    max_data = rng.randn(*shape)
     x = nn.Variable.from_numpy_array(x_data)
-    min_ = nn.Variable.from_numpy_array(min_data)
-    max_ = nn.Variable.from_numpy_array(max_data)
-    with nn.auto_forward(True):
-        y = F.clip_by_value(x, min_, max_)
-    y_ref = ref_clip_by_value(x_data, min_data, max_data)
-    assert_allclose(y.d, y_ref)
+    if dtype is float:
+        min_data = rng.randn()
+        max_data = rng.randn()
+    else:
+        min_data = rng.randn(*shape)
+        max_data = rng.randn(*shape)
+    min_ = convert(min_data)
+    max_ = convert(max_data)
+
+    if dtype is not np.array:
+        with nn.auto_forward(True):
+            y = F.clip_by_value(x, min_, max_)
+        y_ref = ref_clip_by_value(x_data, min_data, max_data)
+
+        if dtype in (nn.Variable, float):
+            assert_allclose(y.d, y_ref)
+        elif dtype is nn.NdArray:
+            assert_allclose(y.data, y_ref)
+    else:
+        with pytest.raises(TypeError):
+            y = F.clip_by_value(x, min_data, max_data)


### PR DESCRIPTION
Currently, `clip_by_value`'s input is either `Variable` or `NdArray`, even for threshold values(`min` and `max`). It seems sometimes we just want to pass the scalar value as threshold, so I modified it to take the scalar input as well.

Now it works like;
```
x = nn.Variable((...))
y = F.clip_by_value(x, 0., 1.)
y.forward() # works
```