### PR TITLE
Less memory shift and flip implementation

### DIFF
--- a/include/nbla/function/flip.hpp
+++ b/include/nbla/function/flip.hpp
@@ -43,6 +43,7 @@ specify (2,3).
 template <typename T> class Flip : public BaseFunction<const vector<int> &> {
 protected:
   vector<int> axes_;
+  vector<bool> flip_;
 
 public:
   Flip(const Context &ctx, const vector<int> &axes)

--- a/include/nbla/function/shift.hpp
+++ b/include/nbla/function/shift.hpp
@@ -47,7 +47,6 @@ class Shift : public BaseFunction<const vector<int> &, const string &> {
 protected:
   vector<int> shifts_;
   string border_mode_;
-  vector<vector<int>> addr_table_;
 
 public:
   Shift(const Context &ctx, const vector<int> &shifts,
@@ -68,7 +67,6 @@ public:
   }
 
   std::vector<int> &shifts() { return shifts_; }
-  void prepare_addr_table(const Variables &inputs);
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -81,10 +79,9 @@ protected:
                                       const vector<bool> &accum);
 
 private:
-  void shift_recursive(Variable *inp, const T *x, T *y, int x_offset,
+  template <bool is_backward>
+  void shift_recursive(Variable *inp, const T *src, T *dst, int x_offset,
                        int y_offset, int dim);
-  void shift_backward_recursive(Variable *outp, const T *dy, T *dx,
-                                int x_offset, int y_offset, int dim);
 };
 }
 #endif

--- a/src/nbla/function/generic/flip.cpp
+++ b/src/nbla/function/generic/flip.cpp
@@ -28,6 +28,7 @@ NBLA_REGISTER_FUNCTION_SOURCE(Flip, const vector<int> &);
 template <typename T>
 void Flip<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   outputs[0]->reshape(inputs[0]->shape(), true);
+  flip_.resize(inputs[0]->ndim());
 }
 
 template <typename T>
@@ -91,12 +92,11 @@ template <typename T>
 void Flip<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
-  std::vector<bool> flip(inputs[0]->ndim());
   for (int id = 0; id < inputs[0]->ndim(); id++) {
     auto itr = std::find(axes_.begin(), axes_.end(), id);
-    flip[id] = itr != axes_.end();
+    flip_[id] = itr != axes_.end();
   }
-  flip_recursive(inputs[0], x, y, flip, false, 0, 0, 0);
+  flip_recursive(inputs[0], x, y, flip_, false, 0, 0, 0);
 }
 
 template <typename T>
@@ -108,12 +108,7 @@ void Flip<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   }
   const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
   T *dx = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
-  std::vector<bool> flip(outputs[0]->ndim());
-  for (int id = 0; id < outputs[0]->ndim(); id++) {
-    auto itr = std::find(axes_.begin(), axes_.end(), id);
-    flip[id] = itr != axes_.end();
-  }
-  flip_recursive(outputs[0], dy, dx, flip, accum[0], 0, 0, 0);
+  flip_recursive(outputs[0], dy, dx, flip_, accum[0], 0, 0, 0);
 }
 
 } // namespace nbla


### PR DESCRIPTION
Now Shift and Flip don't use address tables to reduce memory usage