### PR TITLE
Interpolation with half_pixel and half_pixel_for_nn

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -215,3 +215,5 @@
   RandBeta_ffiIi: 288
   RandBinomial_ifiIi: 289
   RandGamma_ffiIi: 290
+14:
+  Interpolate_iIiBBBB: 291

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -3819,9 +3819,21 @@ Signal Processing:
       align_corners:
         doc: If true, the corner pixels of input and output arrays are aligned, such
           that the output corner pixels have the same values with the input corner
-          pixels.
+          pixels. The default is ``None``, and it becomes `True` if mode is 'linear',
+          otherwise `False`.
         type: bool
-        default: False if mode == 'nearest' else True
+        default: 'True'
+      half_pixel:
+        doc: If true, in the coordinate transformation, 0.5 is added to the output
+          coordinate and 0.5 is subtracted from the input coordinate after scaling.
+        type: bool
+        default: 'False'
+      half_pixel_for_nn:
+        doc: This is a special argument to support the backward-compatibility of the
+          nearest neighbor interpolation. Default is `False`. When in ``True``, the
+          implementation of nearest neighbor interpolation is the old one.
+        type: bool
+        default: 'False'
       channel_last:
         doc: If True, the last dimension is considered as channel dimension, a.k.a
           NHWC order.
@@ -3833,6 +3845,7 @@ Signal Processing:
     function_ids:
       iIiB: 127
       iIiBB: 286
+      iIiBBBB: 291
     c_runtime: not support
   FFT:
     snake_name: fft

--- a/include/nbla/function/interpolate.hpp
+++ b/include/nbla/function/interpolate.hpp
@@ -22,7 +22,7 @@
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_HEADER(Interpolate, const vector<int> &, const string &,
-                              bool, bool);
+                              bool, bool, bool, bool);
 
 /**
 Resize an ND array with interpolation.
@@ -42,28 +42,42 @@ dimensions are replaced with the output_size.
 @param mode Interpolation mode chosen from linear or nearest.
 @param align_corners If true, the corner pixels are aligned to preserve the
 values of the input corner pixels.
+@param half_pixel If true, in the coordinate transformation, 0.5 is added to the
+output coordinate
+and 0.5 is subtracted from the input coordinate after scaling. Default is
+`False`.
+This option is only applicable to the `mode` being linear.
+@param half_pixel_for_nn This is a special argument to support the
+backward-compatibility of the nearest neighbor interpolation. Default is
+`False`.
+
 
 \ingroup FunctionImplGrp
  */
 template <typename T>
-class Interpolate
-    : public BaseFunction<const vector<int> &, const string &, bool, bool> {
+class Interpolate : public BaseFunction<const vector<int> &, const string &,
+                                        bool, bool, bool, bool> {
 protected:
   const vector<int> output_size_;
   const string mode_;
   bool align_corners_;
+  bool half_pixel_;
+  bool half_pixel_for_nn_;
   bool channel_last_;
 
 public:
   Interpolate(const Context &ctx, const vector<int> &output_size,
-              const string &mode, bool align_corners, bool channel_last)
-      : BaseFunction(ctx, output_size, mode, align_corners, channel_last),
+              const string &mode, bool align_corners, bool half_pixel,
+              bool half_pixel_for_nn, bool channel_last)
+      : BaseFunction(ctx, output_size, mode, align_corners, half_pixel,
+                     half_pixel_for_nn, channel_last),
         output_size_(output_size), mode_(mode), align_corners_(align_corners),
+        half_pixel_(half_pixel), half_pixel_for_nn_(half_pixel_for_nn),
         channel_last_(channel_last) {}
   virtual ~Interpolate() {}
   virtual shared_ptr<Function> copy() const {
     return create_Interpolate(ctx_, output_size_, mode_, align_corners_,
-                              channel_last_);
+                              half_pixel_, half_pixel_for_nn_, channel_last_);
   }
   virtual int min_inputs() { return 1; }
   virtual int min_outputs() { return 1; }

--- a/python/src/nnabla/backward_function/interpolate.py
+++ b/python/src/nnabla/backward_function/interpolate.py
@@ -50,6 +50,8 @@ class InterpolateBackward(BackwardFunction):
         output_size = self.forward_func.info.args["output_size"]
         mode = self.forward_func.info.args["mode"]
         align_corners = self.forward_func.info.args["align_corners"]
+        half_pixel = self.forward_func.info.args["half_pixel"]
+        half_pixel_for_nn = self.forward_func.info.args["half_pixel_for_nn"]
         channel_last = self.forward_func.info.args["channel_last"]
 
         # Inputs
@@ -66,7 +68,9 @@ class InterpolateBackward(BackwardFunction):
         # Computation
         if prop_down[1]:
             g_dy_ = F.interpolate(
-                g_dx0, output_size=output_size, mode=mode, align_corners=align_corners,
+                g_dx0, output_size=output_size, mode=mode,
+                align_corners=align_corners, half_pixel=half_pixel,
+                half_pixel_for_nn=half_pixel_for_nn,
                 channel_last=channel_last)
             if accum[1]:
                 g_dy += g_dy_


### PR DESCRIPTION
For ONNX conversion and further conversion from ONNX to runtime libraries, the interpolation function now includes half_pixel and half_pixel_for_nn options and also are addressed for ONNX opset_10 supports. The half_pixel_for_nn options is for the backward-compat.