### PR TITLE
Double Backward for ChannelLast and Half Type

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -208,4 +208,5 @@
   MulN_Empty: 282
 11:
   RandomErase_ffFfFfFiBBiiBB: 285
-  Interpolate_iIiBB: 283
+12:
+  Interpolate_iIiBB: 286

--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -208,3 +208,4 @@
   MulN_Empty: 282
 11:
   RandomErase_ffFfFfFiBBiiBB: 285
+  Interpolate_iIiBB: 283

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -3826,7 +3826,7 @@ Signal Processing:
         doc: N-D array.
     function_ids:
       iIiB: 127
-      iIiBB: 283
+      iIiBB: 286
     c_runtime: not support
   FFT:
     snake_name: fft

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -3816,11 +3816,17 @@ Signal Processing:
           pixels.
         type: bool
         default: False if mode == 'nearest' else True
+      channel_last:
+        doc: If True, the last dimension is considered as channel dimension, a.k.a
+          NHWC order.
+        type: bool
+        default: 'False'
     outputs:
       y:
         doc: N-D array.
     function_ids:
       iIiB: 127
+      iIiBB: 283
     c_runtime: not support
   FFT:
     snake_name: fft

--- a/doc/contributing/add_function.md
+++ b/doc/contributing/add_function.md
@@ -144,6 +144,7 @@ cmake ..
 * Function class template (created only if they don't exist, and should be added to the Git version control)
   * `include/nbla/function/${snake_name}.hpp`
   * `src/nbla/function/generic/${snake_name}.cpp`
+  * `python/src/nnabla/backward_function/${snake_name}.py`
 
 * Template type instantiation of functions (overwritten)
   * `src/nbla/function/${snake_name}.cpp`
@@ -196,6 +197,18 @@ Implement the following three functions in the C++ file by adding your function 
 **Note:**
 The variable names must be valid names for Cython, Python and C++.   
 For example, the variable name lambda cannot be used for keywords, since it is an invalid name in Cython and Python, although it is valid in C++.   
+
+
+Optionally, if you need the gradient of gradient (i.e., double-backward) of the new function added, implement the following two methods:  
+1. **def backward_impl(self, inputs, outputs, prop_down, accum):**  
+   This method implements the backward pass of the backward function, meaning the gradient of gradient of the function added.  
+2. **def _create_forward_inputs_and_outputs(self, inputs, outputs):**  
+   You do not need to implement this method normally.  
+   This method creates the input and output variables used in the *def forward_impl(self, inputs, outputs):* of the backward function class.  
+   The exceptional case is for example the sigmoid funtion where the output of the forward\_impl of the forward function class is used again in the backward\_impl of the forward function class. Here, you have to implement this method to set the input and output variables manually.  
+   In this cases, the *def backward_impl(self, inputs, outputs, prop_down, accum):* implementation is slightly different since the inputs to the backward function class also contains the output of the forward function class in this case.  
+   See [sigmoid.py](https://github.com/sony/nnabla/blob/master/python/src/nnabla/backward_function/sigmoid.py) for details.  
+
 
 ## Write unit testing
 

--- a/include/nbla/function/interpolate.hpp
+++ b/include/nbla/function/interpolate.hpp
@@ -22,7 +22,7 @@
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_HEADER(Interpolate, const vector<int> &, const string &,
-                              bool);
+                              bool, bool);
 
 /**
 Resize an ND array with interpolation.
@@ -47,20 +47,23 @@ values of the input corner pixels.
  */
 template <typename T>
 class Interpolate
-    : public BaseFunction<const vector<int> &, const string &, bool> {
+    : public BaseFunction<const vector<int> &, const string &, bool, bool> {
 protected:
   const vector<int> output_size_;
   const string mode_;
   bool align_corners_;
+  bool channel_last_;
 
 public:
   Interpolate(const Context &ctx, const vector<int> &output_size,
-              const string &mode, bool align_corners)
-      : BaseFunction(ctx, output_size, mode, align_corners),
-        output_size_(output_size), mode_(mode), align_corners_(align_corners) {}
+              const string &mode, bool align_corners, bool channel_last)
+      : BaseFunction(ctx, output_size, mode, align_corners, channel_last),
+        output_size_(output_size), mode_(mode), align_corners_(align_corners),
+        channel_last_(channel_last) {}
   virtual ~Interpolate() {}
   virtual shared_ptr<Function> copy() const {
-    return create_Interpolate(ctx_, output_size_, mode_, align_corners_);
+    return create_Interpolate(ctx_, output_size_, mode_, align_corners_,
+                              channel_last_);
   }
   virtual int min_inputs() { return 1; }
   virtual int min_outputs() { return 1; }

--- a/include/nbla/function/max_pooling_backward.hpp
+++ b/include/nbla/function/max_pooling_backward.hpp
@@ -67,30 +67,6 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "MaxPoolingBackward"; }
-  // TODO: This must be overridden if any of input grad depends on a output
-  // data. See doc in function.hpp.
-  // virtual bool grad_depends_output_data(int i, int o) const {
-  // }
-  // TODO: If any of data/grad storage is inplaced with any of output, you must
-  // override some of these. See doc in function.hpp.
-  // virtual int inplace_data(int i) const {
-  // }
-  // virtual int inplace_data_with(int i) const {
-  // }
-  // virtual int inplace_grad(int i) const {
-  // }
-  // virtual int inplace_grad_with(int i) const {
-  // }
-  // TODO: If you want to avoid clearing input buffers in any case, define this
-  // function returning true.
-  // virtual bool prohibit_clear_input_buffers() const {
-  //   return true;
-  // }
-  // TODO: If you want to avoid zero-ing gradient of inputs even when accum is
-  // true, uncomment the following function definition.
-  // virtual bool prohibit_zero_input_grad() const {
-  //   return true;
-  // }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/python/src/nnabla/backward_function/average_pooling.py
+++ b/python/src/nnabla/backward_function/average_pooling.py
@@ -53,9 +53,6 @@ class AveragePoolingBackward(BackwardFunction):
         channel_last = self.forward_func.info.args["channel_last"]
         including_pad = self.forward_func.info.args["including_pad"]
 
-        # TODO: BHWC
-        assert channel_last == False, "`channel_last = False` is only supported now."
-
         # Inputs
         x0 = inputs[0].data
         dy = inputs[1].data

--- a/python/src/nnabla/backward_function/interpolate.py
+++ b/python/src/nnabla/backward_function/interpolate.py
@@ -50,6 +50,7 @@ class InterpolateBackward(BackwardFunction):
         output_size = self.forward_func.info.args["output_size"]
         mode = self.forward_func.info.args["mode"]
         align_corners = self.forward_func.info.args["align_corners"]
+        channel_last = self.forward_func.info.args["channel_last"]
 
         # Inputs
         x0 = inputs[0].data
@@ -65,7 +66,8 @@ class InterpolateBackward(BackwardFunction):
         # Computation
         if prop_down[1]:
             g_dy_ = F.interpolate(
-                g_dx0, output_size=output_size, mode=mode, align_corners=align_corners)
+                g_dx0, output_size=output_size, mode=mode, align_corners=align_corners,
+                channel_last=channel_last)
             if accum[1]:
                 g_dy += g_dy_
             else:

