### PR TITLE
Fix indexing with a boolean nnabla.Variable or NdArray

### DIFF
--- a/python/test/test_indexing.py
+++ b/python/test/test_indexing.py
@@ -210,3 +210,16 @@ def test_update_index_variable():
     i_nn.d = i_np
     y_nn.forward()
     assert_allclose(y_nn.d, x_np[i_np])
+
+
+def test_nnabla_boolean_array_as_index():
+    x_np = np.random.rand(20)
+    i_np = x_np > 0.5
+    x_nn = nn.Variable.from_numpy_array(x_np)
+    i_nn = nn.Variable.from_numpy_array(i_np)
+    with nn.auto_forward(True):
+        assert_allclose(x_nn[i_nn].d, x_np[i_np])
+        assert_allclose(x_nn.data[i_nn].data, x_np[i_np])
+        x_np[i_np] = -1
+        x_nn[i_nn] = -1
+        assert_allclose(x_nn.d, x_np)


### PR DESCRIPTION
Indexing with a boolean array must produce the index at positions where the index contains True values. This worked with lists and numpy arrays but went wrong for `nnabla.NdArray` or `nnabla.Variable` of boolean values:
```python
>>> x = nnabla.Variable.from_numpy_array(numpy.array([11, 22, 33]))
>>> i = nnabla.Variable.from_numpy_array(numpy.array([True, False, True]))
>>> x[i.d].d == x[[True, False, True]].d
array([ True,  True])
>>> x[i.d].d == x[i].d
False
```
This PR extends the implementation such that `x[i].d == x[i.d].d` is all true.