### PR TITLE
Add FusedConvolution interface and some enhancements & fixes

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -222,3 +222,5 @@
 16:
   DequantizeLinear_Empty: 294
   QuantizeLinear_iBi: 293
+17:
+  FusedConvolution_iiIiIiIiBffBifF: 295

--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -13,6 +13,9 @@ GRU:
 Convolution:
   float: [float]
   half: [Half]
+FusedConvolution:
+  float: [float]
+  half: [Half]
 DepthwiseConvolution:
   float: [float]
   half: [Half]

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -457,7 +457,7 @@ Neural Network Layer:
         doc: N-D array
     c_runtime: not support
     function_ids:
-      iiIiIiIiBffBifF: 293
+      iiIiIiIiBffBifF: 295
   DepthwiseConvolution:
     snake_name: depthwise_convolution
     doc: |2

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -323,6 +323,141 @@ Neural Network Layer:
       iiIiIiIi: 1
       iiIiIiIiB: 265
     c_runtime: support
+  FusedConvolution:
+    snake_name: fused_convolution
+    doc: |2
+
+      Fused operation of Convolution, Batch Normalization, Add2 and Activation.
+
+      This is an equivalent operation to the following,
+      but may be more computationally efficient depending on the backend implementation
+      (currently we don't provide an efficient implementation on any backend).
+
+      .. code-block:: python
+
+        h = F.convolution(x, weight, bias, *conv_opts)
+        h = F.batch_normalization(h, beta, gamma, mean, variance, *bn_opts)
+        y = F.relu(h + z)
+
+      You can optionally disable either of batch normalization, residual addition and activation.
+    inputs:
+      x:
+        doc: N-D array of input.
+      weight:
+        doc: |
+          `weight` in :meth:`~nnabla.functions.convolution`.
+        parameter: true
+      bias:
+        doc: |
+          `bias` in :meth:`~nnabla.functions.convolution`.
+        optional: true
+        parameter: true
+      beta:
+        doc: |
+          `beta` in :meth:`~nnabla.functions.batch_normalization`.
+        optional: true
+        parameter: true
+      gamma:
+        doc: |
+          `gamma` in :meth:`~nnabla.functions.batch_normalization`.
+        optional: true
+        parameter: true
+      mean:
+        optional: true
+        doc: |
+          `mean` in :meth:`~nnabla.functions.batch_normalization`.
+      variance:
+        optional: true
+        doc: |
+          `variance` in :meth:`~nnabla.functions.batch_normalization`.
+      z:
+        optional: true
+        doc: N-D array of a residual input. By specifying None, the activation function
+          will follow immediately after BN operation.
+    arguments:
+      base_axis:
+        doc: |
+          `base_axis` in :meth:`~nnabla.functions.convolution`. Note that the batch normalization `axes` is determined by this and `channel_last` option.
+        type: int64
+        default: '1'
+      pad:
+        doc: |
+          `pad` in :meth:`~nnabla.functions.convolution`.
+        type: Shape
+        default: (0,) * (len(x.shape) - (base_axis+1))
+      stride:
+        doc: |
+          `stride` in :meth:`~nnabla.functions.convolution`.
+        type: Shape
+        default: (1,) * (len(x.shape) - (base_axis+1))
+      dilation:
+        doc: |
+          `dilation` in :meth:`~nnabla.functions.convolution`.
+        type: Shape
+        default: (1,) * (len(x.shape) - (base_axis+1))
+      group:
+        doc: |
+          `group` in :meth:`~nnabla.functions.convolution`.
+        type: int64
+        default: '1'
+      channel_last:
+        doc: |
+          `channel_last` in :meth:`~nnabla.functions.convolution`.group
+        type: bool
+        default: 'False'
+      decay_rate:
+        doc: |
+          `decay_rate` in :meth:`~nnabla.functions.batch_normalization`.
+        type: float
+        default: '0.9'
+      eps:
+        doc: |
+          `eps` in :meth:`~nnabla.functions.batch_normalization`.
+        type: float
+        default: 1e-05
+      batch_stat:
+        doc: |
+          `batch_stat` in :meth:`~nnabla.functions.batch_normalization`.
+        type: bool
+        default: 'True'
+      nonlinearity:
+        doc: |
+          Activation type as string. The following is a list of available activation types
+          and optional parameters specified as a vector of float by `nonlinearity_args`.
+
+          =============== ===============================
+          Activation type Arguments (`nonlinearity_args`)
+          =============== ===============================
+          identity        No argument
+          relu            No argument
+          sigmoid         No argument
+          tanh            No argument
+          leaky_relu      [alpha] (see LeakyReLU doc)
+          elu             [alpha] (see ELU doc)
+          relu6           No argument
+          =============== ===============================
+        type: string
+        available_values:
+        - identity
+        - relu
+        - sigmoid
+        - tanh
+        - leaky_relu
+        - elu
+        - relu6
+        default: '''relu'''
+      nonlinearity_args:
+        doc: |
+          Optional arguments of nonlinearity as a vector of float.
+          See the description of the `nonlinearity` argument.
+        type: repeated float
+        default: list()
+    outputs:
+      y:
+        doc: N-D array
+    c_runtime: not support
+    function_ids:
+      iiIiIiIiBffBifF: 293
   DepthwiseConvolution:
     snake_name: depthwise_convolution
     doc: |2
@@ -1293,8 +1428,8 @@ Normalization:
 
       .. code-block:: python
 
-        h = nn.BatchNormalization(x, beta, gamma, mean, variance, *opts)
-        y = F.ReLU(h + z)
+        h = F.batch_normalization(x, beta, gamma, mean, variance, *opts)
+        y = F.relu(h + z)
     inputs:
       x:
         doc: N-D array of input.

--- a/doc/python/api/function.rst
+++ b/doc/python/api/function.rst
@@ -40,6 +40,7 @@ Neural Network Layers
 .. autofunction:: deconvolution
 .. autofunction:: depthwise_deconvolution
 .. autofunction:: adaptive_separable_convolution
+.. TODO: List fused_convolution once it becomes useful.
 .. autofunction:: max_pooling
 .. autofunction:: average_pooling
 .. autofunction:: global_average_pooling

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -96,15 +96,6 @@ class CgVariable {
   bool prohibit_clear_data_{false};
   string name_{""};
 
-  void
-  visit_function_recursive(CgFunctionPtr func,
-                           unordered_set<CgFunctionPtr> &fclosed,
-                           std::function<void(CgFunctionPtr)> forward_callback);
-
-  void visit_function_backward(
-      CgFunctionPtr func, std::function<void(CgFunctionPtr)> backward_callback,
-      vector<CommunicatorBackwardCallbackPtr> communicator_callbacks);
-
 public:
   typedef shared_ptr<CgVariable> Ptr;
 
@@ -336,6 +327,19 @@ public:
    */
   NBLA_API
   Ptr create_deep_copy(Context ctx, bool copy_grad = true);
+
+  /** Execute callback at functions in forward order in a graph.
+   */
+  void
+  visit_function_recursive(CgFunctionPtr func,
+                           unordered_set<CgFunctionPtr> &fclosed,
+                           std::function<void(CgFunctionPtr)> forward_callback);
+
+  /** Execute callback at functions in backward order in a graph.
+   */
+  void visit_function_backward(
+      CgFunctionPtr func, std::function<void(CgFunctionPtr)> backward_callback,
+      vector<CommunicatorBackwardCallbackPtr> communicator_callbacks);
 };
 
 /** shared_ptr typedef of CGVariable

--- a/include/nbla/function/fused_convolution.hpp
+++ b/include/nbla/function/fused_convolution.hpp
@@ -1,0 +1,122 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_FUSED_CONVOLUTION_HPP
+#define NBLA_FUNCTION_FUSED_CONVOLUTION_HPP
+
+#include <nbla/computation_graph/variable.hpp>
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+#include <unordered_map>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(FusedConvolution, int, const vector<int> &,
+                              const vector<int> &, const vector<int> &, int,
+                              bool, float, float, bool, const string &,
+                              const vector<float> &);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class FusedConvolution
+    : public BaseFunction<int, const vector<int> &, const vector<int> &,
+                          const vector<int> &, int, bool, float, float, bool,
+                          const string &, const vector<float> &> {
+protected:
+  int base_axis_;
+  const vector<int> pad_;
+  const vector<int> stride_;
+  const vector<int> dilation_;
+  int group_;
+  bool channel_last_;
+  float decay_rate_;
+  float eps_;
+  bool batch_stat_;
+  const string nonlinearity_;
+  const vector<float> nonlinearity_args_;
+
+public:
+  // Name of input variables
+  typedef int InName;
+  const InName X = 0, WEIGHT = 1, BIAS = 2, BETA = 3, GAMMA = 4, MEAN = 5,
+               VARIANCE = 6, Z = 7;
+
+public:
+  FusedConvolution(const Context &ctx, int base_axis, const vector<int> &pad,
+                   const vector<int> &stride, const vector<int> &dilation,
+                   int group, bool channel_last, float decay_rate, float eps,
+                   bool batch_stat, const string &nonlinearity,
+                   const vector<float> &nonlinearity_args)
+      : BaseFunction(ctx, base_axis, pad, stride, dilation, group, channel_last,
+                     decay_rate, eps, batch_stat, nonlinearity,
+                     nonlinearity_args),
+        base_axis_(base_axis), pad_(pad), stride_(stride), dilation_(dilation),
+        group_(group), channel_last_(channel_last), decay_rate_(decay_rate),
+        eps_(eps), batch_stat_(batch_stat), nonlinearity_(nonlinearity),
+        nonlinearity_args_(nonlinearity_args) {}
+  virtual ~FusedConvolution() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_FusedConvolution(
+        ctx_, base_axis_, pad_, stride_, dilation_, group_, channel_last_,
+        decay_rate_, eps_, batch_stat_, nonlinearity_, nonlinearity_args_);
+  }
+  virtual int min_inputs() { return 2; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>(),
+                          get_dtype<T>(), get_dtype<T>(), get_dtype<T>(),
+                          get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "FusedConvolution"; }
+
+protected:
+  /**
+    Get pointers of variables from a vector. A pointer to Variable will be set
+    to a referenced variable in the arguments if specified. Otherwise, nullptr
+    will be set.
+  */
+  NBLA_API void get_optional_input_pointers(const Variables &inputs);
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+
+  std::unordered_map<InName, std::pair<int, Variable *>> input_variables_;
+
+private:
+  // Members only used in a naive implementation with composite
+  std::unordered_map<InName, CgVariablePtr> input_cg_variables_;
+  CgVariablePtr last_output_cg_variable_;
+  bool reset_cg_variables(const Variables &inputs, const Variables &outputs);
+};
+}
+#endif