--- a/python/src/nnabla/backward_function/max_pooling.py
+++ b/python/src/nnabla/backward_function/max_pooling.py
@@ -46,6 +46,8 @@ class MaxPoolingBackward(BackwardFunction):
         # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
         # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
 
+        assert len(inputs[0].shape) > 3, "len(inputs[0] shape) should be greater than 3."
+
         # Args
         kernel = self.forward_func.info.args["kernel"]
         stride = self.forward_func.info.args["stride"]

--- a/python/src/nnabla/backward_function/max_pooling.py
+++ b/python/src/nnabla/backward_function/max_pooling.py
@@ -46,7 +46,8 @@ class MaxPoolingBackward(BackwardFunction):
         # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
         # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
 
-        assert len(inputs[0].shape) > 3, "len(inputs[0] shape) should be greater than 3."
+        assert len(
+            inputs[0].shape) > 3, "len(inputs[0] shape) should be greater than 3."
 
         # Args
         kernel = self.forward_func.info.args["kernel"]

--- a/python/src/nnabla/backward_function/sum_pooling.py
+++ b/python/src/nnabla/backward_function/sum_pooling.py
@@ -52,9 +52,6 @@ class SumPoolingBackward(BackwardFunction):
         pad = self.forward_func.info.args["pad"]
         channel_last = self.forward_func.info.args["channel_last"]
 
