### PR TITLE
Add set_seed function

### DIFF
--- a/python/src/nnabla/__init__.py
+++ b/python/src/nnabla/__init__.py
@@ -39,6 +39,7 @@ from .context import (
 from .auto_forward import auto_forward, set_auto_forward, get_auto_forward
 from._computation_graph import forward_all
 from .grad import grad
+from .random import set_seed
 
 # Prefer cached array by default for performance.
 prefer_cached_array(True)

--- a/python/src/nnabla/random.py
+++ b/python/src/nnabla/random.py
@@ -17,3 +17,8 @@ import numpy as np
 # Parameter random number generator
 pseed = 313
 prng = np.random.RandomState(pseed)
+
+
+def set_seed(seed):
+    global prng
+    prng = np.random.RandomState(seed)

--- a/python/test/test_random.py
+++ b/python/test/test_random.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import pytest
+from nnabla.testing import assert_allclose
+
+
+@pytest.mark.parametrize("seed", [313, 314])
+def test_set_seed(seed):
+    # reference random generator
+    rng = np.random.RandomState(seed)
+
+    # set nnabla seed
+    nn.set_seed(seed)
+
+    # sample random values to check the same seed
+    assert_allclose(rng.rand(3, 2, 1), nn.random.prng.rand(3, 2, 1))
+    assert_allclose(rng.rand(3, 2, 1), nn.random.prng.rand(3, 2, 1))
+    assert_allclose(rng.rand(3, 2, 1), nn.random.prng.rand(3, 2, 1))


### PR DESCRIPTION
I have added `nn.set_seed` function for the academic reproducibility.

```
import nnabla as nn

nn.set_seed(0)
```

For the stochastic layers such as `F.rand`, I'll make another PR that will seed C++ random generator through `nn.set_seed` function.

@TE-AkioHayakawa 