### PR TITLE
Suppress warning due to uninitialized NdArray

### DIFF
--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -87,11 +87,11 @@ cdef c_as_numpy_array(CNdArray * arrp, str mode, cpp_bool force_dtype=False, int
             type_num = <int > arrp.array().get().dtype()
         except:
             from nnabla import logger
-            logger.info('Calling the `.data` getter property in this `NdArray` '
-                        'is creating an array with a default data type because '
-                        'the array is not previously initialized by requesting '
-                        'a specific data type, or is not used after '
-                        'calling `zero()` or `fill(value)`.')
+            logger.debug('Calling the `.data` getter property in this `NdArray` '
+                         'is creating an array with a default data type because '
+                         'the array is not previously initialized by requesting '
+                         'a specific data type, or is not used after '
+                         'calling `zero()` or `fill(value)`.')
 
     # Create numpy shape array
     shape.resize(arrp.ndim())


### PR DESCRIPTION
This suppresses an warning message caused by touching uninitialized array with read-access because we noticed that this warning message makes user's stdout logs dirty. As it's not critical, we change the log level to debug.