### PR TITLE
Add patch_correlation function and tests.

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -201,3 +201,5 @@
   AdaptiveSeparableConvolution_Empty: 278
 8:
   Deconvolution_iiIiIiIiB: 279
+9:
+  PatchCorrelation_iIiIiIiIiI: 280

--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -527,3 +527,6 @@ MaxPoolingBackward:
 WarpByFlow:
   float: [float]
   half: [Half]
+PatchCorrelation:
+  float: [float]
+  half: [Half]

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -5839,3 +5839,139 @@ Unsupported, Special Use:
     c_runtime: not support
     function_ids:
       Empty: 277
+  PatchCorrelation:
+    snake_name: patch_correlation
+    doc: |2
+
+        Multiplicative patch-wise comparision between inputs `x1` and `x2`, which
+        must both be 4-dimensional NCHW (with `channel_last=False`) or NHWC (with
+        `channel_last=True`) arrays (where *N* is the number of samples, *H* and
+        *W* are the sample height and width and *C* is the number of channels).
+        The function returns a 5-D array with shape :math:`(N, C_y, C_x, H_o, W_o)`
+        where :math:`H_o, W_o` are determined by the possible patch locations within
+        the, optionally padded, input image sizeand :math:`C_y, C_x` are determined
+        by the optionally shifted patch positions.
+
+        Mathmatically, the patch correlation is formulated as 
+
+        .. math::
+          
+          O(s_y, s_x, h_0, w_0) =
+          \sum_{c} \sum_{k_h} \sum_{k_w} I_1(c, h + k_h, w + k_w) \times I_2(c, h + k_h + s_h, w + k_w + s_w), 
+
+        where :math:`I_1(c, h, w)` and :math:`I_2(c, h, w)` are the inputs at :math:`c`-th channel, 
+        :math:`h`-th height, and :math:`w`-th width, :math:`k_h, k_w` indices for the patch size 
+        and :math:`s_h, s_w` indices for the shifts.
+          
+        A single correlation value (per sample) is produced if the patch extends
+        to the image dimensions and all other parameters use the default values.
+
+        >>> import numpy as np, nnabla as nn, nnabla.functions as F
+        >>> N, C, H, W = (1, 2, 3, 4)
+        >>> x = nn.Variable.from_numpy_array(np.ones([N, C, H, W]))
+        >>> F.patch_correlation(x, x, patch=(H, W)).d
+        array([[[[[24.]]]]], dtype=float32)
+
+        A patch that is smaller than the image size moves horizontal and vertical
+        producing a value per position. The `patch_step` argument may be used to
+        control the position increments.
+
+        >>> F.patch_correlation(x, x, patch=(H-1, W-1)).d
+        array([[[[[12., 12.],
+                  [12., 12.]]]]], dtype=float32)
+        >>> F.patch_correlation(x, x, patch=(H-1, W-1), patch_step=(2, 1)).d
+        array([[[[[12., 12.]]]]], dtype=float32)
+
+        Multiple correlations may be performed at each position between the patch
+        from `x1` and patches from `x2` at relative offsets striding the maximum
+        vertical and horizontal distance given by the `shift` values at increments
+        of `shift_step`. The shifted correlation values can be obtained for the
+        from the second and third output dimension for the vertical and horizontal
+        shifts.
+
+        >>> F.patch_correlation(x, x, (H, 1), shift=(0, 1)).shape
+        (1, 1, 3, 1, 4)
+        >>> F.patch_correlation(x, x, (H, 1), shift=(0, 1)).d
+        array([[[[[0., 6., 6., 6.]],
+                 [[6., 6., 6., 6.]],
+                 [[6., 6., 6., 0.]]]]], dtype=float32)
+        >>> F.patch_correlation(x, x, (H, 1), shift=(0, 1), shift_step=(1, 2)).d
+        array([[[[[0., 6., 6., 6.]],
+                 [[6., 6., 6., 0.]]]]], dtype=float32)
+
+        Padding with zero values may be applied individually to the top, bottom,
+        left and right side of the input image.
+
+        >>> F.patch_correlation(x, x, patch=(H, W), padding=(0, 1, W, W)).d
+        array([[[[[ 0.,  6., 12., 18., 24., 18., 12.,  6.,  0.],
+                  [ 0.,  4.,  8., 12., 16., 12.,  8.,  4.,  0.]]]]], dtype=float32)
+
+        This function may be used to implement the FlowNetC correlation layer.
+
+        >>> N, C, H, W = (1, 256, 44, 60)
+        >>> x1, x2 = nn.Variable((N, C, H, W)), nn.Variable((N, C, H, W))
+        >>> F.patch_correlation(x1, x2, shift=20, shift_step=2).shape
+        (1, 21, 21, 44, 60)
+
+        References:
+        
+            * `Fischer et al., FlowNet: Learning Optical Flow with Convolutional
+              Networks. <https://arxiv.org/abs/1504.06852>`_
+    inputs:
+      x1:
+        doc: Input N-D array with shape :math:`(N, H, W, C)`.
+      x2:
+        doc: Input N-D array with shape :math:`(N, H, W, C)`.
+    arguments:
+      patch:
+        doc: A tuple with height and width of the correlation patch. A single integer
+          expands to identical height and width.
+        type: Shape
+        default: (1, 1)
+      shift:
+        doc: A tuple of maximum vertical and horizontal displacement of patches from
+          `x2` that are correlated with a single patch from `x1`. A single integer
+          expands to identical vertical and horizontal displacement.
+        type: Shape
+        default: (0, 0)
+      patch_step:
+        doc: A tuple of vertical and horizontal increments for advancing the position
+          of the correlation patch within the input image shape. A single integer
+          expands to identical vertical and horizontal increments.
+        type: Shape
+        default: (1, 1)
+      shift_step:
+        doc: A tuple of vertical and horizontal increments for advancing the relative
+          offset position within the shift range. A single integer expands to identical
+          vertical and horizontal increments.
+        type: Shape
+        default: (1, 1)
+      padding:
+        doc: A tuple of top, bottom, left and right padding extent. A tuple of two
+          values yields identical top/bottom and left/right padding from the first
+          and second tuple value. A single integer expands to indential padding extent
+          for all sides.
+        type: Shape
+        default: (0, 0, 0, 0)
+    outputs:
+      y:
+        doc: |2
+
+          N-D array with shape :math:`(N, C_y, C_x, H_o, W_o)`.
+
+          A spatial size of the output is calculated as
+
+          .. math:: 
+
+            H_o = \frac{H + (top\_pad + bottom\_pad) - patch_v }{patch\_step_v} + 1.
+
+          A channel size of the ouptut is calculated as
+
+          .. math::
+            
+            C_y = \frac{2 \times shift_v}{shift\_step_v} + 1.
+
+          :math:`W_o` and :math:`C_x` are the same calculation with differenct components.
+    c_runtime: not support
+    function_ids:
+      iIiIiIiIiI: 280