--- a/python/src/nnabla/backward_function/fused_convolution.py
+++ b/python/src/nnabla/backward_function/fused_convolution.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class FusedConvolutionBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'FusedConvolutionBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of FusedConvolutionBackward class is not implemented.")

--- a/python/test/communicator/test_sync_batch_normalization.py
+++ b/python/test/communicator/test_sync_batch_normalization.py
@@ -125,7 +125,7 @@ def test_sync_batch_normalization_forward_backward(seed, axis, decay_rate, eps, 
     def ref_batch_normalize_grad(x, beta, gamma, rmean, rvar,
                                  dy,
                                  comm, axes, decay_rate,
-                                 eps, batch_stat, output_stat):
+                                 eps, batch_stat, output_stat, **kw):
         orig = x - device_id
         inputs = []
         for i in range(n_devices):
@@ -159,7 +159,7 @@ def test_sync_batch_normalization_forward_backward(seed, axis, decay_rate, eps, 
     def ref_batch_normalize_grad_with_output_stat(x, beta, gamma, rmean, rvar,
                                                   dy, dmean, dvar,
                                                   comm, axes, decay_rate,
-                                                  eps, batch_stat, output_stat):
+                                                  eps, batch_stat, output_stat, **kw):
         orig = x - device_id
         inputs = []
         for i in range(n_devices):

--- a/python/test/function/test_binary_activation.py
+++ b/python/test/function/test_binary_activation.py
@@ -26,7 +26,7 @@ def ref_func_binary_tanh(x):
     return 2 * np.round(np.clip((x + 1) / 2, 0, 1)) - 1
 
 
-def ref_grad_binary_tanh(x, dy):
+def ref_grad_binary_tanh(x, dy, **kw):
     return (dy * (1 - np.floor(np.minimum(np.abs(x), 1)))).flatten()
 
 
@@ -35,7 +35,7 @@ def ref_func_binary_sigmoid(x):
     return np.round(np.clip((x + 1) / 2, 0, 1))
 
 
-def ref_grad_binary_sigmoid(x, dy):
+def ref_grad_binary_sigmoid(x, dy, **kw):
     return (dy * (1 - np.floor(np.minimum(np.abs(x), 1))) / 2).flatten()
 
 

--- a/python/test/function/test_binary_connect_affine.py
+++ b/python/test/function/test_binary_connect_affine.py
@@ -41,7 +41,7 @@ def ref_binary_connect_affine(x, w, dummy, b, base_axis, quantize_zero_to):
     return y.reshape(tuple(shape[:-1]) + tuple(out_shape))
 
 
-def ref_grad_binary_connect_affine(x, w, wb, b, dy, base_axis, quantize_zero_to):
+def ref_grad_binary_connect_affine(x, w, wb, b, dy, base_axis, quantize_zero_to, **kw):
     shape = list(x.shape[:base_axis])
 
     x_ = x.reshape(np.prod(shape), -1)

