### PR TITLE
Add prohibit_clear flag to CgVariable to keep inplaced data from clear_buffer operation

### DIFF
--- a/include/nbla/computation_graph/computation_graph.hpp
+++ b/include/nbla/computation_graph/computation_graph.hpp
@@ -28,7 +28,8 @@ namespace nbla {
 
 */
 NBLA_API vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f,
-                                                       int n_outputs = -1);
+                                                       int n_outputs = -1,
+                                                       bool prohibit_clear_output = false);
 
 /** Connect function to network.
 

--- a/include/nbla/computation_graph/computation_graph.hpp
+++ b/include/nbla/computation_graph/computation_graph.hpp
@@ -27,9 +27,9 @@ namespace nbla {
     flags are automatically applied to created outputs.
 
 */
-NBLA_API vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f,
-                                                       int n_outputs = -1,
-                                                       bool prohibit_clear_output = false);
+NBLA_API vector<CgVariablePtr>
+create_function_outputs(CgFunctionPtr cg_f, int n_outputs = -1,
+                        bool prohibit_clear_output = false);
 
 /** Connect function to network.
 

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -93,6 +93,7 @@ class CgVariable {
       function_references_;
   bool allow_modify_data_{true}; ///< Whether the data can be in-placed.
   bool persistent_{false};       ///<Persistency flag against clearing.
+  bool prohibit_clear_data_ {false};
   string name_{""};
 
   void
@@ -185,6 +186,14 @@ public:
   /** Unset need grad state flag.
    */
   inline void unset_need_grad_state() { need_grad_state_ = NG_NONE; }
+
+  /** Get prohibit_clear_data_ flag.
+   */
+  inline bool prohibit_clear_data() { return prohibit_clear_data_; }
+
+  /** Set prohibit_clear_data_ flag.
+   */
+  inline void set_prohibit_clear_data(bool b) { prohibit_clear_data_ = b; }
 
   /** Set parent function.
 

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -93,7 +93,7 @@ class CgVariable {
       function_references_;
   bool allow_modify_data_{true}; ///< Whether the data can be in-placed.
   bool persistent_{false};       ///<Persistency flag against clearing.
-  bool prohibit_clear_data_ {false};
+  bool prohibit_clear_data_{false};
   string name_{""};
 
   void

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -37,7 +37,8 @@ static void set_function_inputs(CgFunctionPtr func,
 }
 
 vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f,
-                                              int n_outputs) {
+                                              int n_outputs,
+                                              bool prohibit_clear_output) {
   // Check inplace outputs size and create outputs.
   if (n_outputs < 0) {
     n_outputs = cg_f->function()->min_outputs();
@@ -47,6 +48,7 @@ vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f,
     auto v = make_shared<CgVariable>();
     v->set_need_grad_state(cg_f->need_grad());
     v->set_parent(cg_f);
+    v->set_prohibit_clear_data(prohibit_clear_output);
     outputs[i] = v;
   }
   // Weak references are held inside.
@@ -60,7 +62,19 @@ vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
                               int n_outputs, vector<NdArrayPtr> inplace_outputs,
                               bool execute) {
   set_function_inputs(cg_f, inputs);
-  vector<CgVariablePtr> outputs = create_function_outputs(cg_f, n_outputs);
+
+  // check if data can be cleared or not.
+  bool persistent = false, inplace = false, prohibit_clear = false;
+  for (int i=0; i < inputs.size(); ++i) {
+    auto inp = inputs[i];
+    persistent |= inp->rank() == 0 || inp->persistent();
+    prohibit_clear |= inp->prohibit_clear_data();
+    inplace |= cg_f->function()->inplace_data(i) > 0;
+  }
+
+  bool prohibit_output_clear = (prohibit_clear || persistent) && inplace;
+
+  vector<CgVariablePtr> outputs = create_function_outputs(cg_f, n_outputs, prohibit_output_clear);
 
   // Setup function.
   cg_f->setup();
@@ -127,6 +141,7 @@ void steal_variable_from_to(CgVariablePtr from, CgVariablePtr to) {
   } else {
     to->unset_need_grad();
   }
+  to->set_prohibit_clear_data(from->prohibit_clear_data());
 
   // F. Reference contents
   to->set_variable(from->variable());

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -36,8 +36,7 @@ static void set_function_inputs(CgFunctionPtr func,
   func->set_inputs_(inputs);
 }
 
-vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f,
-                                              int n_outputs,
+vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f, int n_outputs,
                                               bool prohibit_clear_output) {
   // Check inplace outputs size and create outputs.
   if (n_outputs < 0) {
@@ -65,7 +64,7 @@ vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
 
   // check if data can be cleared or not.
   bool persistent = false, inplace = false, prohibit_clear = false;
-  for (int i=0; i < inputs.size(); ++i) {
+  for (int i = 0; i < inputs.size(); ++i) {
     auto inp = inputs[i];
     persistent |= inp->rank() == 0 || inp->persistent();
     prohibit_clear |= inp->prohibit_clear_data();
@@ -74,7 +73,8 @@ vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
 
   bool prohibit_output_clear = (prohibit_clear || persistent) && inplace;
 
-  vector<CgVariablePtr> outputs = create_function_outputs(cg_f, n_outputs, prohibit_output_clear);
+  vector<CgVariablePtr> outputs =
+      create_function_outputs(cg_f, n_outputs, prohibit_output_clear);
 
   // Setup function.
   cg_f->setup();

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -120,7 +120,8 @@ public:
         continue;
       }
       if (vi->rank() == 0 || vi->persistent() ||
-          func->function()->inplace_data(i)) {
+          func->function()->inplace_data(i) ||
+          vi->prohibit_clear_data()) {
         continue;
       }
       if (clear_buffer_) {

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -120,8 +120,7 @@ public:
         continue;
       }
       if (vi->rank() == 0 || vi->persistent() ||
-          func->function()->inplace_data(i) ||
-          vi->prohibit_clear_data()) {
+          func->function()->inplace_data(i) || vi->prohibit_clear_data()) {
         continue;
       }
       if (clear_buffer_) {


### PR DESCRIPTION
To keep inplaced variable data from being removed unintentioanly by clear_buffer operation, the new flag named `prohibit_clear_data_` is added. 
This flag is used in the forward process of the core graph engine, and if ture, the data of the variable would not be removed by clear_buffer operation. 
The test cases are also added.