### PR TITLE
alleviate test for gamma

### DIFF
--- a/python/test/function/test_random_functions.py
+++ b/python/test/function/test_random_functions.py
@@ -17,6 +17,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+import platform
 
 ctxs_rand = list_context('Rand')
 ctxs_randint = list_context('Randint')
@@ -145,6 +146,7 @@ def test_rand_binomial_forward(seed, ctx, func_name, n, p, shape):
 @pytest.mark.parametrize("k, theta", [(1, 2), (9, 0.5), (3, 2), (7.5, 1), (0.5, 1)])
 @pytest.mark.parametrize("shape", [[50], [100, 100], [1000, 1000]])
 @pytest.mark.parametrize("seed", [-1, 313])
+@pytest.mark.skipif(platform.system() == "Darwin", reason='skipped on mac')
 def test_rand_gamma_forward(seed, ctx, func_name, k, theta, shape):
     with nn.context_scope(ctx):
         o = F.rand_gamma(k, theta, shape, seed=seed)


### PR DESCRIPTION
workaround for a known issue about `test_random_functions.py` on Mac OS X.