### PR TITLE
change data type of size from int to int64 to fix overflow.

### DIFF
--- a/include/nbla/function/batch_normalization.hpp
+++ b/include/nbla/function/batch_normalization.hpp
@@ -85,7 +85,7 @@ protected:
   bool batch_stat_;
   Variable mean_;
   Variable var_;
-  int size0_, size1_, size2_, size02_, size12_;
+  Size_t size0_, size1_, size2_, size02_, size12_;
   shared_ptr<Function> identity_;
   shared_ptr<Function> add2_;
   shared_ptr<Function> sub2_;

--- a/include/nbla/function/categorical_cross_entropy.hpp
+++ b/include/nbla/function/categorical_cross_entropy.hpp
@@ -56,7 +56,7 @@ template <typename T, typename Tl = int>
 class CategoricalCrossEntropy : public BaseFunction<int> {
 protected:
   int axis_;
-  int size0_, size1_, size2_;
+  Size_t size0_, size1_, size2_;
 
 public:
   CategoricalCrossEntropy(const Context &ctx, int axis)

--- a/include/nbla/function/confusion_matrix.hpp
+++ b/include/nbla/function/confusion_matrix.hpp
@@ -46,7 +46,7 @@ class.
 template <typename T, typename T1> class ConfusionMatrix : public Function {
 protected:
   int axis_;
-  int size0_, size1_, size2_;
+  Size_t size0_, size1_, size2_;
 
 public:
   ConfusionMatrix(const Context &ctx, int axis) : Function(ctx), axis_(axis) {}

--- a/include/nbla/function/crelu.hpp
+++ b/include/nbla/function/crelu.hpp
@@ -51,7 +51,7 @@ Units (ELUs). https://arxiv.org/abs/1511.07289
 template <typename T> class CReLU : public BaseFunction<int> {
 protected:
   int axis_;
-  int size0_, size1_;
+  Size_t size0_, size1_;
 
 public:
   CReLU(const Context &ctx, int axis) : BaseFunction(ctx, axis), axis_(axis) {}

--- a/include/nbla/function/log_softmax.hpp
+++ b/include/nbla/function/log_softmax.hpp
@@ -42,7 +42,7 @@ Outputs:
 template <typename T> class LogSoftmax : public BaseFunction<int> {
 protected:
   int axis_;
-  int size0_, size1_, size2_;
+  Size_t size0_, size1_, size2_;
 
 public:
   LogSoftmax(const Context &ctx, int axis)

--- a/include/nbla/function/mean_subtraction.hpp
+++ b/include/nbla/function/mean_subtraction.hpp
@@ -70,7 +70,7 @@ protected:
   int base_axis_;
   bool update_running_mean_;
   Variable mean_;
-  int size0_, size1_;
+  Size_t size0_, size1_;
 
 public:
   MeanSubtraction(const Context &ctx, int base_axis, bool update_running_mean)

--- a/include/nbla/function/softmax.hpp
+++ b/include/nbla/function/softmax.hpp
@@ -50,7 +50,7 @@ Outputs:
 template <typename T> class Softmax : public BaseFunction<int> {
 protected:
   int axis_;
-  int size0_, size1_, size2_;
+  Size_t size0_, size1_, size2_;
 
 public:
   Softmax(const Context &ctx, int axis)

--- a/include/nbla/function/softmax_cross_entropy.hpp
+++ b/include/nbla/function/softmax_cross_entropy.hpp
@@ -59,7 +59,7 @@ template <typename T, typename Tl = int>
 class SoftmaxCrossEntropy : public BaseFunction<int> {
 protected:
   int axis_;
-  int size0_, size1_, size2_;
+  Size_t size0_, size1_, size2_;
   shared_ptr<Function> log_softmax_;
   Variable log_softmax_output_;
 


### PR DESCRIPTION
In some functions, overflow might be happened when the input array is quite big.
This PR fixes this issue.

nnabla-ext-cuda: https://github.com/sony/nnabla-ext-cuda/pull/221