-        # TODO: BHWC
-        assert channel_last == False, "`channel_last = False` is only supported now."
-
         # Inputs
         x0 = inputs[0].data
         dy = inputs[1].data

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -658,7 +658,7 @@ def clip_by_norm(x, clip_norm, axis=None):
     return y
 
 
-def interpolate(x, scale=None, output_size=None, mode='linear', align_corners=None):
+def interpolate(x, scale=None, output_size=None, mode='linear', align_corners=None, channel_last=False):
     '''
     Resize an ND array with interpolation.
 
@@ -711,6 +711,7 @@ def interpolate(x, scale=None, output_size=None, mode='linear', align_corners=No
             same values with the input corner pixels.
             The default is ``None``, and it becomes ``True`` if mode is
             'linear', otherwise ``False``.
+        channel_last: Last dimension is the channel (NHWC order) if True.
 
     Returns:
         ~nnabla.Variable: N-D array.
@@ -721,14 +722,16 @@ def interpolate(x, scale=None, output_size=None, mode='linear', align_corners=No
     if scale is None and output_size is None:
         raise ValueError('Either scale or output_size must be given')
     elif output_size is None:
+        input_size = x.shape[-len(scale)-1:-1] if channel_last \
+          else x.shape[-len(scale):]
         output_size = [int(math.floor(s * d))
-                       for d, s in zip(x.shape[-len(scale):], scale)]
+                       for d, s in zip(input_size, scale)]
     if align_corners is None:
         if mode == 'linear':
             align_corners = True
         else:
             align_corners = False
-    return interpolate_base(x, output_size, mode, align_corners)
+    return interpolate_base(x, output_size, mode, align_corners, channel_last)
 
 
 def sort(x, axis=-1, reverse=False, with_index=False, only_index=False):

--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -47,10 +47,7 @@ class GradEndFunction(PythonFunction):
 class Grad(object):
 
     def __init__(self, ):
-        ctx = nn.get_current_context()
-        if "half" in [x.split(":")[-1] for x in ctx.backend]:
-            raise ValueError(
-                "Half is not supported up to now, context = {}".format(ctx))
+        pass
 
     def _force_list(self, x):
         if isinstance(x, list):

--- a/python/test/function/test_abs.py
+++ b/python/test/function/test_abs.py
@@ -46,4 +46,4 @@ def test_abs_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_add2.py
+++ b/python/test/function/test_add2.py
@@ -70,4 +70,4 @@ def test_add2_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_add_scalar.py
+++ b/python/test/function/test_add_scalar.py
@@ -46,4 +46,4 @@ def test_add_scalar_double_backward(seed, val, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_affine.py
+++ b/python/test/function/test_affine.py
@@ -56,7 +56,7 @@ def test_affine_forward_backward(seed, base_axis, weight_shape, bias,
 @pytest.mark.parametrize("ctx, func_name", ctxs)
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("base_axis, weight_shape",
-                         [(1, (12, 2, 3)), (2, (4, 4))])
+                         [(1, (12, 3, 4)), (2, (4, 4))])
 @pytest.mark.parametrize("bias", [True, False])
 def test_affine_double_backward(seed, base_axis, weight_shape, bias,
                                 ctx, func_name):

--- a/python/test/function/test_average_pooling.py
+++ b/python/test/function/test_average_pooling.py
@@ -136,13 +136,11 @@ def test_average_pooling_2d_double_backward(seed, inshape, kernel, stride, pad, 
                                             channel_last,
                                             including_pad, ctx, func_name):
     from nbla_test_utils import backward_function_tester
+    if channel_last and not func_name.endswith('Cudnn'):
+        pytest.skip('Channel last is only supported in Cudnn so far')
     if channel_last:
-        pytest.skip('Channel last is not supported in the double backward.')
-    # if channel_last and not func_name.endswith('Cudnn'):
-    #     pytest.skip('Channel last is only supported in Cudnn so far')
-    # if channel_last:
-    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
-    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+        t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+        inshape = tuple(inshape[i] for i in t.inv_axes)
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border,
@@ -167,13 +165,11 @@ def test_average_pooling_3d_double_backward(seed, inshape, kernel, stride, pad, 
                                             channel_last,
                                             including_pad, ctx, func_name):
     from nbla_test_utils import backward_function_tester
+    if channel_last and not func_name.endswith('Cudnn'):
+        pytest.skip('Channel last is only supported in Cudnn so far')
     if channel_last:
-        pytest.skip('Channel last is not supported in the double backward.')
-    # if channel_last and not func_name.endswith('Cudnn'):
-    #     pytest.skip('Channel last is only supported in Cudnn so far')
-    # if channel_last:
-    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
-    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+        t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+        inshape = tuple(inshape[i] for i in t.inv_axes)
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border,

--- a/python/test/function/test_broadcast.py
+++ b/python/test/function/test_broadcast.py
@@ -83,7 +83,7 @@ def test_broadcast_double_backward(ndim, broadcast_dim, seed, fname, ctx, func_n
                                  atol_accum=1e-3,
                                  dstep=1e-3,
                                  ctx=ctx, func_name=None,
-                                 disable_half_test=True)
+                                 disable_half_test=False)
 
     inputs = [np.array(rng.randn(*inshape)).astype("float32")]
     backward_function_tester(rng, F.broadcast, None,
@@ -94,4 +94,4 @@ def test_broadcast_double_backward(ndim, broadcast_dim, seed, fname, ctx, func_n
                              atol_accum=2e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_concatenate.py
+++ b/python/test/function/test_concatenate.py
@@ -71,4 +71,4 @@ def test_concatenate_double_backward(seed, axis, different_size, num_inputs, ctx
                              atol_accum=1e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_convolution.py
+++ b/python/test/function/test_convolution.py
@@ -138,27 +138,25 @@ def core_test_convolution_double_backward(inshape, kernel, outmaps, pad, stride,
                                           dilation, group, channel_last, with_bias, seed, ctx,
                                           func_name, atol_f=1e-4, atol_b=1e-1, atol_accum=1e-1, dstep=1e-3):
     from nbla_test_utils import backward_function_tester, cap_ignore_region
-    if channel_last:
-        pytest.skip('Channel last is not supported in the double backward.')
 
     if func_name == 'ConvolutionCuda':
         pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
-    # if channel_last and not func_name.endswith('Cudnn'):
-    # pytest.skip(
-    # 'channel_last=True is only supported in CUDNN backend so far.')
-    # if channel_last and func_name.endswith('Cudnn') and (np.any(np.asarray(dilation) > 1) or group > 1):
-    ##     import nnabla_ext.cuda as nc
-    ##     major, minor, revision = map(int, nc.__cudnn_version__.split('.'))
-    ##     version = major * 1000 + minor * 100
-    # if version < 7200:
-    # pytest.skip(
-    # 'channel_last dilated convolution not work in CUDNN {}.'.format(version))
+    if channel_last and not func_name.endswith('Cudnn'):
+        pytest.skip(
+            'channel_last=True is only supported in CUDNN backend so far.')
+    if channel_last and func_name.endswith('Cudnn') and (np.any(np.asarray(dilation) > 1) or group > 1):
+        import nnabla_ext.cuda as nc
+        major, minor, revision = map(int, nc.__cudnn_version__.split('.'))
+        version = major * 1000 + minor * 100
+        if version < 7200:
+            pytest.skip(
+                'channel_last dilated convolution not work in CUDNN {}.'.format(version))
 
     base_axis = len(inshape) - len(kernel) - 1
     inmaps = inshape[base_axis]
-    # if channel_last:
-    ##     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
-    ##     inshape = tuple(inshape[i] for i in t.inv_axes)
+    if channel_last:
+        t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+        inshape = tuple(inshape[i] for i in t.inv_axes)
     rng = np.random.RandomState(seed)
     i = rng.randn(*inshape).astype(np.float32)
     kshape = (outmaps,) + (inmaps // group,) + kernel
@@ -222,9 +220,15 @@ def test_convolution_2d_double_backward(inshape, kernel, outmaps, pad, stride,
 @pytest.mark.parametrize("group", [1, 2])
 @pytest.mark.parametrize("channel_last", [False, True])
 @pytest.mark.parametrize("with_bias", [True, False])
-def test_convolution_3d_double_backward_with_bias(inshape, kernel, outmaps, pad, stride,
-                                                  dilation, group, channel_last, with_bias, seed, ctx,
-                                                  func_name):
+def test_convolution_3d_double_backward(inshape, kernel, outmaps, pad, stride,
+                                        dilation, group, channel_last, with_bias, seed, ctx,
+                                        func_name):
+    if channel_last:
+        pytest.skip('3d')
+    import platform
+    if platform.system() == "Linux" and platform.uname().machine not in ["x86_64", "ppc64le"]:
+        pytest.skip('Convolution 3-D for x86_64 and ppc64 are only supported.')
+
     core_test_convolution_double_backward(inshape, kernel, outmaps, pad, stride,
                                           dilation, group, channel_last, with_bias, seed, ctx,
                                           func_name, atol_b=3e-1, atol_accum=3e-1, dstep=1e-3)

--- a/python/test/function/test_convolution.py
+++ b/python/test/function/test_convolution.py
@@ -231,4 +231,4 @@ def test_convolution_3d_double_backward(inshape, kernel, outmaps, pad, stride,
 
     core_test_convolution_double_backward(inshape, kernel, outmaps, pad, stride,
                                           dilation, group, channel_last, with_bias, seed, ctx,
-                                          func_name, atol_b=3e-1, atol_accum=3e-1, dstep=1e-3)
+                                          func_name, atol_b=3e-1, atol_accum=3e-1, dstep=5e-4)

--- a/python/test/function/test_deconvolution.py
+++ b/python/test/function/test_deconvolution.py
@@ -102,7 +102,7 @@ def test_deconvolution_2d_double_backward(inshape, kernel, outmaps, pad, stride,
     base_axis = len(inshape) - 3
     b = None
     if with_bias:
-        b = rng.randn(outmaps).astype(np.float32) * 1e3  # long tailed
+        b = rng.randn(outmaps).astype(np.float32)
     inputs = [i, k, b]
     backward_function_tester(rng, F.deconvolution, None, inputs,
                              func_args=[base_axis, pad,

--- a/python/test/function/test_div2.py
+++ b/python/test/function/test_div2.py
@@ -34,4 +34,4 @@ def test_div2_double_backward(seed, ctx, func_name):
                              atol_accum=1e-1,
                              dstep=1e-4,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_elu.py
+++ b/python/test/function/test_elu.py
@@ -50,4 +50,4 @@ def test_elu_double_backward(seed, alpha, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_exp.py
+++ b/python/test/function/test_exp.py
@@ -43,4 +43,4 @@ def test_exp_double_backward(seed, ctx, func_name):
                              atol_accum=1e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_hard_sigmoid.py
+++ b/python/test/function/test_hard_sigmoid.py
@@ -52,4 +52,4 @@ def test_hard_sigmoid_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_hard_tanh.py
+++ b/python/test/function/test_hard_tanh.py
@@ -53,4 +53,4 @@ def test_hard_tanh_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_identity.py
+++ b/python/test/function/test_identity.py
@@ -47,4 +47,4 @@ def test_identity_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_leaky_relu.py
+++ b/python/test/function/test_leaky_relu.py
@@ -66,6 +66,6 @@ def test_relu_double_backward(seed, alpha, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)
 
 # TODO: inplace double_backward

--- a/python/test/function/test_log.py
+++ b/python/test/function/test_log.py
@@ -45,4 +45,4 @@ def test_log_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_log_sigmoid.py
+++ b/python/test/function/test_log_sigmoid.py
@@ -49,4 +49,4 @@ def test_log_sigmoid_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_max_pooling.py
+++ b/python/test/function/test_max_pooling.py
@@ -129,13 +129,11 @@ def test_max_pooling_3d(seed, inshape, kernel, stride, pad, ignore_border, chann
 def test_max_pooling_2d_double_backward(seed, inshape, kernel, stride, pad, ignore_border, channel_last,
                                         ctx, func_name):
     from nbla_test_utils import backward_function_tester, cap_ignore_region
+    if channel_last and not func_name.endswith('Cudnn'):
+        pytest.skip('Channel last is only supported in Cudnn so far')
     if channel_last:
-        pytest.skip('Channel last is not supported in the double backward.')
-    # if channel_last and not func_name.endswith('Cudnn'):
-    ##     pytest.skip('Channel last is only supported in Cudnn so far')
-    # if channel_last:
-    ##     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
-    ##     inshape = tuple(inshape[i] for i in t.inv_axes)
+        t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+        inshape = tuple(inshape[i] for i in t.inv_axes)
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border, pad, channel_last]
@@ -160,13 +158,11 @@ def test_max_pooling_3d_double_backward(seed, inshape, kernel, stride, pad, igno
     # pytest.skip('`>3`-dimension are not supported.')
     # TODO: some test fail
     from nbla_test_utils import backward_function_tester, cap_ignore_region
+    if channel_last and not func_name.endswith('Cudnn'):
+        pytest.skip('Channel last is only supported in Cudnn so far')
     if channel_last:
-        pytest.skip('Channel last is not supported in the double backward.')
-    # if channel_last and not func_name.endswith('Cudnn'):
-    ##     pytest.skip('Channel last is only supported in Cudnn so far')
-    # if channel_last:
-    ##     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
-    ##     inshape = tuple(inshape[i] for i in t.inv_axes)
+        t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+        inshape = tuple(inshape[i] for i in t.inv_axes)
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border, pad, channel_last]

--- a/python/test/function/test_maximum2.py
+++ b/python/test/function/test_maximum2.py
@@ -38,4 +38,4 @@ def test_maximum2_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_maximum_scalar.py
+++ b/python/test/function/test_maximum_scalar.py
@@ -46,4 +46,4 @@ def test_maximum_scalar_double_backward(seed, val, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_minimum2.py
+++ b/python/test/function/test_minimum2.py
@@ -38,4 +38,4 @@ def test_minimum2_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_minimum_scalar.py
+++ b/python/test/function/test_minimum_scalar.py
@@ -46,4 +46,4 @@ def test_minimum_scalar_double_backward(seed, val, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_mul2.py
+++ b/python/test/function/test_mul2.py
@@ -34,4 +34,4 @@ def test_mul2_double_backward(seed, ctx, func_name):
                              atol_accum=1e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_mul_scalar.py
+++ b/python/test/function/test_mul_scalar.py
@@ -46,4 +46,4 @@ def test_mul_scalar_double_backward(seed, val, ctx, func_name):
                              atol_accum=2e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_pow2.py
+++ b/python/test/function/test_pow2.py
@@ -34,4 +34,4 @@ def test_pow2_double_backward(seed, ctx, func_name):
                              atol_accum=5e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_pow_scalar.py
+++ b/python/test/function/test_pow_scalar.py
@@ -46,4 +46,4 @@ def test_pow_scalar_double_backward(seed, val, ctx, func_name):
                              atol_accum=1e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_prune.py
+++ b/python/test/function/test_prune.py
@@ -50,5 +50,5 @@ def test_prune_forward_backward(rate, seed, ctx, func_name):
 
     function_tester(rng, F.prune, ref_func_prune, inputs, func_args=[rate],
                     ctx=ctx, func_name=func_name,
-                    ref_grad=ref_grad_prune)
-    # disable_half_test=True)
+                    ref_grad=ref_grad_prune, 
+                    disable_half_test=True)

--- a/python/test/function/test_prune.py
+++ b/python/test/function/test_prune.py
@@ -50,5 +50,5 @@ def test_prune_forward_backward(rate, seed, ctx, func_name):
 
     function_tester(rng, F.prune, ref_func_prune, inputs, func_args=[rate],
                     ctx=ctx, func_name=func_name,
-                    ref_grad=ref_grad_prune, 
+                    ref_grad=ref_grad_prune,
                     disable_half_test=True)

--- a/python/test/function/test_r_div_scalar.py
+++ b/python/test/function/test_r_div_scalar.py
@@ -50,4 +50,4 @@ def test_r_div_scalar_double_backward(seed, val, ctx, func_name):
                              atol_accum=1e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_r_sub_scalar.py
+++ b/python/test/function/test_r_sub_scalar.py
@@ -50,4 +50,4 @@ def test_r_sub_scalar_double_backward(seed, val, ctx, func_name):
                              atol_b=1e-3, atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_reduction.py
+++ b/python/test/function/test_reduction.py
@@ -57,7 +57,7 @@ def test_large_sum_reduction(seed, inshape, axis, ctx, func_name):
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     function_tester(rng, F.sum, np.sum, inputs, ctx=ctx, func_name=func_name,
-                    func_args=[axis], atol_b=1e-2, disable_half_test=True)
+                    func_args=[axis], atol_b=1e-2, disable_half_test=False)
 
 
 @pytest.mark.parametrize("seed", [313])

--- a/python/test/function/test_relu.py
+++ b/python/test/function/test_relu.py
@@ -63,7 +63,7 @@ def test_relu_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)
 
 
 # TODO: inplace double_backward

--- a/python/test/function/test_relu6.py
+++ b/python/test/function/test_relu6.py
@@ -49,4 +49,4 @@ def test_relu6_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_reshape.py
+++ b/python/test/function/test_reshape.py
@@ -68,7 +68,7 @@ def test_reshape_double_backward(seed, ctx, func_name, inshape, outshape):
                              atol_accum=5e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)
 
 
 # TODO: inplace double_backward

--- a/python/test/function/test_selu.py
+++ b/python/test/function/test_selu.py
@@ -52,4 +52,4 @@ def test_selu_double_backward(seed, scale, alpha, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_sigmoid.py
+++ b/python/test/function/test_sigmoid.py
@@ -46,4 +46,4 @@ def test_sigmoid_double_backward(seed, ctx, func_name):
                              atol_b=1e-3, atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_split.py
+++ b/python/test/function/test_split.py
@@ -62,4 +62,4 @@ def test_split_double_backward(seed, axis, ctx, func_name):
                              atol_accum=5e-3,
                              dstep=1e-2,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_stack.py
+++ b/python/test/function/test_stack.py
@@ -55,4 +55,4 @@ def test_stack_double_backward(seed, axis, num_inputs, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_sub2.py
+++ b/python/test/function/test_sub2.py
@@ -38,4 +38,4 @@ def test_sub2_double_backward(seed, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_sum_pooling.py
+++ b/python/test/function/test_sum_pooling.py
@@ -79,6 +79,8 @@ def test_sum_pooling_2d(seed, inshape, kernel, stride, pad, ignore_border, chann
     if channel_last:
         t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
         inshape = tuple(inshape[i] for i in t.inv_axes)
+    if not ignore_border and func_name.endswith('Cudnn'):
+        pytest.skip('ignore_border=False in Cudnn is not supported.')
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border, pad, channel_last]
@@ -103,12 +105,14 @@ def test_sum_pooling_3d(seed, inshape, kernel, stride, pad, ignore_border, chann
     if channel_last:
         t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
         inshape = tuple(inshape[i] for i in t.inv_axes)
+    if not ignore_border and func_name.endswith('Cudnn'):
+        pytest.skip('ignore_border=False in Cudnn is not supported.')
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border, pad, channel_last]
     function_tester(rng, F.sum_pooling, ref_sum_pooling, inputs=inputs,
                     func_args=func_args, func_name=func_name, ctx=ctx,
-                    atol_f=1e-6, atol_b=1e-2)
+                    atol_f=1e-6, atol_b=5e-2, atol_accum=1e-2)
 
 
 @pytest.mark.parametrize("ctx, func_name", ctxs)
@@ -122,13 +126,13 @@ def test_sum_pooling_3d(seed, inshape, kernel, stride, pad, ignore_border, chann
 def test_sum_pooling_2d_double_backward(seed, inshape, kernel, stride, pad, ignore_border, channel_last,
                                         ctx, func_name):
     from nbla_test_utils import backward_function_tester
+    if channel_last and not func_name.endswith('Cudnn'):
+        pytest.skip('Channel last is only supported in Cudnn so far')
     if channel_last:
-        pytest.skip('Channel last is not supported in the double backward.')
-    # if channel_last and not func_name.endswith('Cudnn'):
-    #     pytest.skip('Channel last is only supported in Cudnn so far')
-    # if channel_last:
-    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
-    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+        t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+        inshape = tuple(inshape[i] for i in t.inv_axes)
+    if not ignore_border and func_name.endswith('Cudnn'):
+        pytest.skip('ignore_border=False in Cudnn is not supported.')
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border, pad, channel_last]
@@ -148,13 +152,13 @@ def test_sum_pooling_2d_double_backward(seed, inshape, kernel, stride, pad, igno
 def test_sum_pooling_3d_double_backward(seed, inshape, kernel, stride, pad, ignore_border, channel_last,
                                         ctx, func_name):
     from nbla_test_utils import backward_function_tester
+    if channel_last and not func_name.endswith('Cudnn'):
+        pytest.skip('Channel last is only supported in Cudnn so far')
     if channel_last:
-        pytest.skip('Channel last is not supported in the double backward.')
-    # if channel_last and not func_name.endswith('Cudnn'):
-    #     pytest.skip('Channel last is only supported in Cudnn so far')
-    # if channel_last:
-    #     t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
-    #     inshape = tuple(inshape[i] for i in t.inv_axes)
+        t = refs.ChannelLastToFirstTranspose(len(inshape), len(kernel))
+        inshape = tuple(inshape[i] for i in t.inv_axes)
+    if not ignore_border and func_name.endswith('Cudnn'):
+        pytest.skip('ignore_border=False in Cudnn is not supported.')
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]
     func_args = [kernel, stride, ignore_border, pad, channel_last]

--- a/python/test/function/test_swish.py
+++ b/python/test/function/test_swish.py
@@ -50,4 +50,4 @@ def test_swish_double_backward(seed, ctx, func_name):
                              atol_accum=1e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/function/test_tanh.py
+++ b/python/test/function/test_tanh.py
@@ -45,4 +45,4 @@ def test_tanh_double_backward(seed, ctx, func_name):
                              atol_accum=1e-2,
                              dstep=1e-3,
                              ctx=ctx, func_name=None,
-                             disable_half_test=True)
+                             disable_half_test=False)

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -696,8 +696,6 @@ def backward_function_tester(rng, func, ref_func, inputs,
     In the forward test, it compares the results of nn.grad and `func`.backward.
     In the backward test, it compares the analytical gradients and numerical gradient with `grad_outputs`.
     """
-    # TODO: half
-
     from scipy.optimize import approx_fprime
 
     if ctx is None:
@@ -777,12 +775,12 @@ def backward_function_tester(rng, func, ref_func, inputs,
         gp2.forward()
         return gp2.d.copy()
 
-    # # Half test
-    # if not disable_half_test:
-    #     finputs = create_variables(inputs, backward)
-    #     hinputs = create_variables(inputs, backward)
-    #     half_test(rng, func, finputs, hinputs, func_args,
-    #               func_kwargs, backward, ctx, func_name, atol=atol_half)
+    # Half test
+    if not disable_half_test:
+        finputs = create_variables(inputs, backward)
+        hinputs = create_variables(inputs, backward)
+        half_test(rng, func, finputs, hinputs, func_args,
+                  func_kwargs, backward, ctx, func_name, atol=atol_half)
 
     # Create input variables
     vinputs = create_variables(inputs, backward)

--- a/src/nbla/function/generic/max_pooling_backward.cpp
+++ b/src/nbla/function/generic/max_pooling_backward.cpp
@@ -158,6 +158,10 @@ void MaxPoolingBackward<T>::backward_impl(const Variables &inputs,
                                           const Variables &outputs,
                                           const vector<bool> &propagate_down,
                                           const vector<bool> &accum) {
+  NBLA_CHECK(!this->channel_last_, error_code::not_implemented,
+             "The passed argument channel_last=true is not supported in CPU "
+             "pooling.");
+
   if (!(propagate_down[0] || propagate_down[1])) {
     return;
   }


### PR DESCRIPTION
Double backward (aka grad of grad) supports the following functions with the channel last tensor format and the half data type for utilizing NVIDIA TensorCore: 
- Convolution
- Deconvolution
- MaxPooling
- AveragePooling
- SumPooling
- Interpolate (linear and nearest)