### PR TITLE
Add to_grad option to F.assign

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -197,3 +197,5 @@
   WarpByFlow_Empty: 277
 6:
   MinMaxQuantize_fBBBf: 274
+7:
+  Assign_B: 278

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -3575,6 +3575,18 @@ Array Manipulation:
 
       Unlike TensorFlow, the returned Variable has a backward path to `dst`:
 
+      If `to_grad` is `True`, the destination is the `gradient` property and the
+      same value remains in backward.
+
+      .. code-block:: python
+        dst = nn.Variable((2, 3, 4))
+        src = nn.Variable((2, 3, 4))
+        assign = F.assign(dst, src, to_grad=True)
+
+        assign.forward()
+        assert np.allclose(dst.g, src.d) # dst.grad is updated instead of dst.data
+        assert np.allclose(assign.g dst.d)
+
       .. math::
 
         g_{dst} = g_{y}
@@ -3583,12 +3595,18 @@ Array Manipulation:
         doc: A destination N-D array
       src:
         doc: A source N-D array
+    arguments:
+      to_grad:
+        doc: Flag whether the destination is gradient.
+        type: bool
+        default: 'False'
     outputs:
       y:
         doc: An assigned array
     c_runtime: not support
     function_ids:
       Empty: 248
+      B: 278
   GatherNd:
     snake_name: gather_nd
     doc: |2

--- a/include/nbla/function/assign.hpp
+++ b/include/nbla/function/assign.hpp
@@ -21,7 +21,7 @@
 
 namespace nbla {
 
-NBLA_REGISTER_FUNCTION_HEADER(Assign);
+NBLA_REGISTER_FUNCTION_HEADER(Assign, bool);
 
 /** Assign source array to destination array
 The function is defined as
@@ -32,18 +32,24 @@ y_i = x_i
 Inputs:
 - destination N-D array
 - source N-D array
+- to_grad flag
 
 Outputs:
 - N-D array identical to source array
 
 \ingroup FunctionImplGrp
  */
-template <typename T> class Assign : public BaseFunction<> {
+template <typename T> class Assign : public BaseFunction<bool> {
 protected:
+  bool to_grad_;
+
 public:
-  Assign(const Context &ctx) : BaseFunction(ctx) {}
+  Assign(const Context &ctx, bool to_grad)
+      : BaseFunction<bool>(ctx, to_grad), to_grad_(to_grad) {}
   virtual ~Assign() {}
-  virtual shared_ptr<Function> copy() const { return create_Assign(ctx_); }
+  virtual shared_ptr<Function> copy() const {
+    return create_Assign(ctx_, to_grad_);
+  }
   virtual int min_inputs() { return 2; }
   virtual int min_outputs() { return 1; }
   virtual vector<dtypes> in_types() {


### PR DESCRIPTION
Hi, @TE-AkioHayakawa san , @TE-TakuyaNarihira san.

I've added `to_grad` option to `F.assign` function. This will be useful to build original your own gradient manipulation with use of `nn.grad`.
```py
x = nn.Variable((2, 3), need_grad=True)
y = nn.Variable((2, 3))

l = F.mean(F.squared_error(x, y))

# backward
grad = nn.grad([l], [x], bind_grad_output=True)[0]

# clip gradients by norm
clipped_grad = F.clip_by_norm(grad, 0.5)

# apply clipped gradients to x
assign = F.assign(x, clipped_grad, to_grad=True)

assign.forward(clear_buffer=True)
```