--- a/doc/python/api/function.rst
+++ b/doc/python/api/function.rst
@@ -50,6 +50,7 @@ Neural Network Layers
 .. autofunction:: lstm
 .. autofunction:: gru
 .. autofunction:: multi_head_attention
+.. autofunction:: patch_correlation
 
 
 Neural Network Activation

--- a/include/nbla/function/patch_correlation.hpp
+++ b/include/nbla/function/patch_correlation.hpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_PATCH_CORRELATION_HPP
+#define NBLA_FUNCTION_PATCH_CORRELATION_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(PatchCorrelation, const vector<int> &,
+                              const vector<int> &, const vector<int> &,
+                              const vector<int> &, const vector<int> &);
+
+/** PatchConvolution
+
+Inputs:
+- Input N-D array with shape (N, H, W, C).
+- Input N-D array with shape (N, H, W, C).
+
+Outputs:
+- N-D array with shape (N, C_y, C_x, Ho, Wo)
+
+@tparam T Data type for computation.
+@param patch Height and width of the correlation patch.
+@param shift Maximum vertical and horizontal displacement of patches.
+@param patch_step Vertical and horizontal patch increments.
+@param shift_step Vertical and horizontal shift increments.
+@param padding Top, bottom, left and right padding extent.
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class PatchCorrelation
+    : public BaseFunction<const vector<int> &, const vector<int> &,
+                          const vector<int> &, const vector<int> &,
+                          const vector<int> &> {
+protected:
+  const vector<int> patch_;
+  const vector<int> shift_;
+  const vector<int> patch_step_;
+  const vector<int> shift_step_;
+  const vector<int> padding_;
+
+public:
+  PatchCorrelation(const Context &ctx, const vector<int> &patch,
+                   const vector<int> &shift, const vector<int> &patch_step,
+                   const vector<int> &shift_step, const vector<int> &padding)
+      : BaseFunction(ctx, patch, shift, patch_step, shift_step, padding),
+        patch_(patch), shift_(shift), patch_step_(patch_step),
+        shift_step_(shift_step), padding_(padding) {}
+  virtual ~PatchCorrelation() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_PatchCorrelation(ctx_, patch_, shift_, patch_step_,
+                                   shift_step_, padding_);
+  }
+  virtual int min_inputs() { return 2; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "PatchCorrelation"; }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/python/src/nnabla/backward_function/patch_correlation.py
+++ b/python/src/nnabla/backward_function/patch_correlation.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class PatchCorrelationBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'PatchCorrelationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of PatchCorrelationBackward class is not implemented.")

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -1225,3 +1225,161 @@ def multi_head_attention(query, key, value, num_heads, q_weight, k_weight, v_wei
     attn_output = F.affine(attn_output, out_weight, out_bias, base_axis=2)
 
     return attn_output, attn_output_weights
+
+
+def patch_correlation(x1, x2, patch=(1, 1), shift=(0, 0), patch_step=(1, 1),
+                      shift_step=(1, 1), padding=(0, 0, 0, 0),
+                      channel_last=False):
+    r"""
+    Multiplicative patch-wise comparision between inputs `x1` and `x2`, which
+    must both be 4-dimensional NCHW (with `channel_last=False`) or NHWC (with
+    `channel_last=True`) arrays (where *N* is the number of samples, *H* and
+    *W* are the sample height and width and *C* is the number of channels).
+    The function returns a 5-D array with shape :math:`(N, C_y, C_x, H_o, W_o)`
+    where :math:`H_o, W_o` are determined by the possible patch locations within
+    the, optionally padded, input image sizeand :math:`C_y, C_x` are determined
+    by the optionally shifted patch positions.
+
+    Mathmatically, the patch correlation is formulated as 
+
+    .. math::
+
+       O(s_y, s_x, h_0, w_0) =
+       \sum_{c} \sum_{k_h} \sum_{k_w} I_1(c, h + k_h, w + k_w) \times I_2(c, h + k_h + s_h, w + k_w + s_w), 
+
+    where :math:`I_1(c, h, w)` and :math:`I_2(c, h, w)` are the inputs at :math:`c`-th channel, 
+    :math:`h`-th height, and :math:`w`-th width, :math:`k_h, k_w` indices for the patch size 
+    and :math:`s_h, s_w` indices for the shifts.
+
+    A single correlation value (per sample) is produced if the patch extends
+    to the image dimensions and all other parameters use the default values.
+
+    >>> import numpy as np, nnabla as nn, nnabla.functions as F
+    >>> N, C, H, W = (1, 2, 3, 4)
+    >>> x = nn.Variable.from_numpy_array(np.ones([N, C, H, W]))
+    >>> F.patch_correlation(x, x, patch=(H, W)).d
+    array([[[[[24.]]]]], dtype=float32)
+
+    A patch that is smaller than the image size moves horizontal and vertical
+    producing a value per position. The `patch_step` argument may be used to
+    control the position increments.
+
+    >>> F.patch_correlation(x, x, patch=(H-1, W-1)).d
+    array([[[[[12., 12.],
+              [12., 12.]]]]], dtype=float32)
+    >>> F.patch_correlation(x, x, patch=(H-1, W-1), patch_step=(2, 1)).d
+    array([[[[[12., 12.]]]]], dtype=float32)
+
+    Multiple correlations may be performed at each position between the patch
+    from `x1` and patches from `x2` at relative offsets striding the maximum
+    vertical and horizontal distance given by the `shift` values at increments
+    of `shift_step`. The shifted correlation values can be obtained for the
+    from the second and third output dimension for the vertical and horizontal
+    shifts.
+
+    >>> F.patch_correlation(x, x, (H, 1), shift=(0, 1)).shape
+    (1, 1, 3, 1, 4)
+    >>> F.patch_correlation(x, x, (H, 1), shift=(0, 1)).d
+    array([[[[[0., 6., 6., 6.]],
+             [[6., 6., 6., 6.]],
+             [[6., 6., 6., 0.]]]]], dtype=float32)
+    >>> F.patch_correlation(x, x, (H, 1), shift=(0, 1), shift_step=(1, 2)).d
+    array([[[[[0., 6., 6., 6.]],
+             [[6., 6., 6., 0.]]]]], dtype=float32)
+
+    Padding with zero values may be applied individually to the top, bottom,
+    left and right side of the input image.
+
+    >>> F.patch_correlation(x, x, patch=(H, W), padding=(0, 1, W, W)).d
+    array([[[[[ 0.,  6., 12., 18., 24., 18., 12.,  6.,  0.],
+              [ 0.,  4.,  8., 12., 16., 12.,  8.,  4.,  0.]]]]], dtype=float32)
+
+    This function may be used to implement the FlowNetC correlation layer.
+
+    >>> N, C, H, W = (1, 256, 44, 60)
+    >>> x1, x2 = nn.Variable((N, C, H, W)), nn.Variable((N, C, H, W))
+    >>> F.patch_correlation(x1, x2, shift=20, shift_step=2).shape
+    (1, 21, 21, 44, 60)
+
+    References:
+
+        * `Fischer et al., FlowNet: Learning Optical Flow with Convolutional
+          Networks. <https://arxiv.org/abs/1504.06852>`_
+
+    Args:
+        x1(~nnabla.Variable): Input N-D array with shape :math:`(N, C, H, W)`
+            or :math:`(N, H, W, C)`.
+        x2(~nnabla.Variable): Input N-D array with shape :math:`(N, C, H, W)`
+            or :math:`(N, H, W, C)`.
+        patch: A tuple with height and width of the correlation patch. A single
+            integer expands to identical height and width.
+        shift: A tuple of maximum vertical and horizontal displacement of
+            patches from `x2` that are correlated with a single patch from `x1`.
+            A single integer expands to identical vertical and horizontal
+            displacement.
+        patch_step: A tuple of vertical and horizontal increments for advancing
+            the position of the correlation patch within the input image shape.
+            A single integer expands to identical vertical and horizontal
+            increments.
+        shift_step: A tuple of vertical and horizontal increments for advancing
+            the relative offset position within the shift range. A single
+            integer expands to identical vertical and horizontal increments.
+        padding: A tuple of top, bottom, left and right padding extent. A tuple
+            of two values yields identical top/bottom and left/right padding
+            from the first and second tuple value. A single integer expands to
+            indential padding extent for all sides.
+        channel_last: Last dimension is the channel (NHWC order) if True.
+
+    Returns:
+        ~nnabla.Variable: N-D array with shape :math:`(N, C_y, C_x, H_o, W_o)` or :math:`(N, H, W, C_y, C_x)` if `channel_last=True`.
+
+          A spatial size of the output is calculated as
+
+          .. math:: 
+
+            H_o = \frac{H + (top\_pad + bottom\_pad) - patch_v}{patch\_step_v} + 1.
+
+          A channel size of the ouptut is calculated as
+
+          .. math::
+
+            C_y = \frac{2 \times shift_v}{shift\_step_v} + 1.
+
+          :math:`W_o` and :math:`C_x` are the same calculation with differenct components.
+    """
+    from .function_bases import patch_correlation as patch_correlation_base
+
+    if not len(x1.shape) == len(x2.shape) == 4:
+        raise ValueError("Both inputs x1 and x2 must have 4 dimensions.")
+
+    if not x1.shape == x2.shape:
+        raise ValueError("Both inputs x1 and x2 must have equal shape.")
+
+    if isinstance(patch, int):
+        patch = 2 * (patch,)
+    if isinstance(shift, int):
+        shift = 2 * (shift,)
+    if isinstance(patch_step, int):
+        patch_step = 2 * (patch_step,)
+    if isinstance(shift_step, int):
+        shift_step = 2 * (shift_step,)
+    if isinstance(padding, int):
+        padding = 4 * (padding,)
+    if len(padding) == 2 and all(isinstance(p, int) for p in padding):
+        padding = 2 * (padding[0],) + 2 * (padding[1],)
+
+    if not channel_last:
+        if x1.shape[1] == 1:
+            x1 = reshape(x1, (x1.shape[0], *x1.shape[2:4], 1))
+            x2 = reshape(x2, (x2.shape[0], *x2.shape[2:4], 1))
+        else:
+            x1 = transpose(x1, (0, 2, 3, 1))
+            x2 = transpose(x2, (0, 2, 3, 1))
+
+    y = patch_correlation_base(x1, x2, patch, shift, patch_step, shift_step,
+                               padding)
+
+    if not channel_last:
+        y = transpose(y, (0, 3, 4, 1, 2))
+
+    return y

--- a/python/test/function/test_patch_correlation.py
+++ b/python/test/function/test_patch_correlation.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2019 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context, function_tester
+
+ctxs = list_context('PatchCorrelation')
+
+
+@pytest.mark.parametrize("N", [1, 3])
+@pytest.mark.parametrize("C", [1, 4])
+@pytest.mark.parametrize("H, W, params, oCH, oCW, oH, oW", [
+    (5, 5, {}, 1, 1, 5, 5),
+    (5, 5, {'patch': 3}, 1, 1, 3, 3),
+    (5, 5, {'shift': 2}, 5, 5, 5, 5),
+    (5, 5, {'shift': 2, 'shift_step': 2}, 3, 3, 5, 5),
+    (5, 5, {'patch': 3, 'padding': 2}, 1, 1, 7, 7),
+    (5, 5, {'patch': 3, 'patch_step': 2, 'padding': 2}, 1, 1, 4, 4),
+    (5, 5, {'patch': 4, 'patch_step': 2, 'padding': 2}, 1, 1, 3, 3),
+    (7, 8, {'patch': 4, 'patch_step': 1}, 1, 1, 4, 5),
+    (7, 8, {'patch': 4, 'patch_step': 2}, 1, 1, 2, 3),
+    (7, 8, {'patch': 4, 'patch_step': 3}, 1, 1, 2, 2),
+    (3, 3, {'patch': 3, 'padding': 0}, 1, 1, 1, 1),
+    (3, 3, {'patch': 3, 'padding': 1}, 1, 1, 3, 3),
+    (3, 3, {'patch': 2, 'padding': 0}, 1, 1, 2, 2),
+    (3, 3, {'patch': 2, 'padding': 1}, 1, 1, 4, 4),
+])
+def test_output_shape(N, C, H, W, params, oCH, oCW, oH, oW):
+    x = nn.Variable((N, C, H, W))
+    assert F.patch_correlation(x, x, **params).shape == (N, oCH, oCW, oH, oW)
+
+
+@pytest.mark.parametrize("C", [1, 2, 5])
+@pytest.mark.parametrize("H, W, params, output", [
+    (3, 3, {'patch': 3, 'padding': 0}, np.array([[[[[9]]]]])),
+    (2, 3, {'patch': (2, 3), 'padding': 0}, np.array([[[[[6]]]]])),
+    (2, 3, {'patch': (2, 3), 'padding': (0, 1)}, np.array([[[[[4, 6, 4]]]]])),
+    (3, 3, {'patch': 3, 'padding': (0, 0, 2, 0)}, np.array([[[[[3, 6, 9]]]]])),
+    (3, 3, {'patch': 3, 'padding': (0, 0, 0, 2)}, np.array([[[[[9, 6, 3]]]]])),
+])
+def test_padding(C, H, W, params, output):
+    x = F.constant(1, (1, C, H, W))
+    y = F.patch_correlation(x, x, **params)
+    y.forward()
+    assert np.allclose(y.d, output * C)
+
+
+def patch_correlation(x1, x2, patch=(1, 1), shift=(0, 0), patch_step=(1, 1),
+                      shift_step=(1, 1), padding=(0, 0, 0, 0)):
+    # inputs and output are NHWC tensors
+
+    oh = (x1.shape[1] + sum(padding[:2]) -
+          patch[0] + patch_step[0]) // patch_step[0]
+    ow = (x1.shape[2] + sum(padding[2:]) -
+          patch[1] + patch_step[1]) // patch_step[1]
+    och = int(np.ceil((1 + 2 * shift[0]) / shift_step[0]))
+    ocw = int(np.ceil((1 + 2 * shift[1]) / shift_step[1]))
+    out_array = np.empty((x1.shape[0], oh, ow, och, ocw), dtype=x1.dtype)
+    out_index = np.ndindex(out_array.shape)
+
+    x1 = np.pad(x1, ((0, 0), padding[:2], padding[2:], (0, 0)), 'constant')
+    x2 = np.pad(x2, ((0, 0), padding[:2], padding[2:], (0, 0)), 'constant')
+    x2 = np.pad(x2, ((0, 0), *zip(shift, shift), (0, 0)), 'constant')
+
+    for n in range(x1.shape[0]):
+        for y in range(0, x1.shape[1] - patch[0] + 1, patch_step[0]):
+            for x in range(0, x1.shape[2] - patch[1] + 1, patch_step[1]):
+                p1 = x1[n, y:y+patch[0], x:x+patch[1]]
+                for yy in range(y, y + 1 + 2 * shift[0], shift_step[0]):
+                    for xx in range(x, x + 1 + 2 * shift[1], shift_step[1]):
+                        p2 = x2[n, yy:yy+patch[0], xx:xx+patch[1]]
+                        out_array[next(out_index)] = np.sum(p1 * p2)
+
+    return out_array
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [314])
+@pytest.mark.parametrize("N", [1, 2])
+@pytest.mark.parametrize("C", [1, 2])
+@pytest.mark.parametrize("H, W, params", [
+    (5, 5, {'patch': (1, 1), 'shift': (2, 2), 'shift_step': (2, 2)}),
+    (4, 4, {'patch': (3, 3), 'padding': (1, 2, 2, 1)}),
+    (5, 9, {'patch': (2, 3), 'shift': (1, 1), 'patch_step': (2, 3)}),
+    (3, 8, {'patch': (1, 2), 'patch_step': (2, 3), 'padding': (1, 1, 0, 0)}),
+    (5, 5, {'shift': (1, 0), 'shift_step': (1, 2), 'padding': (0, 0, 0, 0)}),
+])
+def test_forward_backward(N, C, H, W, params, seed, ctx, func_name):
+    rng = np.random.RandomState(seed)
+    x1 = rng.randn(N, H, W, C).astype(np.float32)
+    x2 = rng.randn(N, H, W, C).astype(np.float32)
+    # must use function_bases.patch_correlation for func_name check in tester
+    function_tester(rng, nn.function_bases.patch_correlation, patch_correlation,
+                    [x1, x2], func_kwargs=params, func_name=func_name, ctx=ctx,
+                    atol_b=2e-2)

--- a/src/nbla/function/generic/patch_correlation.cpp
+++ b/src/nbla/function/generic/patch_correlation.cpp
@@ -1,0 +1,220 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/patch_correlation.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(PatchCorrelation, const vector<int> &,
+                              const vector<int> &, const vector<int> &,
+                              const vector<int> &, const vector<int> &);
+
+struct Shape2D {
+  int h; // height
+  int w; // width
+  Shape2D(const vector<int> v) {
+    h = v.at(0);
+    w = v.at(1);
+  };
+};
+
+struct Pad2D {
+  int t; // top
+  int b; // bottom
+  int l; // left
+  int r; // right
+  int h;
+  int w;
+  Pad2D(const vector<int> v) {
+    t = v.at(0);
+    b = v.at(1);
+    l = v.at(2);
+    r = v.at(3);
+    h = t + b;
+    w = l + r;
+  };
+};
+
+template <typename T>
+void PatchCorrelation<T>::setup_impl(const Variables &inputs,
+                                     const Variables &outputs) {
+#define CHECK_VALUE(condition, msg, ...)                                       \
+  NBLA_CHECK(condition, error_code::value, msg, ##__VA_ARGS__);
+
+  auto const x1 = inputs.at(0);
+  auto const x2 = inputs.at(1);
+
+  CHECK_VALUE(x1->shape().size() == 4, "The input x1 must have 4 dimensions.");
+  CHECK_VALUE(x2->shape().size() == 4, "The input x2 must have 4 dimensions.");
+  CHECK_VALUE(x1->shape() == x2->shape(), "x1 and x2 must have same shape.");
+
+  auto const patch = Shape2D(this->patch_);
+  auto const shift = Shape2D(this->shift_);
+  auto const patch_step = Shape2D(this->patch_step_);
+  auto const shift_step = Shape2D(this->shift_step_);
+  auto const padding = Pad2D(this->padding_);
+
+  CHECK_VALUE(patch.h > 0, "patch height must be greater than zero.");
+  CHECK_VALUE(patch.w > 0, "patch width must be greater than zero.");
+  CHECK_VALUE(shift.h >= 0, "shift height must not be negative.");
+  CHECK_VALUE(shift.w >= 0, "shift width must not be negative.");
+  CHECK_VALUE(patch_step.h > 0, "patch_step height must be greater than zero.");
+  CHECK_VALUE(patch_step.w > 0, "patch_step width must be greater than zero.");
+  CHECK_VALUE(shift_step.h > 0, "shift_step height must be greater than zero.");
+  CHECK_VALUE(shift_step.w > 0, "shift_step width must be greater than zero.");
+  CHECK_VALUE(padding.t >= 0, "top padding must not be negative.");
+  CHECK_VALUE(padding.b >= 0, "bottom padding must not be negative.");
+  CHECK_VALUE(padding.l >= 0, "left padding must not be negative.");
+  CHECK_VALUE(padding.r >= 0, "right padding must not be negative.");
+
+  auto const N = x1->shape()[0];
+  auto const H = x1->shape()[1];
+  auto const W = x1->shape()[2];
+
+  auto const och = (2 * shift.h + shift_step.h) / shift_step.h;
+  auto const ocw = (2 * shift.w + shift_step.w) / shift_step.w;
+  auto const oh = (H + padding.h - patch.h + patch_step.h) / patch_step.h;
+  auto const ow = (W + padding.w - patch.w + patch_step.w) / patch_step.w;
+
+  outputs.at(0)->reshape({N, oh, ow, och, ocw}, true);
+
+#undef CHECK_VALUE
+}
+
+template <typename T>
+void PatchCorrelation<T>::forward_impl(const Variables &inputs,
+                                       const Variables &outputs) {
+  auto in1_data = inputs[0]->get_data_pointer<T>(this->ctx_);
+  auto in2_data = inputs[1]->get_data_pointer<T>(this->ctx_);
+  auto out_data = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
+
+  auto const patch = Shape2D(this->patch_);
+  auto const shift = Shape2D(this->shift_);
+  auto const patch_step = Shape2D(this->patch_step_);
+  auto const shift_step = Shape2D(this->shift_step_);
+  auto const pad = Pad2D(this->padding_);
+
+  auto const N = inputs[0]->shape()[0];
+  auto const H = inputs[0]->shape()[1];
+  auto const W = inputs[0]->shape()[2];
+  auto const C = inputs[0]->shape()[3];
+
+  auto flat = [N, H, W, C](decltype(N) n, decltype(H) y, decltype(W) x) {
+    return n * H * W * C + y * W * C + x * C;
+  };
+
+  auto out_iter = Size_t{0};
+
+  for (auto n = decltype(N){0}; n < N; n++) {
+    for (auto y = -pad.t; y <= H - patch.h + pad.b; y += patch_step.h) {
+      for (auto x = -pad.l; x <= W - patch.w + pad.r; x += patch_step.w) {
+        for (auto yy = -shift.h; yy <= shift.h; yy += shift_step.h) {
+          for (auto xx = -shift.w; xx <= shift.w; xx += shift_step.w) {
+            auto value = T{0};
+            for (auto ky = decltype(patch.h){0}; ky < patch.h; ky++) {
+              if ((0 <= y + ky) && (y + ky < H) && (0 <= y + yy + ky) &&
+                  (y + yy + ky < H)) {
+                for (auto kx = decltype(patch.w){0}; kx < patch.w; kx++) {
+                  if ((0 <= x + kx) && (x + kx < W) && (0 <= x + xx + kx) &&
+                      (x + xx + kx < W)) {
+                    auto i1 = flat(n, y + ky, x + kx);
+                    auto i2 = flat(n, y + yy + ky, x + xx + kx);
+                    for (auto c = decltype(C){0}; c < C; c++) {
+                      value += in1_data[i1++] * in2_data[i2++];
+                    }
+                  }
+                }
+              }
+            }
+            out_data[out_iter++] = value;
+          }
+        }
+      }
+    }
+  }
+}
+
+template <typename T>
+void PatchCorrelation<T>::backward_impl(const Variables &inputs,
+                                        const Variables &outputs,
+                                        const vector<bool> &propagate_down,
+                                        const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+
+  if ((propagate_down[0]) && (!accum[0]))
+    inputs[0]->grad()->zero();
+
+  if ((propagate_down[1]) && (!accum[1]))
+    inputs[1]->grad()->zero();
+
+  auto in1_grad = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, false);
+  auto in2_grad = inputs[1]->cast_grad_and_get_pointer<T>(this->ctx_, false);
+  auto out_grad = outputs[0]->get_grad_pointer<T>(this->ctx_);
+
+  auto in1_data = inputs[0]->get_data_pointer<T>(this->ctx_);
+  auto in2_data = inputs[1]->get_data_pointer<T>(this->ctx_);
+
+  auto const patch = Shape2D(this->patch_);
+  auto const shift = Shape2D(this->shift_);
+  auto const patch_step = Shape2D(this->patch_step_);
+  auto const shift_step = Shape2D(this->shift_step_);
+  auto const pad = Pad2D(this->padding_);
+
+  auto const N = inputs[0]->shape()[0];
+  auto const H = inputs[0]->shape()[1];
+  auto const W = inputs[0]->shape()[2];
+  auto const C = inputs[0]->shape()[3];
+
+  auto flat = [N, H, W, C](decltype(N) n, decltype(H) y, decltype(W) x) {
+    return n * H * W * C + y * W * C + x * C;
+  };
+
+  auto out_iter = Size_t{0};
+
+  for (auto n = decltype(N){0}; n < N; n++) {
+    for (auto y = -pad.t; y <= H - patch.h + pad.b; y += patch_step.h) {
+      for (auto x = -pad.l; x <= W - patch.w + pad.r; x += patch_step.w) {
+        for (auto yy = -shift.h; yy <= shift.h; yy += shift_step.h) {
+          for (auto xx = -shift.w; xx <= shift.w; xx += shift_step.w) {
+            auto grad = out_grad[out_iter++];
+            for (auto ky = decltype(patch.h){0}; ky < patch.h; ky++) {
+              if ((0 <= y + ky) && (y + ky < H) && (0 <= y + yy + ky) &&
+                  (y + yy + ky < H)) {
+                for (auto kx = decltype(patch.w){0}; kx < patch.w; kx++) {
+                  if ((0 <= x + kx) && (x + kx < W) && (0 <= x + xx + kx) &&
+                      (x + xx + kx < W)) {
+                    auto i1 = flat(n, y + ky, x + kx);
+                    auto i2 = flat(n, y + yy + ky, x + xx + kx);
+                    for (auto c = decltype(C){0}; c < C; c++) {
+                      if (propagate_down[0])
+                        in1_grad[i1 + c] += in2_data[i2 + c] * grad;
+                      if (propagate_down[1])
+                        in2_grad[i2 + c] += in1_data[i1 + c] * grad;
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+}


### PR DESCRIPTION
A function to correlate patches of two input images. Compares at incrementing coordinates a patch from the first input with patches shifted around that coordinate of the second input. The patch and shift increments are configurable and padding may also be applied.