--- a/python/test/function/test_binary_connect_convolution.py
+++ b/python/test/function/test_binary_connect_convolution.py
@@ -43,7 +43,7 @@ def ref_binary_connect_convolution(x, w, wb, b, base_axis, pad, stride, dilation
     return ref_convolution(x, binarize(w, quantize_zero_to), b, base_axis, pad, stride, dilation, group, quantize_zero_to)
 
 
-def ref_grad_binary_connect_convolution(x, w, wb, b, dy, base_axis, pad, stride, dilation, group, quantize_zero_to):
+def ref_grad_binary_connect_convolution(x, w, wb, b, dy, base_axis, pad, stride, dilation, group, quantize_zero_to, **kw):
     # Set variables
     vx = nn.Variable(x.shape, need_grad=True)
     vx.d = x

--- a/python/test/function/test_binary_weight_affine.py
+++ b/python/test/function/test_binary_weight_affine.py
@@ -43,7 +43,7 @@ def ref_binary_weight_affine(x, w, wb, alpha, b, base_axis, quantize_zero_to):
     return y.reshape(tuple(shape[:-1]) + tuple(out_shape))
 
 
-def ref_grad_binary_weight_affine(x, w, wb, alpha, b, dy, base_axis, quantize_zero_to):
+def ref_grad_binary_weight_affine(x, w, wb, alpha, b, dy, base_axis, quantize_zero_to, **kw):
     # wb and alpha is the placeholder for the binary weights and scaling factor
     shape = list(x.shape[:base_axis])
 

--- a/python/test/function/test_binary_weight_convolution.py
+++ b/python/test/function/test_binary_weight_convolution.py
@@ -44,7 +44,7 @@ def ref_binary_weight_convolution(x, w, wb, alpha, b, base_axis, pad, stride, di
     return ref_convolution(x, binarize_kernel(w, quantize_zero_to), b, base_axis, pad, stride, dilation, group, quantize_zero_to)
 
 
-def ref_grad_binary_weight_convolution(x, w, wb, alpha, b, dy, base_axis, pad, stride, dilation, group, quantize_zero_to):
+def ref_grad_binary_weight_convolution(x, w, wb, alpha, b, dy, base_axis, pad, stride, dilation, group, quantize_zero_to, **kw):
     # Set variables
     vx = nn.Variable(x.shape, need_grad=True)
     vx.d = x

--- a/python/test/function/test_ceil.py
+++ b/python/test/function/test_ceil.py
@@ -24,7 +24,7 @@ def ref_ceil(x):
     return np.ceil(x)
 
 
-def ref_grad_ceil(x, dy):
+def ref_grad_ceil(x, dy, **kw):
     return dy.flatten()
 
 

--- a/python/test/function/test_clip_grad_by_norm.py
+++ b/python/test/function/test_clip_grad_by_norm.py
@@ -25,7 +25,7 @@ def ref_clip_grad_by_norm(x, clip_norm, axes):
     return y
 
 
-def ref_grad_clip_by_norm(x, dy, clip_norm, axes):
+def ref_grad_clip_by_norm(x, dy, clip_norm, axes, **kw):
     dx = np.copy(dy)
     dx = clip_norm * dy / \
         np.broadcast_to(

--- a/python/test/function/test_clip_grad_by_value.py
+++ b/python/test/function/test_clip_grad_by_value.py
@@ -25,7 +25,7 @@ def ref_clip_grad_by_value(x, min_, max_):
     return y
 
 
-def ref_grad_clip_grad_by_value(x, min_, max_, dy):
+def ref_grad_clip_grad_by_value(x, min_, max_, dy, **kw):
     dx = dy
     idx_min = np.where(dy < min_)
     idx_max = np.where(dy > max_)

--- a/python/test/function/test_fft.py
+++ b/python/test/function/test_fft.py
@@ -35,7 +35,7 @@ def ref_fft(x, signal_ndim, normalized):
     return ref_data_float2
 
 
-def ref_grad_fft(x, dy, signal_ndim, normalized):
+def ref_grad_fft(x, dy, signal_ndim, normalized, **kw):
     from nbla_test_utils import convert_to_float2_array, convert_to_complex_array
 
     dy_complex = convert_to_complex_array(dy)

--- a/python/test/function/test_fixed_point_quantize.py
+++ b/python/test/function/test_fixed_point_quantize.py
@@ -43,7 +43,7 @@ def ref_fixed_point_quantize(x, sign, n, delta, quantize, ste_fine_grained):
 
 
 def ref_grad_fixed_point_quantize(x, dy, sign, n, delta,
-                                  quantize, ste_fine_grained):
+                                  quantize, ste_fine_grained, **kw):
 
     if not ste_fine_grained:
         return dy.flatten()

--- a/python/test/function/test_floor.py
+++ b/python/test/function/test_floor.py
@@ -24,7 +24,7 @@ def ref_floor(x):
     return np.floor(x)
 
 
-def ref_grad_floor(x, dy):
+def ref_grad_floor(x, dy, **kw):
     return dy.flatten()
 
 

--- a/python/test/function/test_fused_batch_normalization.py
+++ b/python/test/function/test_fused_batch_normalization.py
@@ -58,7 +58,7 @@ def ref_fused_batch_normalization(x, beta, gamma, rmean, rvar, z, axes, decay_ra
 
 
 def ref_grad_fused_batch_normalization(x, beta, gamma, rmean, rvar, z, dy, axes, decay_rate,
-                                       eps, batch_stat, nonlinearity, output_stat):
+                                       eps, batch_stat, nonlinearity, output_stat, **kw):
     with nn.context_scope(cpu_context):
         xvar = nn.Variable.from_numpy_array(x, need_grad=True)
         xvar.g = 0

--- a/python/test/function/test_fused_convolution.py
+++ b/python/test/function/test_fused_convolution.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
+
+ctxs = list_context('FusedConvolution')
+cpu_context = nn.Context(["cpu:float"])
+
+
+class RefFusedConvolutionGraph(object):
+
+    def __init__(self, x, weight, bias, beta, gamma, rmean, rvar, z,
+                 base_axis, pad, stride, dilation, group, channel_last,
+                 decay_rate, eps, batch_stat,
+                 nonlinearity, nonlinearity_args):
+
+        from collections import OrderedDict
+        inputs = OrderedDict()
+        xvar = nn.Variable.from_numpy_array(x)
+        weightvar = nn.Variable.from_numpy_array(weight)
+        inputs['x'] = xvar
+        inputs['weight'] = weightvar
+        biasvar = None
+        betavar = None
+        gammavar = None
+        rmeanvar = None
+        rvarvar = None
+        zvar = None
+        if bias is not None:
+            biasvar = nn.Variable.from_numpy_array(bias)
+            inputs['bias'] = biasvar
+        if beta is not None:
+            betavar = nn.Variable.from_numpy_array(beta)
+            gammavar = nn.Variable.from_numpy_array(gamma)
+            rmeanvar = nn.Variable.from_numpy_array(rmean)
+            rvarvar = nn.Variable.from_numpy_array(rvar)
+            inputs['beta'] = betavar
+            inputs['gamma'] = gammavar
+            inputs['rmean'] = rmeanvar
+            inputs['rvar'] = rvarvar
+        if z is not None:
+            zvar = nn.Variable.from_numpy_array(z)
+            inputs['z'] = zvar
+        h = F.convolution(xvar, weightvar, biasvar, base_axis,
+                          pad, stride, dilation, group, channel_last)
+        if beta is not None:
+            h = F.batch_normalization(h, betavar, gammavar, rmeanvar, rvarvar,
+                                      [h.ndim - 1 if channel_last else base_axis],
+                                      decay_rate, eps, batch_stat)
+        if z is not None:
+            h = F.add2(h, zvar)
+        h = ref_activation(h, nonlinearity, nonlinearity_args)
+        self.input_dict = inputs
+        self.output = h
+
+    def get_output(self):
+        self.output.forward(clear_buffer=True)
+        return self.output.data.get_data('r')
+
+    def get_grads(self, grad, need_grad_flags):
+        ng_flags = [ng for ng in need_grad_flags if ng is not None]
+        for ivar, ng in zip(self.input_dict.values(), ng_flags):
+            ivar.need_grad = ng
+            ivar.grad.zero()
+        self.output.forward(clear_no_need_grad=True)
+        self.output.backward(grad, clear_buffer=True)
+        return np.concatenate([ivar.grad.get_data('r').flatten() for (ivar, ng) in zip(self.input_dict.values(), ng_flags) if ng])
+
+
+def ref_activation(x, nonlinearity, nonlinearity_args):
+    if nonlinearity == 'identity' or not nonlinearity:
+        return x
+    elif nonlinearity == 'relu':
+        return F.relu(x)
+    elif nonlinearity == 'sigmoid':
+        return F.sigmoid(x)
+    elif nonlinearity == 'tanh':
+        return F.tanh(x)
+    elif nonlinearity == 'leaky_relu':
+        return F.leaky_relu(x, nonlinearity_args[0])
+    elif nonlinearity == 'elu':
+        return F.elu(x, nonlinearity_args[0])
+    elif nonlinearity == 'relu6':
+        return F.relu6(x)
+    raise ValueError("unknown nonlinearity type {}".format(nonlinearity))
+
+
+def ref_fused_convolution(x, weight, bias, beta, gamma, rmean, rvar, z,
+                          base_axis, pad, stride, dilation, group, channel_last,
+                          decay_rate, eps, batch_stat,
+                          nonlinearity, nonlinearity_args):
+
+    with nn.context_scope(cpu_context):
+        graph = RefFusedConvolutionGraph(**locals())
+    return graph.get_output()
+
+
+def ref_grad_fused_convolution(x, weight, bias, beta, gamma, rmean, rvar, z, dy,
+                               base_axis, pad, stride, dilation, group, channel_last,
+                               decay_rate, eps, batch_stat,
+                               nonlinearity, nonlinearity_args, need_grad_flags):
+    args = locals().copy()
+    del args['dy']
+    del args['need_grad_flags']
+    with nn.context_scope(cpu_context):
+        graph = RefFusedConvolutionGraph(**args)
+    return graph.get_grads(dy, need_grad_flags=need_grad_flags)
+
+
+def create_inputs(rng, kernel, pad, stride, dilation, group, with_bias, bn, add2, channel_last):
+    from refs import get_conv_out_size
+    bs = 2
+    hw = (5, 5)
+    ohw = tuple(get_conv_out_size(s, kernel, pad, stride, dilation)
+                for s in hw)
+    ichannels = 4
+    ochannels = 6
+    kernels = (kernel, kernel)
+    inshape = (bs, ichannels) + hw
+    outshape = (bs, ochannels) + ohw
+    wshape = (ochannels, ichannels // group,) + kernels
+
+    def to_channel_last(shape):
+        return tuple(shape[i] for i in (0, 2, 3, 1))
+    if channel_last:
+        inshape = to_channel_last(inshape)
+        outshape = to_channel_last(outshape)
+        wshape = to_channel_last(wshape)
+    x = rng.randn(*inshape).astype(np.float32)
+    weight = rng.randn(*wshape).astype(np.float32)
+    bias = None
+    if with_bias:
+        bias = rng.randn(ochannels).astype(np.float32)
+    if bn is not None:
+        axis = 3 if channel_last else 1
+        shape_stat = [1 for _ in range(x.ndim)]
+        shape_stat[axis] = ochannels
+        beta = rng.randn(*shape_stat).astype(np.float32)
+        gamma = rng.randn(*shape_stat).astype(np.float32)
+        rmean = np.zeros(shape_stat, dtype=np.float32)
+        rvar = np.ones(shape_stat, dtype=np.float32)
+    else:
+        beta = None
+        gamma = None
+        rmean = None
+        rvar = None
+    if add2:
+        # Note: The last dimension must be a multiple of 4
+        # if we want to test cudnn BN persistent mode.
+        z = rng.randn(*outshape).astype(np.float32)
+    else:
+        z = None
+
+    return x, weight, bias, beta, gamma, rmean, rvar, z
+
+
+@pytest.mark.parametrize("seed", [1223, 726])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("kernel", [3])
+@pytest.mark.parametrize("pad", [1])
+@pytest.mark.parametrize("stride", [2])
+@pytest.mark.parametrize("dilation", [1])
+@pytest.mark.parametrize("group", [2])
+@pytest.mark.parametrize("decay_rate", [0.9])
+@pytest.mark.parametrize("eps", [1e-5])
+@pytest.mark.parametrize("with_bias, bn, add2, channel_last", [
+    (False, True, True, False),
+    (False, True, False, False),
+    # TODO will make channel_last=True once conv cpu supports it
+    (True, None, True, False),
+    (False, False, False, False),
+])
+@pytest.mark.parametrize("nonlinearity, nonlinearity_args", [
+    ('identity', []),
+    ('relu', []),
+    ('sigmoid', []),
+    ('tanh', []),
+    ('leaky_relu', [0.1]),
+    ('leaky_relu', [0.2]),
+    ('elu', [0.1]),
+    ('elu', [0.2]),
+    ('relu6', [])])
+def test_fused_convolution(seed, kernel, pad, stride, dilation, group, channel_last, decay_rate, eps, nonlinearity, nonlinearity_args, with_bias, bn, add2, ctx, func_name):
+
+    from nbla_test_utils import function_tester
+    rng = np.random.RandomState(seed)
+    inputs = list(create_inputs(rng, kernel, pad, stride,
+                                dilation, group, with_bias, bn, add2, channel_last))
+    base_axis = 1
+    batch_stat = True if bn is None else bn
+    bn_backward = [None, None, None, None]
+    if bn is True:
+        bn_backward = [True, True, False, False]
+    elif bn is False:
+        bn_backward = [True, True, True, True]
+    function_tester(rng, F.fused_convolution, ref_fused_convolution,
+                    inputs,
+                    ref_grad=ref_grad_fused_convolution,
+                    func_args=[base_axis, (pad, pad), (stride, stride), (dilation, dilation), group, channel_last,
+                               decay_rate, eps, batch_stat, nonlinearity, nonlinearity_args],
+                    backward=[True, True, True if with_bias else None] +
+                    bn_backward + [True if add2 else None],
+                    ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2)

--- a/python/test/function/test_gelu.py
+++ b/python/test/function/test_gelu.py
@@ -24,7 +24,7 @@ def ref_gelu(x):
     return x/2*(1+np.tanh(np.sqrt(2/np.pi)*(x + 0.044715 * np.power(x, 3))))
 
 
-def ref_gelu_backward(x, dx):
+def ref_gelu_backward(x, dx, **kw):
     return np.array(np.array(0.5 + (0.398942*x + 0.0535161 * np.power(x, 3)) * np.power(1 / np.cosh(0.797885*x + 0.0356774 * np.power(x, 3)), 2) + 0.5*np.tanh(0.797885*x + 0.0356774*np.power(x, 3))).flat)
 
 

--- a/python/test/function/test_gru.py
+++ b/python/test/function/test_gru.py
@@ -130,7 +130,7 @@ def execute_fixed_length_gru(xs_np, h0_np, w0_np, w_np, b_np, num_layers=1, drop
     return ys.d, hn.d
 
 
-def get_gru_grad(xs_np, h0_np, w0_np, w_np, b_np, dy, dh, num_layers=1, dropout=0.0, bidirectional=False, training=True):
+def get_gru_grad(xs_np, h0_np, w0_np, w_np, b_np, dy, dh, num_layers=1, dropout=0.0, bidirectional=False, training=True, **kw):
     # Inputs are numpy arrays
     num_directions = 2 if bidirectional else 1
     seq_len = xs_np.shape[0]

--- a/python/test/function/test_hard_sigmoid.py
+++ b/python/test/function/test_hard_sigmoid.py
@@ -24,7 +24,7 @@ def ref_hard_sigmoid(x):
     return np.maximum(0, np.minimum(1, x*0.2 + 0.5))
 
 
-def ref_hard_sigmoid_backward(x, dy):
+def ref_hard_sigmoid_backward(x, dy, **kw):
     return np.array([dy*0.2 if 2.5 >= i >= -2.5 else 0 for i in np.nditer(x)])
 
 

--- a/python/test/function/test_hard_tanh.py
+++ b/python/test/function/test_hard_tanh.py
@@ -24,7 +24,7 @@ def ref_hard_tanh(x):
     return np.maximum(-1, np.minimum(1, x))
 
 
-def ref_hard_tanh_backward(x, dy):
+def ref_hard_tanh_backward(x, dy, **kw):
     return np.array([dy if -1 <= i <= 1 else 0 for i in np.nditer(x)])
 
 

--- a/python/test/function/test_ifft.py
+++ b/python/test/function/test_ifft.py
@@ -36,7 +36,7 @@ def ref_ifft(x, signal_ndim, normalized):
     return ref_data_float2
 
 
-def ref_grad_ifft(x, dy, signal_ndim, normalized):
+def ref_grad_ifft(x, dy, signal_ndim, normalized, **kw):
     from nbla_test_utils import convert_to_float2_array, convert_to_complex_array
 
     dy_complex = convert_to_complex_array(dy)

--- a/python/test/function/test_inf_nan.py
+++ b/python/test/function/test_inf_nan.py
@@ -54,7 +54,7 @@ def test_reset_nan_reset_inf_forward_backward(seed, val, fname, ctx, func_name):
         y[np_fun(x)] = val
         return y
 
-    def ref_backward(x, dy, val):
+    def ref_backward(x, dy, val, **kw):
         dx = dy.copy()
         dx[np_fun(x)] = 0
         return dx.flatten()

--- a/python/test/function/test_inq_affine.py
+++ b/python/test/function/test_inq_affine.py
@@ -76,7 +76,7 @@ def ref_inq_affine(x, w, i, b, base_axis, num_bits,
 
 
 def ref_grad_inq_affine(x, w, i, b, dy, base_axis, num_bits,
-                        inq_iterations, selection_algorithm, seed):
+                        inq_iterations, selection_algorithm, seed, **kw):
     shape = list(x.shape[:base_axis])
 
     if inq_iterations[-1] == 0:

--- a/python/test/function/test_inq_convolution.py
+++ b/python/test/function/test_inq_convolution.py
@@ -77,7 +77,7 @@ def ref_inq_convolution(x, w, i, b, base_axis, pad, stride, dilation, group,
 
 
 def ref_grad_inq_convolution(x, w, i, b, dy, base_axis, pad, stride, dilation, group,
-                             num_bits, inq_iterations, selection_algorithm, seed):
+                             num_bits, inq_iterations, selection_algorithm, seed, **kw):
     if inq_iterations[-1] == 0:
         # last element in `inq_iterations`, quantize all weights
         i = np.ones_like(i)

--- a/python/test/function/test_lstm.py
+++ b/python/test/function/test_lstm.py
@@ -135,7 +135,7 @@ def execute_fixed_length_lstm(xs_np, h0_np, c0_np, w0_np, w_np, b_np, num_layers
     return ys.d, hn.d, cn.d
 
 
-def get_lstm_grad(xs_np, h0_np, c0_np, w0_np, w_np, b_np, dy, dh, dc, num_layers=1, dropout=0.0, bidirectional=False, training=True):
+def get_lstm_grad(xs_np, h0_np, c0_np, w0_np, w_np, b_np, dy, dh, dc, num_layers=1, dropout=0.0, bidirectional=False, training=True, **kw):
     num_directions = 2 if bidirectional else 1
     seq_len = xs_np.shape[0]
     batch_size = xs_np.shape[1]

--- a/python/test/function/test_min_max_quantize.py
+++ b/python/test/function/test_min_max_quantize.py
@@ -64,7 +64,7 @@ def ref_min_max_quantize(x, qr_min, qr_max, ql_min, ql_max,
 
 def ref_grad_min_max_quantize(x, qr_min, qr_max, ql_min, ql_max, dy,
                               decay, x_min_max, ema, ste_fine_grained, eps,
-                              quantize):
+                              quantize, **kw):
     if not quantize:
         return dy.flatten()
 

--- a/python/test/function/test_pow2_quantize.py
+++ b/python/test/function/test_pow2_quantize.py
@@ -51,7 +51,7 @@ def ref_pow2_quantize(x, sign, with_zero, n, m, quantize, ste_fine_grained):
 
 
 def ref_grad_pow2_quantize(x, dy, sign,
-                           with_zero, n, m, quantize, ste_fine_grained):
+                           with_zero, n, m, quantize, ste_fine_grained, **kw):
     if not ste_fine_grained:
         return dy.flatten()
 

--- a/python/test/function/test_prune.py
+++ b/python/test/function/test_prune.py
@@ -35,7 +35,7 @@ def ref_func_prune(x, rate):
     return y
 
 
-def ref_grad_prune(x, dy, rate):
+def ref_grad_prune(x, dy, rate, **kw):
     # pass through gradient from output to input
     return dy.flatten()
 

--- a/python/test/function/test_rnn.py
+++ b/python/test/function/test_rnn.py
@@ -126,7 +126,7 @@ def execute_fixed_length_rnn(xs_np, h0_np, w0_np, w_np, b_np, num_layers=1, nonl
     return ys.d, hn.d
 
 
-def get_rnn_grad(xs_np, h0_np, w0_np, w_np, b_np, dy, dh, num_layers=1, nonlinearity='tanh', dropout=0.0, bidirectional=False, training=True):
+def get_rnn_grad(xs_np, h0_np, w0_np, w_np, b_np, dy, dh, num_layers=1, nonlinearity='tanh', dropout=0.0, bidirectional=False, training=True, **kw):
     # Inputs are numpy arrays
     num_directions = 2 if bidirectional else 1
     seq_len = xs_np.shape[0]

--- a/python/test/function/test_round.py
+++ b/python/test/function/test_round.py
@@ -24,7 +24,7 @@ def ref_round(x):
     return np.sign(x) * np.floor(np.abs(x) + 0.5)
 
 
-def ref_grad_round(x, dy):
+def ref_grad_round(x, dy, **kw):
     return dy.flatten()
 
 

--- a/python/test/function/test_sign.py
+++ b/python/test/function/test_sign.py
@@ -27,7 +27,7 @@ def ref_func_sign(x, alpha):
     return y
 
 
-def ref_grad_sign(x, dy, alpha):
+def ref_grad_sign(x, dy, alpha, **kw):
     # pass through gradient from output to input
     return dy.flatten()
 

--- a/python/test/function/test_top_k_data.py
+++ b/python/test/function/test_top_k_data.py
@@ -44,7 +44,7 @@ def ref_top_k_data_fw(x, k, abs, reduce, base_axis):
     return ref_top_k_data(x, k, abs, reduce, base_axis)[0]
 
 
-def ref_top_k_data_bw(x, g, k, abs, reduce, base_axis):
+def ref_top_k_data_bw(x, g, k, abs, reduce, base_axis, **kw):
     return ref_top_k_data(x, k, abs, reduce, base_axis, g)[1].flatten()
 
 

--- a/python/test/function/test_top_k_grad.py
+++ b/python/test/function/test_top_k_grad.py
@@ -36,7 +36,7 @@ def ref_top_k_grad_fw(x, k, abs, base_axis):
     return x
 
 
-def ref_top_k_grad_bw(x, g, k, abs, base_axis):
+def ref_top_k_grad_bw(x, g, k, abs, base_axis, **kw):
     return ref_top_k_grad(k, abs, base_axis, g).flatten()
 
 

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -157,6 +157,10 @@ def compute_analytical_and_numerical_grad(f, inputs, outputs, inputs0,
                 bind += i.size
             else:
                 assert not i.need_grad
+        f.setup(vinputs, outputs)
+        # Need to call reset output grads since output might be inplaced
+        for o, d in zip(outputs, vgrads):
+            o.g = d
         f.forward(vinputs, outputs)
         f.backward(vinputs, outputs)
 
@@ -572,12 +576,21 @@ def function_tester(rng, func, ref_func, inputs,
                test in zip(rinputs, backward)]
     vgrads = [randn(rng, *o_.shape) for o_ in o]
 
+    def reset_ograds():
+        '''
+        Reset output grads everytime we call backward.
+        This is required because the output grad might
+        be inplaced and modified during backward operation.
+        '''
+        for ovar, g in zip(o, vgrads):
+            ovar.g = g
+
     agrads, ngrads = compute_analytical_and_numerical_grad(
         o[0].parent, vinputs, o, rinputs, vgrads, epsilon=dstep,
         rng=rng, ref_grad=ref_grad)
     if ref_grad is not None:
         rinputs = copy.deepcopy(inputs)
-        doutputs = [o_.g for o_ in o]
+        doutputs = copy.deepcopy(vgrads)
         ngrads = ref_grad(*(rinputs + doutputs + func_args),
                           **func_kwargs, need_grad_flags=backward)
 
@@ -589,6 +602,7 @@ def function_tester(rng, func, ref_func, inputs,
             continue
         v.grad.zero()
         v.need_grad = False
+        reset_ograds()
         try:
             o[0].parent.forward(
                 list(filter(lambda x: x is not None, vinputs)), o)
@@ -624,6 +638,7 @@ def function_tester(rng, func, ref_func, inputs,
         # Save accum gradient result
         g = randn(rng, *v.shape)
         v.g = g
+        reset_ograds()
         f.forward(finputs, o)
         f.backward(finputs, o)
         true_g = v.g - g
@@ -631,6 +646,7 @@ def function_tester(rng, func, ref_func, inputs,
         # Check accum=False
         accum = [j != i for j, vv in enumerate(vinputs) if vv is not None]
         v.g = randn(rng, *v.shape)
+        reset_ograds()
         f.forward(finputs, o)
         f.backward(finputs, o, accum)
         assert_allclose(
@@ -638,6 +654,7 @@ def function_tester(rng, func, ref_func, inputs,
 
         # Check accum=False with NaN gradient
         v.g = np.float32('nan')
+        reset_ograds()
         f.forward(finputs, o)
         f.backward(finputs, o, accum)
         assert not np.any(np.isnan(v.g))

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -578,7 +578,8 @@ def function_tester(rng, func, ref_func, inputs,
     if ref_grad is not None:
         rinputs = copy.deepcopy(inputs)
         doutputs = [o_.g for o_ in o]
-        ngrads = ref_grad(*(rinputs + doutputs + func_args), **func_kwargs)
+        ngrads = ref_grad(*(rinputs + doutputs + func_args),
+                          **func_kwargs, need_grad_flags=backward)
 
     assert_allclose(ngrads, agrads, atol=atol_b)
 

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -57,9 +57,18 @@ vector<CgVariablePtr> create_function_outputs(CgFunctionPtr cg_f, int n_outputs,
 }
 
 vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
-                              const vector<CgVariablePtr> &inputs,
+                              const vector<CgVariablePtr> &inputs_orig,
                               int n_outputs, vector<NdArrayPtr> inplace_outputs,
                               bool execute) {
+  // Filter null inputs (since cpp functions doesn't handle optional inputs in
+  // functions.cpp)
+  vector<CgVariablePtr> inputs;
+  for (auto &inp : inputs_orig) {
+    if (inp) {
+      inputs.push_back(inp);
+    }
+  }
+
   set_function_inputs(cg_f, inputs);
 
   // check if data can be cleared or not.

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <nbla/computation_graph/computation_graph.hpp>
 #include <nbla/computation_graph/function.hpp>
 #include <nbla/computation_graph/variable.hpp>
 
@@ -320,7 +321,12 @@ class BackwardCallback {
       if (first) { // first visit
         // Terminal variable always doesn't allow to clear buffers.
         prohibit_clear[i] = true;
-        vseen_[v] = true; // It must be ok to add vseen_.
+
+        // Note that the following vseen_[v] won't be referred in the current
+        // implementation because query_input_flags is called earlier than
+        // query_output_flags. TODO: We may be able to call query_output_flags
+        // before query_input_flags.
+        vseen_[v] = true;
       } else {
         // Propagate prohibit_clear_inputs_buffers flag from the previous seen
         // inputs.
@@ -568,6 +574,9 @@ void CgVariable::forward(bool clear_buffer, bool clear_no_need_grad,
                          function_hook_type function_pre_hook,
                          function_hook_type function_post_hook) {
   unordered_set<CgFunctionPtr> scoped_fclosed;
+  auto clear_buffer_state =
+      SingletonManager::get<GlobalClearBufferState>()->state(
+          clear_buffer, clear_no_need_grad);
   if (fclosed == nullptr) {
     fclosed = &scoped_fclosed;
   }
@@ -585,6 +594,9 @@ void CgVariable::backward(
     function_hook_type function_pre_hook,
     function_hook_type function_post_hook) {
   NBLA_CHECK(parent_, error_code::value, "The variable has no parent.");
+  auto clear_buffer_state =
+      SingletonManager::get<GlobalClearBufferState>()->state(clear_buffer,
+                                                             false);
 
   // Scoped context.
   // Set flags used during backward of this variable to avoid clearing

--- a/src/nbla/function/generic/convolution.cpp
+++ b/src/nbla/function/generic/convolution.cpp
@@ -81,6 +81,9 @@ void Convolution<T>::setup_impl(const Variables &inputs,
   NBLA_CHECK(dilation_.size() == spatial_dims_, error_code::value,
              "dilation size mismatch. dilation size: %d != spatial dims: %d.",
              dilation_.size(), spatial_dims_);
+  kernel_.clear();
+  spatial_shape_i_.clear();
+  spatial_shape_o_.clear();
   for (int i = 0; i < spatial_dims_; ++i) {
     kernel_.push_back(shape_weights[weight_first_spatial_axis + i]);
     inner_size_k_ *= kernel_[i];

--- a/src/nbla/function/generic/deconvolution.cpp
+++ b/src/nbla/function/generic/deconvolution.cpp
@@ -97,6 +97,9 @@ void Deconvolution<T>::setup_impl(const Variables &inputs,
              "output_padding size mismatch: %d != spatial dims: %d.",
              output_padding_.size(), spatial_dims_);
 
+  kernel_.clear();
+  spatial_shape_i_.clear();
+  spatial_shape_o_.clear();
   for (int i = 0; i < spatial_dims_; ++i) {
     kernel_.push_back(shape_weights[weight_first_spatial_axis + i]);
     inner_size_k_ *= kernel_[i];

--- a/src/nbla/function/generic/depthwise_convolution.cpp
+++ b/src/nbla/function/generic/depthwise_convolution.cpp
@@ -117,6 +117,7 @@ void DepthwiseConvolution<T>::setup_impl(const Variables &inputs,
   copy_dims_to(sample_shape_, input_shape, base_axis_ + 1);
   sample_size_ = multiply_dimensions(sample_shape_);
 
+  outmap_shape_.clear();
   outmap_shape_.reserve(kernel_shape_.size());
   for (int i = 0; i < kernel_shape_.size(); i++) {
     auto kernel = dilation_[i] * (kernel_shape_[i] - 1) + 1; // dilated kernel

--- a/src/nbla/function/generic/depthwise_deconvolution.cpp
+++ b/src/nbla/function/generic/depthwise_deconvolution.cpp
@@ -116,6 +116,7 @@ void DepthwiseDeconvolution<T>::setup_impl(const Variables &inputs,
   copy_dims_to(sample_shape_, input_shape, base_axis_ + 1);
   sample_size_ = multiply_dimensions(sample_shape_);
 
+  outmap_shape_.clear();
   outmap_shape_.reserve(kernel_shape_.size());
   for (int i = 0; i < kernel_shape_.size(); ++i) {
     auto shape = sample_shape_[i];

--- a/src/nbla/function/generic/fused_convolution.cpp
+++ b/src/nbla/function/generic/fused_convolution.cpp
@@ -1,0 +1,269 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/computation_graph/computation_graph.hpp>
+#include <nbla/computation_graph/function.hpp>
+#include <nbla/computation_graph/variable.hpp>
+#include <nbla/function/fused_convolution.hpp>
+#include <nbla/functions.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(FusedConvolution, int, const vector<int> &,
+                              const vector<int> &, const vector<int> &, int,
+                              bool, float, float, bool, const string &,
+                              const vector<float> &);
+
+template <typename T>
+void FusedConvolution<T>::get_optional_input_pointers(const Variables &inputs) {
+  input_variables_[X] = {0, inputs[0]};
+  input_variables_[WEIGHT] = {1, inputs[1]};
+  auto set_bn_ptrs = [&]() {
+    input_variables_[BETA] = {2, inputs[2]};
+    input_variables_[GAMMA] = {3, inputs[3]};
+    input_variables_[MEAN] = {4, inputs[4]};
+    input_variables_[VARIANCE] = {5, inputs[5]};
+  };
+
+  // Combination is quite complex. Writing down for all patterns
+  switch (inputs.size()) {
+  case 2:
+    break;
+  case 3:
+    // Assume bias vector is one dimensional vector, while z has a spatial
+    // structure.
+    input_variables_[Z] = {2, inputs[2]};
+    break;
+  case 4:
+    // No BN.
+    input_variables_[BIAS] = {2, inputs[2]};
+    input_variables_[Z] = {3, inputs[3]};
+    break;
+  case 6:
+    // No bias nor z
+    set_bn_ptrs();
+    break;
+  case 7: {
+    // Assume bias vector is one dimensional vector, while bn args and z have
+    // spatial dimensions.
+    size_t offset = 0;
+    NBLA_CHECK(inputs[2]->ndim() != 1, error_code::value,
+               "Wrong input shape. It seeems that you pass convolution bias "
+               "and batch normalization inputs at the same time (prohibited).");
+    // No bias nor z
+    set_bn_ptrs();
+    if (!offset) {
+      input_variables_[Z] = {6, inputs[6]};
+    }
+    break;
+  }
+  default:
+    NBLA_ERROR(error_code::value,
+               "Unknown error. Wrong number of arguments are specified.");
+  }
+}
+
+namespace {
+CgVariablePtr create_cgvariable_from_variable(Variable *var, bool need_grad) {
+  auto cg_var = make_shared<CgVariable>(var->shape(), need_grad);
+  cg_var->variable()->set_data(var->data());
+  cg_var->variable()->set_grad(var->grad());
+  return cg_var;
+}
+
+bool reset_cgvariable(CgVariablePtr cg_var, Variable *var) {
+  bool ret = false;
+  // std::cout << cg_var->variable()->data().get() << " ? " << var->data().get()
+  //           << std::endl;
+  if (cg_var->variable()->data() != var->data()) {
+    cg_var->variable()->set_data(var->data());
+    ret = true;
+  }
+  // std::cout << cg_var->variable()->grad().get() << " ? " << var->grad().get()
+  //           << std::endl;
+  if (cg_var->variable()->grad() != var->grad()) {
+    cg_var->variable()->set_grad(var->grad());
+    ret = true;
+  }
+  return ret;
+}
+}
+
+template <typename T>
+bool FusedConvolution<T>::reset_cg_variables(const Variables &inputs,
+                                             const Variables &outputs) {
+  auto get_index = [this](InName name) {
+    return this->input_variables_[name].first;
+  };
+  bool ret = false;
+  ret |= reset_cgvariable(input_cg_variables_[X], inputs[get_index(X)]);
+  ret |=
+      reset_cgvariable(input_cg_variables_[WEIGHT], inputs[get_index(WEIGHT)]);
+  if (input_cg_variables_[BIAS]) {
+    ret |= reset_cgvariable(input_cg_variables_[BIAS], inputs[get_index(BIAS)]);
+  }
+  if (input_cg_variables_[BETA]) {
+    ret |= reset_cgvariable(input_cg_variables_[BETA], inputs[get_index(BETA)]);
+    ret |=
+        reset_cgvariable(input_cg_variables_[GAMMA], inputs[get_index(GAMMA)]);
+    ret |= reset_cgvariable(input_cg_variables_[MEAN], inputs[get_index(MEAN)]);
+    ret |= reset_cgvariable(input_cg_variables_[VARIANCE],
+                            inputs[get_index(VARIANCE)]);
+  }
+  if (input_cg_variables_[Z]) {
+    ret |= reset_cgvariable(input_cg_variables_[Z], inputs[get_index(Z)]);
+  }
+  return ret;
+}
+
+template <typename T>
+void FusedConvolution<T>::setup_impl(const Variables &inputs,
+                                     const Variables &outputs) {
+
+  this->get_optional_input_pointers(inputs);
+
+  // ----------------------------------------------------------------
+  // Convolution
+  // ----------------------------------------------------------------
+  auto cg_x = create_cgvariable_from_variable(input_variables_[X].second, true);
+  auto cg_weight =
+      create_cgvariable_from_variable(input_variables_[WEIGHT].second, true);
+  input_cg_variables_[X] = cg_x;
+  input_cg_variables_[WEIGHT] = cg_weight;
+  CgVariablePtr cg_bias;
+  if (input_variables_[BIAS].second) {
+    cg_bias =
+        create_cgvariable_from_variable(input_variables_[BIAS].second, true);
+    input_cg_variables_[BIAS] = cg_bias;
+  }
+  auto last_out =
+      functions::convolution(ctx_, cg_x, cg_weight, cg_bias, base_axis_, pad_,
+                             stride_, dilation_, group_, channel_last_)[0];
+
+  // ----------------------------------------------------------------
+  // BatchNormalization
+  // ----------------------------------------------------------------
+  if (input_variables_[BETA].second) {
+    auto cg_beta =
+        create_cgvariable_from_variable(input_variables_[BETA].second, true);
+    auto cg_gamma =
+        create_cgvariable_from_variable(input_variables_[GAMMA].second, true);
+    auto cg_mean =
+        create_cgvariable_from_variable(input_variables_[MEAN].second, true);
+    auto cg_variance = create_cgvariable_from_variable(
+        input_variables_[VARIANCE].second, true);
+    input_cg_variables_[BETA] = cg_beta;
+    input_cg_variables_[GAMMA] = cg_gamma;
+    input_cg_variables_[MEAN] = cg_mean;
+    input_cg_variables_[VARIANCE] = cg_variance;
+    vector<int> axes{channel_last_ ? (int)(inputs[0]->ndim() - 1) : base_axis_};
+    last_out = functions::batch_normalization(
+        ctx_, last_out, cg_beta, cg_gamma, cg_mean, cg_variance, axes,
+        decay_rate_, eps_, batch_stat_)[0];
+  }
+
+  // ----------------------------------------------------------------
+  // Add2
+  // ----------------------------------------------------------------
+  if (input_variables_[Z].second) {
+    auto cg_z =
+        create_cgvariable_from_variable(input_variables_[Z].second, true);
+    input_cg_variables_[Z] = cg_z;
+    last_out = functions::add2(ctx_, last_out, cg_z, true /* inplace */)[0];
+  }
+
+  // ----------------------------------------------------------------
+  // Activation
+  // ----------------------------------------------------------------
+  size_t num_args = nonlinearity_args_.size();
+  if (nonlinearity_ == "identity" || nonlinearity_.empty()) {
+  } else if (nonlinearity_ == "relu") {
+    last_out = functions::relu(ctx_, last_out, true)[0];
+  } else if (nonlinearity_ == "sigmoid") {
+    last_out = functions::sigmoid(ctx_, last_out)[0];
+  } else if (nonlinearity_ == "tanh") {
+    last_out = functions::tanh(ctx_, last_out)[0];
+  } else if (nonlinearity_ == "leaky_relu") {
+    NBLA_CHECK(num_args == 1, error_code::value,
+               "LeakyReLU requires 1 arguments in nonlinearity_args (alpha).");
+    last_out =
+        functions::leaky_relu(ctx_, last_out, nonlinearity_args_[0], true)[0];
+  } else if (nonlinearity_ == "elu") {
+    NBLA_CHECK(num_args == 1, error_code::value,
+               "ELU requires 1 arguments in nonlinearity_args (alpha).");
+    last_out = functions::elu(ctx_, last_out, nonlinearity_args_[0])[0];
+  } else if (nonlinearity_ == "relu6") {
+    last_out = functions::relu6(ctx_, last_out)[0];
+  } else {
+    NBLA_ERROR(error_code::not_implemented,
+               "Not implemented activation type %s", nonlinearity_.c_str());
+  }
+  // Replace the output variable in the last CgVariable with outputs[0].
+
+  outputs[0]->reshape(last_out->variable()->shape(), true);
+  last_out->variable()->set_data(outputs[0]->data());
+  last_out->variable()->set_grad(outputs[0]->grad());
+  // Call all setup again to ensure inplaced variable is refer to the correct
+  // array.
+  std::unordered_set<CgFunctionPtr> fclosed;
+  last_out->visit_function_recursive(last_out->parent(), fclosed,
+                                     [](CgFunctionPtr fn) { fn->setup(); });
+  this->last_output_cg_variable_ = last_out;
+}
+
+template <typename T>
+void FusedConvolution<T>::forward_impl(const Variables &inputs,
+                                       const Variables &outputs) {
+  reset_cg_variables(inputs, outputs);
+  bool clear_buffer =
+      SingletonManager::get<GlobalClearBufferState>()->clear_buffer();
+  last_output_cg_variable_->forward(clear_buffer, false);
+}
+
+template <typename T>
+void FusedConvolution<T>::backward_impl(const Variables &inputs,
+                                        const Variables &outputs,
+                                        const vector<bool> &propagate_down,
+                                        const vector<bool> &accum) {
+  reset_cg_variables(inputs, outputs);
+  auto get_index = [this](InName name) {
+    return this->input_variables_[name].first;
+  };
+  input_cg_variables_[X]->set_need_grad(propagate_down[get_index(X)]);
+  input_cg_variables_[WEIGHT]->set_need_grad(propagate_down[get_index(WEIGHT)]);
+  if (input_cg_variables_[BIAS]) {
+    input_cg_variables_[BIAS]->set_need_grad(propagate_down[get_index(BIAS)]);
+  }
+  if (input_cg_variables_[BETA]) {
+    input_cg_variables_[BETA]->set_need_grad(propagate_down[get_index(BETA)]);
+    input_cg_variables_[GAMMA]->set_need_grad(propagate_down[get_index(GAMMA)]);
+    input_cg_variables_[MEAN]->set_need_grad(propagate_down[get_index(MEAN)]);
+    input_cg_variables_[VARIANCE]->set_need_grad(
+        propagate_down[get_index(VARIANCE)]);
+  }
+  if (input_cg_variables_[Z]) {
+    input_cg_variables_[Z]->set_need_grad(propagate_down[get_index(Z)]);
+  }
+
+  // Propagate need_grad states
+  std::unordered_set<CgFunctionPtr> fclosed;
+  last_output_cg_variable_->visit_function_recursive(
+      last_output_cg_variable_->parent(), fclosed, [](CgFunctionPtr fn) {});
+
+  last_output_cg_variable_->backward(outputs[0]->grad(), true);
+}
+}


### PR DESCRIPTION
Add:

FusedConvolution interface and CPU implementation as composite.
Enhancement:

GlobalClearBufferState: Informing clear buffer flag to Functions, Especially it can be use in forward operation in which we determine whether it can delete intermediate buffers.
Visit function as public in CgVariable
Allow optional backward flags in ref_grad for function_tester
Python-like function API can now take nullptr to an input argument to disable the input.
Fixes:

Avoid clearing inplaced gradient buffer
Unit testing in pytest can now handle a function with inplaced gradient outputs