### PR TITLE
Add DLPack interface to share a tensor on host or device among frameworks and libraries without copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@
 /python/src/nnabla/utils/load_function.py
 /python/src/nnabla/utils/nnabla_pb2.py
 /python/src/nnabla/utils/save_function.py
+/python/src/nnabla/utils/dlpack.cpp
 /python/test/Test-error.series.txt
 /python/test/Training-error.series.txt
 /python/test/Training-loss.series.txt
@@ -87,6 +88,8 @@
 /build-android/
 /build-doc/
 /build_wheel_py*/
+/python/src/nnabla/bin/
+/python/src/nnabla/libnnabla.so
 
 # Converted ReST
 # doc/python/tutorial/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,8 @@ if(BUILD_CPP_LIB)
   # includes
   list(APPEND NBLA_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/include
-    ${CMAKE_SOURCE_DIR}/third_party/eigen-3.3.5)
+    ${CMAKE_SOURCE_DIR}/third_party/eigen-3.3.5
+    ${CMAKE_SOURCE_DIR}/third_party/dlpack/include)
   
   if(BUILD_CPP_UTILS)
     list(APPEND NBLA_INCLUDE_DIRS
@@ -344,10 +345,15 @@ if(BUILD_PYTHON_PACKAGE)
   file(GLOB_RECURSE NBLA_PYTHON_DEPS
     ${CMAKE_CURRENT_SOURCE_DIR}/python/src/*.py
     ${CMAKE_CURRENT_SOURCE_DIR}/python/src/*.pyx
-    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/*.pxd)
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/*.pxd,
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/utils/dlpack/*.py,
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/utils/dlpack/*.pyx,
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/utils/dlpack/*.pxd)
   file(GLOB_RECURSE NBLA_PYTHON_BUILD_OUTPUT_CYTHON
     ${CMAKE_CURRENT_SOURCE_DIR}/python/src/*.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/*.h)
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/*.h,
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/utils/dlpack/*.cpp,
+    ${CMAKE_CURRENT_SOURCE_DIR}/python/src/utils/dlpack/*.h)
   
   set(NBLA_PYTHON_SETUP ${CMAKE_CURRENT_SOURCE_DIR}/python/setup.py)
   set(NBLA_PYTHON_OUTPUT ${CMAKE_BINARY_DIR}/build)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,7 @@ if(BUILD_CPP_LIB)
   list(APPEND NBLA_INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/third_party/eigen-3.3.5
-    ${CMAKE_SOURCE_DIR}/third_party/dlpack/include)
+    ${CMAKE_SOURCE_DIR}/include/third_party)
   
   if(BUILD_CPP_UTILS)
     list(APPEND NBLA_INCLUDE_DIRS

--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -43,7 +43,8 @@ nnabla-auto-format:
 		'\./python/src/nnabla/(solver.pyx|function.pyx|function.pxd|function_bases.py)' \
 		'\./python/src/nnabla/utils/(save|load)_function.py' \
 		'\./src/nbla_utils/nnp_impl_create_function.cpp' \
-		'\./src/nbla_utils/nnabla\.pb\.(h|cc)'
+		'\./src/nbla_utils/nnabla\.pb\.(h|cc)' \
+		'\./include/third_party/.*'
 
 
 ########################################################################################################################

--- a/doc/python/api/nd_array.rst
+++ b/doc/python/api/nd_array.rst
@@ -3,5 +3,5 @@
 NdArray
 =======
 
-.. autoclass:: nnabla._nd_array.NdArray
+.. autoclass:: nnabla.NdArray
     :members:

--- a/doc/python/api/utils.rst
+++ b/doc/python/api/utils.rst
@@ -8,5 +8,6 @@ Utils
     utils/image_utils.rst
     utils/data_iterator.rst
     utils/debug_utils.rst
+    utils/dlpack.rst
     utils/misc.rst
 

--- a/doc/python/api/utils/dlpack.rst
+++ b/doc/python/api/utils/dlpack.rst
@@ -1,0 +1,10 @@
+DLPack
+======
+
+Via a `DLPack <https://github.com/dmlc/dlpack>`_ capsule, you can borrow a tensor from external software as a :obj:`nnabla.NdArray` and can share a ``NdArray`` to external software.
+
+.. automodule:: nnabla.utils.dlpack
+
+.. autofunction:: from_dlpack
+
+.. autofunction:: to_dlpack

--- a/docker/development/Dockerfile.onnx-test
+++ b/docker/development/Dockerfile.onnx-test
@@ -122,7 +122,6 @@ RUN umask 0 \
     && pip install -U -r /tmp/deps/setup_requirements.txt \
     && pip install -U -r /tmp/deps/requirements.txt \
     && pip install -U -r /tmp/deps/test_requirements.txt \
-    && conda install pytorch cpuonly -c pytorch \
     && conda clean -y --all \
     && cd / \
     && rm -rf /tmp/*

--- a/docker/development/Dockerfile.onnx-test
+++ b/docker/development/Dockerfile.onnx-test
@@ -122,6 +122,7 @@ RUN umask 0 \
     && pip install -U -r /tmp/deps/setup_requirements.txt \
     && pip install -U -r /tmp/deps/requirements.txt \
     && pip install -U -r /tmp/deps/test_requirements.txt \
+    && conda install pytorch cpuonly -c pytorch \
     && conda clean -y --all \
     && cd / \
     && rm -rf /tmp/*

--- a/include/nbla/array.hpp
+++ b/include/nbla/array.hpp
@@ -62,6 +62,14 @@ protected:
 
   static NBLA_API size_t size_as_bytes(Size_t size, dtypes dtype);
 
+  // This method is used to override Array::pointer.
+  virtual NBLA_API void *mem_pointer() { return mem_.pointer(); }
+
+  // This method is used to override Array::const_pointer.
+  virtual NBLA_API const void *mem_const_pointer() const {
+    return mem_.const_pointer();
+  }
+
 public:
   typedef shared_ptr<Array> Ptr;
 
@@ -70,13 +78,13 @@ public:
   /** Get object pointer.
    */
   template <typename T = void> T *pointer() {
-    return reinterpret_cast<T *>(mem_.pointer());
+    return reinterpret_cast<T *>(mem_pointer());
   }
 
   /** Get constant object pointer
    */
   template <typename T = void> const T *const_pointer() const {
-    return reinterpret_cast<const T *>(mem_.const_pointer());
+    return reinterpret_cast<const T *>(mem_const_pointer());
   }
 
   /** Return dtype. */

--- a/include/nbla/array/cpu_array.hpp
+++ b/include/nbla/array/cpu_array.hpp
@@ -44,5 +44,14 @@ public:
   virtual ~CpuCachedArray();
   static Context filter_context(const Context &ctx);
 };
+
+/** Helper template to copy data from CpuArray with other data type.
+*/
+template <typename Ta, typename Tb>
+void cpu_array_copy(const Array *src, Array *dst);
+
+template <typename T> void cpu_fill(Array *self, float value);
+
+NBLA_DEFINE_COPY_WRAPPER(cpu_array_copy);
 }
 #endif

--- a/include/nbla/array/cpu_array.hpp
+++ b/include/nbla/array/cpu_array.hpp
@@ -44,14 +44,5 @@ public:
   virtual ~CpuCachedArray();
   static Context filter_context(const Context &ctx);
 };
-
-/** Helper template to copy data from CpuArray with other data type.
-*/
-template <typename Ta, typename Tb>
-void cpu_array_copy(const Array *src, Array *dst);
-
-template <typename T> void cpu_fill(Array *self, float value);
-
-NBLA_DEFINE_COPY_WRAPPER(cpu_array_copy);
 }
 #endif

--- a/include/nbla/array/cpu_dlpack_array.hpp
+++ b/include/nbla/array/cpu_dlpack_array.hpp
@@ -1,0 +1,34 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_CPU_DLPACK_ARRAY_HPP__
+#define __NBLA_CPU_DLPACK_ARRAY_HPP__
+
+#include <nbla/array/dlpack_array.hpp>
+
+namespace nbla {
+
+/** CPU array with a borrwed memory pointer from other frameworks via DLPack.
+*/
+class NBLA_API CpuDlpackArray : public DlpackArray {
+public:
+  explicit CpuDlpackArray(const Size_t size, dtypes dtype, const Context &ctx);
+  virtual ~CpuDlpackArray();
+  virtual void copy_from(const Array *src_array);
+  virtual void zero();
+  virtual void fill(float value);
+  static Context filter_context(const Context &ctx);
+};
+}
+#endif

--- a/include/nbla/array/dlpack_array.hpp
+++ b/include/nbla/array/dlpack_array.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
 #ifndef __NBLA_DLPACK_ARRAY_HPP__
 #define __NBLA_DLPACK_ARRAY_HPP__
 
-#include <nbla/array.hpp>
 #include <dlpack/dlpack.h> // third-party
+#include <nbla/array.hpp>
 
 namespace nbla {
 /** Array with a borrwed memory pointer from other frameworks via DLPack.
 */
 class NBLA_API DlpackArray : public Array {
 protected:
-  DLManagedTensor *dlp_ = nullptr;  
+  DLManagedTensor *dlp_ = nullptr;
   void *ptr_ = nullptr; // Borrowed memory pointer added "byte_offset".
 
   // Return the borrowed memory pointer.
@@ -32,7 +32,7 @@ protected:
 
 public:
   /** Constructor not to finish the construction of this class.
-  
+
       This special constructor is expected to be called from
       ArrayCreator::create in SyncedArray::get/cast. After the call,
       DlpackArray::borrow must be done to complete the construction.

--- a/include/nbla/array/dlpack_array.hpp
+++ b/include/nbla/array/dlpack_array.hpp
@@ -1,0 +1,55 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_DLPACK_ARRAY_HPP__
+#define __NBLA_DLPACK_ARRAY_HPP__
+
+#include <nbla/array.hpp>
+#include <dlpack/dlpack.h> // third-party
+
+namespace nbla {
+/** Array with a borrwed memory pointer from other frameworks via DLPack.
+*/
+class NBLA_API DlpackArray : public Array {
+protected:
+  DLManagedTensor *dlp_ = nullptr;  
+  void *ptr_ = nullptr; // Borrowed memory pointer added "byte_offset".
+
+  // Return the borrowed memory pointer.
+  virtual void *mem_pointer() { return ptr_; }
+  virtual const void *mem_const_pointer() const { return ptr_; }
+
+public:
+  /** Constructor not to finish the construction of this class.
+  
+      This special constructor is expected to be called from
+      ArrayCreator::create in SyncedArray::get/cast. After the call,
+      DlpackArray::borrow must be done to complete the construction.
+   */
+  DlpackArray(const Size_t size, dtypes dtype, const Context &ctx);
+  virtual ~DlpackArray();
+  void borrow(DLManagedTensor *dlp);
+
+  // Not implemented methods in this interface class.
+  // Deveclopers must implement them in derived classes.
+  // However, you can see the definition of these methods in .cpp file.
+  // This is becasuse this class is used like dynamic_cast<DlpackArray>
+  // and it needs that this class is not abstruct.
+  virtual void copy_from(const Array *src_array);
+  virtual void zero();
+  virtual void fill(float value);
+  static Context filter_context(const Context &ctx);
+};
+}
+#endif

--- a/include/nbla/array_registry.hpp
+++ b/include/nbla/array_registry.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2017-2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -45,12 +45,11 @@ public:
 
 private:
   // Never be created
-  inline ArrayGroup() {};
+  inline ArrayGroup(){};
 
   /** Get registry of array creator function.
    */
   static Registry_t &get_registry();
-
 };
 
 /** ArrayCreator class this is never be instantiated. */

--- a/include/nbla/array_registry.hpp
+++ b/include/nbla/array_registry.hpp
@@ -31,6 +31,28 @@ using std::string;
 using std::map;
 using std::pair;
 
+/** Array classes which can be get/cast without copy. */
+class NBLA_API ArrayGroup {
+public:
+  // map array classes to group names
+  using Registry_t = map<string, string>;
+
+  /** Register a new array */
+  static void add_group(const string &array_class, const string &group_name);
+
+  /** Get the group name of an array */
+  static string get_group(const string &array_class);
+
+private:
+  // Never be created
+  inline ArrayGroup() {};
+
+  /** Get registry of array creator function.
+   */
+  static Registry_t &get_registry();
+
+};
+
 /** ArrayCreator class this is never be instantiated. */
 class NBLA_API ArrayCreator {
 public:
@@ -91,6 +113,9 @@ private:
    same device class like CpuArray-CpuCachedArray.
  */
 NBLA_API void synchronizer_default(Array *src, Array *dst);
+
+#define NBLA_REGISTER_ARRAY_GROUP(CLASS, GROUP)                                \
+  { ArrayGroup::add_group(#CLASS, #GROUP); }
 
 #define NBLA_REGISTER_ARRAY_CREATOR(CLS)                                       \
   {                                                                            \

--- a/include/nbla/memory/allocator.hpp
+++ b/include/nbla/memory/allocator.hpp
@@ -89,6 +89,13 @@ public:
    */
   NBLA_API AllocatorMemory(shared_ptr<Memory> memory,
                            shared_ptr<Allocator> allocator);
+
+  /** Constructor.
+
+      This is called to create an epmpty instance.
+  */
+  NBLA_API AllocatorMemory();
+
   /** Destructor returns a Memory instance given at a constructor to an
       allocator.
    */

--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -85,6 +85,14 @@ public:
    */
   shared_ptr<const Array> get_sp(dtypes dtype, const Context &ctx);
 
+  /** Get the head array.
+  */
+  Array *head_array();
+
+  /** Get the head array as a shared pointer.
+  */
+  shared_ptr<Array> head_array_sp();
+
   /** Get array's ptr.
 
       @param[in] dtype Enum of data type.

--- a/include/nbla/utils/dlpack_array_registry.hpp
+++ b/include/nbla/utils/dlpack_array_registry.hpp
@@ -1,0 +1,73 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_DLPACK_ARRAY_REGISTRY_HPP__
+#define __NBLA_DLPACK_ARRAY_REGISTRY_HPP__
+
+#include <nbla/context.hpp>
+#include <dlpack/dlpack.h> // third-party
+
+#include <map>
+
+namespace nbla {
+
+using std::map;
+
+/** DlpackArrayCreator class this is never be instantiated.
+
+    This creator class is used only for DlpackArray.
+*/
+class NBLA_API DlpackArrayRegistry {
+  using ArrayToDLDeviceType = map<string, DLDeviceType>;
+  using DLDeviceTypeToArray = map<DLDeviceType, string>;
+  using DLDeviceTypeToBackend = map<DLDeviceType, string>;
+
+  static DLDeviceTypeToArray device_type_to_array_;
+  static DLDeviceTypeToBackend device_type_to_backend_;
+  static ArrayToDLDeviceType array_to_device_type_;
+
+public:
+  /** Interface to create a context for DlpackArray */
+  static Context create_context(const DLTensor &dlp);
+
+  /** Interface to convert an array class to DLDeviceType */
+  static DLDeviceType array_to_device_type(const string &array_class);
+
+  /** Register the map from DLDeviceType to Array class and backend name */
+  static void add_map(const DLDeviceType device_type,
+                      const string &backend,
+                      const string &array_class);
+
+  /** Register the map from Array class to DLDeviceType */
+  static void add_map(const string &array_class,
+                      const DLDeviceType device_tyep);
+private:
+  // Never be created
+  inline DlpackArrayRegistry() {}
+};
+
+//------------------------------------------------------------------------------
+// Mcros to register the information about DLDeviceType.
+//------------------------------------------------------------------------------
+#define NBLA_REGISTER_DLPACK_DEVICE_TYPE_TO_CONTEXT(DEVICE_TYPE, BACKEND, CLS) \
+{                                                                              \
+  DlpackArrayRegistry::add_map(DEVICE_TYPE, #BACKEND, #CLS);                   \
+}
+
+#define NBLA_REGISTER_ARRAY_TO_DLPACK_DEVICE_TYPE(CLS, DEVICE_TYPE)            \
+{                                                                              \
+  DlpackArrayRegistry::add_map(#CLS, DEVICE_TYPE);                             \
+}
+}
+#endif

--- a/include/nbla/utils/dlpack_array_registry.hpp
+++ b/include/nbla/utils/dlpack_array_registry.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #ifndef __NBLA_DLPACK_ARRAY_REGISTRY_HPP__
 #define __NBLA_DLPACK_ARRAY_REGISTRY_HPP__
 
-#include <nbla/context.hpp>
 #include <dlpack/dlpack.h> // third-party
+#include <nbla/context.hpp>
 
 #include <map>
 
@@ -45,13 +45,13 @@ public:
   static DLDeviceType array_to_device_type(const string &array_class);
 
   /** Register the map from DLDeviceType to Array class and backend name */
-  static void add_map(const DLDeviceType device_type,
-                      const string &backend,
+  static void add_map(const DLDeviceType device_type, const string &backend,
                       const string &array_class);
 
   /** Register the map from Array class to DLDeviceType */
   static void add_map(const string &array_class,
                       const DLDeviceType device_tyep);
+
 private:
   // Never be created
   inline DlpackArrayRegistry() {}
@@ -61,13 +61,9 @@ private:
 // Mcros to register the information about DLDeviceType.
 //------------------------------------------------------------------------------
 #define NBLA_REGISTER_DLPACK_DEVICE_TYPE_TO_CONTEXT(DEVICE_TYPE, BACKEND, CLS) \
-{                                                                              \
-  DlpackArrayRegistry::add_map(DEVICE_TYPE, #BACKEND, #CLS);                   \
-}
+  { DlpackArrayRegistry::add_map(DEVICE_TYPE, #BACKEND, #CLS); }
 
 #define NBLA_REGISTER_ARRAY_TO_DLPACK_DEVICE_TYPE(CLS, DEVICE_TYPE)            \
-{                                                                              \
-  DlpackArrayRegistry::add_map(#CLS, DEVICE_TYPE);                             \
-}
+  { DlpackArrayRegistry::add_map(#CLS, DEVICE_TYPE); }
 }
 #endif

--- a/include/nbla/utils/dlpack_utils.hpp
+++ b/include/nbla/utils/dlpack_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #ifndef __NBLA_DLPACK_UTILS_HPP__
 #define __NBLA_DLPACK_UTILS_HPP__
 
-#include <nbla/nd_array.hpp>
 #include <dlpack/dlpack.h> // included from the third-party directory
+#include <nbla/nd_array.hpp>
 
 namespace nbla {
 
@@ -28,19 +28,19 @@ NBLA_API NdArrayPtr from_dlpack(DLManagedTensor *from);
 
 /** NNabla borrows a DLPack Tensor as a NdArray.
 
-    The passed NdArray is destroyed by this function. Into the NdArray, 
+    The passed NdArray is destroyed by this function. Into the NdArray,
     a array shared the memory in DLPack is newly set.
  */
 NBLA_API void from_dlpack(DLManagedTensor *from, NdArray *to);
 
 /** NNabla lends the head array in a NdArray as a DLPack Tensor.
 */
-NBLA_API DLManagedTensor* to_dlpack(NdArray *array);
+NBLA_API DLManagedTensor *to_dlpack(NdArray *array);
 
 /** NNabla lends a array in NdArray as a DLPack Tensor
     according to given dtype and context.
  */
-NBLA_API DLManagedTensor* to_dlpack(NdArray *array, const dtypes dtype,
+NBLA_API DLManagedTensor *to_dlpack(NdArray *array, const dtypes dtype,
                                     const Context &ctx);
 
 /** Call deleter in DLManagedTensor and then delete DLManagedTensor itself

--- a/include/nbla/utils/dlpack_utils.hpp
+++ b/include/nbla/utils/dlpack_utils.hpp
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_DLPACK_UTILS_HPP__
+#define __NBLA_DLPACK_UTILS_HPP__
+
+#include <nbla/nd_array.hpp>
+#include <dlpack/dlpack.h> // included from the third-party directory
+
+namespace nbla {
+
+/** NNabla borrows a DLPack Tensor as a NdArray.
+
+    NdArray is newly created shared the memory in DLPack and is returned.
+*/
+NBLA_API NdArrayPtr from_dlpack(DLManagedTensor *from);
+
+/** NNabla borrows a DLPack Tensor as a NdArray.
+
+    The passed NdArray is destroyed by this function. Into the NdArray, 
+    a array shared the memory in DLPack is newly set.
+ */
+NBLA_API void from_dlpack(DLManagedTensor *from, NdArray *to);
+
+/** NNabla lends the head array in a NdArray as a DLPack Tensor.
+*/
+NBLA_API DLManagedTensor* to_dlpack(NdArray *array);
+
+/** NNabla lends a array in NdArray as a DLPack Tensor
+    according to given dtype and context.
+ */
+NBLA_API DLManagedTensor* to_dlpack(NdArray *array, const dtypes dtype,
+                                    const Context &ctx);
+
+/** Call deleter in DLManagedTensor and then delete DLManagedTensor itself
+ */
+NBLA_API void call_deleter(DLManagedTensor *dlp);
+
+/** Convert DLDataType to Nnabla dtype
+*/
+dtypes convert_dlpack_type_to_dtype(const DLDataType &dlp_type);
+}
+#endif

--- a/include/third_party/dlpack/dlpack.h
+++ b/include/third_party/dlpack/dlpack.h
@@ -1,0 +1,174 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ */
+#ifndef DLPACK_DLPACK_H_
+#define DLPACK_DLPACK_H_
+
+#ifdef __cplusplus
+#define DLPACK_EXTERN_C extern "C"
+#else
+#define DLPACK_EXTERN_C
+#endif
+
+/*! \brief The current version of dlpack */
+#define DLPACK_VERSION 020
+
+/*! \brief DLPACK_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef DLPACK_EXPORTS
+#define DLPACK_DLL __declspec(dllexport)
+#else
+#define DLPACK_DLL __declspec(dllimport)
+#endif
+#else
+#define DLPACK_DLL
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*!
+ * \brief The device type in DLContext.
+ */
+typedef enum {
+  /*! \brief CPU device */
+  kDLCPU = 1,
+  /*! \brief CUDA GPU device */
+  kDLGPU = 2,
+  /*!
+   * \brief Pinned CUDA GPU device by cudaMallocHost
+   * \note kDLCPUPinned = kDLCPU | kDLGPU
+   */
+  kDLCPUPinned = 3,
+  /*! \brief OpenCL devices. */
+  kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics. */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU. */
+  kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
+  kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
+  kDLROCM = 10,
+  /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+  kDLExtDev = 12,
+} DLDeviceType;
+
+/*!
+ * \brief A Device context for Tensor and operator.
+ */
+typedef struct {
+  /*! \brief The device type used in the device. */
+  DLDeviceType device_type;
+  /*! \brief The device index */
+  int device_id;
+} DLContext;
+
+/*!
+ * \brief The type code options DLDataType.
+ */
+typedef enum {
+  kDLInt = 0U,
+  kDLUInt = 1U,
+  kDLFloat = 2U,
+  kDLBfloat = 4U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type the tensor can hold.
+ *
+ *  Examples
+ *   - float: type_code = 2, bits = 32, lanes=1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes=4
+ *   - int8: type_code = 0, bits = 8, lanes=1
+ */
+typedef struct {
+  /*!
+   * \brief Type code of base types.
+   * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+   * footprint, but the value should be one of DLDataTypeCode enum values.
+   * */
+  uint8_t code;
+  /*!
+   * \brief Number of bits, common choices are 8, 16, 32.
+   */
+  uint8_t bits;
+  /*! \brief Number of lanes in the type, used for vector types. */
+  uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief Plain C Tensor object, does not manage memory.
+ */
+typedef struct {
+  /*!
+   * \brief The opaque data pointer points to the allocated data. This will be
+   * CUDA device pointer or cl_mem handle in OpenCL. This pointer is always
+   * aligned to 256 bytes as in CUDA.
+   *
+   * For given DLTensor, the size of memory required to store the contents of
+   * data is calculated as follows:
+   *
+   * \code{.c}
+   * static inline size_t GetDataSize(const DLTensor* t) {
+   *   size_t size = 1;
+   *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+   *     size *= t->shape[i];
+   *   }
+   *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+   *   return size;
+   * }
+   * \endcode
+   */
+  void* data;
+  /*! \brief The device context of the tensor */
+  DLContext ctx;
+  /*! \brief Number of dimensions */
+  int ndim;
+  /*! \brief The data type of the pointer*/
+  DLDataType dtype;
+  /*! \brief The shape of the tensor */
+  int64_t* shape;
+  /*!
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
+   */
+  int64_t* strides;
+  /*! \brief The offset in bytes to the beginning pointer to data */
+  uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to facilitate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ */
+typedef struct DLManagedTensor {
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+  /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+  void * manager_ctx;
+  /*! \brief Destructor signature void (*)(void*) - this should be called
+   *   to destruct manager_ctx which holds the DLManagedTensor. It can be NULL
+   *   if there is no way for the caller to provide a reasonable destructor.
+   *   The destructors deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensor * self);
+} DLManagedTensor;
+#ifdef __cplusplus
+}  // DLPACK_EXTERN_C
+#endif
+#endif  // DLPACK_DLPACK_H_

--- a/python/setup.py
+++ b/python/setup.py
@@ -53,7 +53,7 @@ def extopts(library_name, library_dir):
     include_dir = os.path.realpath(os.path.join(
         os.path.dirname(__file__), '../include'))
     dlpack_include_dir = os.path.realpath(os.path.join(
-        os.path.dirname(__file__), '../third_party/dlpack/include'))
+        os.path.dirname(__file__), '../include/third_party'))
     ext_opts = dict(
         include_dirs=[include_dir, dlpack_include_dir, np.get_include()],
         libraries=[library_name],

--- a/python/setup.py
+++ b/python/setup.py
@@ -52,8 +52,10 @@ def extopts(library_name, library_dir):
     import numpy as np
     include_dir = os.path.realpath(os.path.join(
         os.path.dirname(__file__), '../include'))
+    dlpack_include_dir = os.path.realpath(os.path.join(
+        os.path.dirname(__file__), '../third_party/dlpack/include'))
     ext_opts = dict(
-        include_dirs=[include_dir, np.get_include()],
+        include_dirs=[include_dir, dlpack_include_dir, np.get_include()],
         libraries=[library_name],
         library_dirs=[library_dir],
         language="c++",
@@ -178,9 +180,10 @@ if __name__ == '__main__':
         '_computation_graph',
         '_array',
         '_arithmetic_ops',
-        '_indexing']
+        '_indexing',
+        'utils/dlpack']
 
-    ext_modules = [Extension('nnabla.{}'.format(mname),
+    ext_modules = [Extension('nnabla.{}'.format(mname.replace('/', '.')),
                              [os.path.join(path_pkg,
                                            '{}.pyx'.format(mname))],
                              **ext_opts) for mname in module_names]

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -108,8 +108,8 @@ cdef c_as_numpy_array(CNdArray * arrp, str mode, cpp_bool force_dtype=False, int
 
 cdef class NdArray:
     """
-    :class:`nnabla._nd_array.NdArray` is a device-agnostic data container for multi-dimensional arrays (tensors).
-    :class:`nnabla._nd_array.NdArray` can also implicitly handle data transfers across different devices (e.g. CPU to CUDA GPU, CUDA GPU to CPU).
+    :class:`nnabla.NdArray` is a device-agnostic data container for multi-dimensional arrays (tensors).
+    :class:`nnabla.NdArray` can also implicitly handle data transfers across different devices (e.g. CPU to CUDA GPU, CUDA GPU to CPU).
     See `Python API Tutorial <http://nnabla.readthedocs.io/en/latest/python/tutorial/python_api.html>`_ for more details.
 
     :class:`~nnabla.NdArray` overrides some arithmetic operators
@@ -146,7 +146,7 @@ cdef class NdArray:
             nparr (~numpy.ndarray): Numpy multi-dimensional array.
 
         Returns: 
-            nnabla._nd_array.NdArray
+            nnabla.NdArray
 
         """
         assert isinstance(nparr, np.ndarray)
@@ -303,7 +303,7 @@ cdef class NdArray:
         """
         Returns the values held by this array as a :class:`numpy.ndarray`.
         Note that only the references are returned, and the values are not copied. Therefore,
-        modifying the returned :class:`nnabla._nd_array.NdArray` will affect the data contained inside the
+        modifying the returned :class:`nnabla.NdArray` will affect the data contained inside the
         NNabla array.
         This method can also be called as a setter where an array is created as the same type as rhs.
         There is an exception where `zero()` or `fill(rhs)` is invoked if a scalar with a float or an
@@ -354,7 +354,7 @@ cdef class NdArray:
                 * 'rw': You can both read and write.
             dtype (:obj:`numpy.dtype`, optional): Force dtype of a returned array.
 
-        See :function:`nnabla._nd_array.NdArray.data` for more details.
+        See :function:`nnabla.NdArray.data` for more details.
 
         '''
         if dtype is None:

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -121,7 +121,7 @@ cdef class Variable:
     * Reference to the parent function in a
       computation graph. This provides traceability of all connections in the computation graph.
     * Both data and error
-      signal (gradient) containers as :class:`nnabla._nd_array.NdArray` s.
+      signal (gradient) containers as :class:`nnabla.NdArray` s.
     * Some additional information of the computation graph.
 
     :class:`~nnabla.Variable` overrides some arithmetic operators
@@ -384,14 +384,14 @@ cdef class Variable:
     @property
     def data(self):
         """Returns the data held by this variable, as a
-        :class:`~nnabla._nd_array.NdArray`. This can also be used as a setter.
+        :class:`~nnabla.NdArray`. This can also be used as a setter.
 
         Args:
-            ndarray (~nnabla._nd_array.NdArray): NdArray object. Size must
+            ndarray (~nnabla.NdArray): NdArray object. Size must
                 be the same as this Variable.
 
         Returns:
-            :class:`~nnabla._nd_array.NdArray`
+            :class:`~nnabla.NdArray`
         """
         return NdArray.create(self.varp.variable().get().data())
 
@@ -402,14 +402,14 @@ cdef class Variable:
     @property
     def grad(self):
         """Returns the gradient held by this variable, as a
-        :class:`~nnabla._nd_array.NdArray`. This can also be used as a setter.
+        :class:`~nnabla.NdArray`. This can also be used as a setter.
 
         Args:
-            ndarray (~nnabla._nd_array.NdArray): NdArray object. Size must
+            ndarray (~nnabla.NdArray): NdArray object. Size must
                 be the same as this Variable.
 
         Returns:
-            :class:`~nnabla._nd_array.NdArray`
+            :class:`~nnabla.NdArray`
         """
         return NdArray.create(self.varp.variable().get().grad())
 
@@ -425,7 +425,7 @@ cdef class Variable:
         modification of the returned ndarray will affect the data of the
         NNabla array.
         This method can be called as a setter to set the value held by this variable.
-        Refer to the documentation of the setter `nnabla._nd_array.NdArray.data`
+        Refer to the documentation of the setter `nnabla.NdArray.data`
         for detailed behaviors of the setter.
 
         Args:
@@ -448,7 +448,7 @@ cdef class Variable:
         modification of the returned ndarray will affect the data of the
         NNabla array.
         This method can be called as a setter to set the gradient held by this variable.        
-        Refer to the documentation of the setter `nnabla._nd_array.NdArray.data`
+        Refer to the documentation of the setter `nnabla.NdArray.data`
         for detailed behaviors of the setter.
 
         Args:
@@ -550,7 +550,7 @@ cdef class Variable:
         The propagation will stop at a variable with need_grad=False.
 
         Args:
-            grad(scalar, :obj:`numpy.ndarray`, :obj:`nnabla._nd_array.NdArray`, or None):
+            grad(scalar, :obj:`numpy.ndarray`, :obj:`nnabla.NdArray`, or None):
                 The gradient signal value(s) of this variable.
                 The default value 1 is used in an usual neural network training.
                 This option is useful if you have a gradient computation module outside NNabla,

--- a/python/src/nnabla/experimental/mixed_precision_training.py
+++ b/python/src/nnabla/experimental/mixed_precision_training.py
@@ -27,7 +27,7 @@ class DynamicLossScalingUpdater(object):
         accum_grad (:obj:`int`): Number of accumulation of gradients. Update method of the `solver` is called after the `accum_grad` number of the forward and backward is called.
         weight_decay (:obj:`float`): Decay constant. Default is `None`, not applying the weight decay.
         comm (:obj:`nnabla.communicators.Communicator`): Communicator when to do distributed training. Default is :obj:`None`.
-        grads (:obj:`list` of :obj:`nnabla._nd_array.NdArray`): The list of gradients to be exchanged when to do distributed training. Default is the empty :obj:`list`.
+        grads (:obj:`list` of :obj:`nnabla.NdArray`): The list of gradients to be exchanged when to do distributed training. Default is the empty :obj:`list`.
 
     Attributes:
         solver (:obj:`nnabla.solvers.Solver`): Solver object. E.g., Momentum or Adam.
@@ -40,7 +40,7 @@ class DynamicLossScalingUpdater(object):
         accum_grad (:obj:`int`): Number of accumulation of gradients. Update method of the `solver` is called after the `accum_grad` number of the forward and backward is called.
         weight_decay (:obj:`float`): Decay constant. Default is `None`, not applying the weight decay.
         comm (:obj:`nnabla.communicators.Communicator`): Communicator when to do distributed training.
-        grads (:obj:`list` of :obj:`nnabla._nd_array.NdArray`): The list of gradients to be exchanged when to do distributed training.
+        grads (:obj:`list` of :obj:`nnabla.NdArray`): The list of gradients to be exchanged when to do distributed training.
 
     Example:
 

--- a/python/src/nnabla/experimental/trainers/updater.py
+++ b/python/src/nnabla/experimental/trainers/updater.py
@@ -31,7 +31,7 @@ class Updater(object):
         clear_buffer (:obj:`bool`, optional): Clears the no longer referenced variables during backpropagation to save memory.
         accum_grad (:obj:`int`, optional): Number of accumulation of gradients. Update method of the `solver` is called after the `accum_grad` number of the forward and backward is called. Default is 1.
         comm (:obj:`nnabla.communicators.Communicator`, optional): Communicator when to do distributed training. Default is :obj:`None`.
-        grads (:obj:`list` of :obj:`nnabla._nd_array.NdArray`, optional): The list of gradients to be exchanged when to do distributed training. Default is the empty :obj:`list`.
+        grads (:obj:`list` of :obj:`nnabla.NdArray`, optional): The list of gradients to be exchanged when to do distributed training. Default is the empty :obj:`list`.
 
     Example:
 

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -407,7 +407,7 @@ cdef class UnsafeVariable:
         """Get data as ``NdArray``.
 
         Returns:
-            :class:`~nnabla._nd_array.NdArray`
+            :class:`~nnabla.NdArray`
         """
         return NdArray.create(self.var.data())
 
@@ -416,7 +416,7 @@ cdef class UnsafeVariable:
         """Get grad as ``NdArray``.
 
         Returns:
-            :class:`~nnabla._nd_array.NdArray`
+            :class:`~nnabla.NdArray`
         """
         return NdArray.create(self.var.grad())
 

--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -252,7 +252,7 @@ def grad(outputs, inputs, grad_outputs=None, persistent_outputs=[], bind_grad_ou
     Args: 
         outputs (list of :obj:`~nnabla.Variable` or :obj:`~nnabla.Variable`): Outputs of the differentiable function.
         inputs (list of :obj:`~nnabla.Variable` or :obj:`~nnabla.Variable`): Inputs w.r.t. which the gradients of outputs are computed.
-        grad_outputs (None, scalar, :obj:`numpy.ndarray`, :obj:`nnabla._nd_array.NdArray`, or list of scalar, :obj:`numpy.ndarray`, or :obj:`nnabla._nd_array.NdArray`, ): Gradient outputs corresponding to outputs. This is same as the grad argument of :meth:`~nnabla.Variable.backward`. Default is None, so 1 is used as the in-coming gradient at the very beginning of the Variable in the backward graph.
+        grad_outputs (None, scalar, :obj:`numpy.ndarray`, :obj:`nnabla.NdArray`, or list of scalar, :obj:`numpy.ndarray`, or :obj:`nnabla.NdArray`, ): Gradient outputs corresponding to outputs. This is same as the grad argument of :meth:`~nnabla.Variable.backward`. Default is None, so 1 is used as the in-coming gradient at the very beginning of the Variable in the backward graph.
         persistent_outputs (list of `bool`): Outputs become persistent accordingly. If not specified, all outputs become persistent.
         bind_grad_output (`bool`): Bind data to grad of input variable. This is useful for the case where one wants to use the backward graph for training a neural network using the first-order gradients only. Default is False.
 

--- a/python/src/nnabla/utils/dlpack.pxd
+++ b/python/src/nnabla/utils/dlpack.pxd
@@ -1,0 +1,28 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .._context cimport CContext
+from .._array cimport dtypes
+from .._nd_array cimport CNdArray, NdArrayPtr
+
+cdef extern from "nbla/utils/dlpack_utils.hpp":
+    cdef struct CDLManagedTensor "DLManagedTensor":
+        pass
+
+cdef extern from "nbla/utils/dlpack_utils.hpp" namespace "nbla":
+    NdArrayPtr from_dlpack(CDLManagedTensor *dltensor) nogil except+
+    void from_dlpack(CDLManagedTensor *dltensor, CNdArray *a) nogil except+
+    CDLManagedTensor* to_dlpack(CNdArray *a) nogil except+
+    CDLManagedTensor* to_dlpack(CNdArray *a, const dtypes dtype, const CContext &ctx) nogil except+
+    void call_deleter(CDLManagedTensor *dlp) nogil except+

--- a/python/src/nnabla/utils/dlpack.pyx
+++ b/python/src/nnabla/utils/dlpack.pyx
@@ -1,3 +1,17 @@
+# Copyright (c) 2017-2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from .._nd_array cimport NdArray
 from dlpack cimport from_dlpack as c_from_dlpack, \
                     to_dlpack as c_to_dlpack, \
@@ -21,6 +35,48 @@ cdef const char *c_str_used_dltensor = "used_dltensor"
 
 
 def from_dlpack(dlp, arr=None):
+    '''
+    Decode a DLPack to :obj:`~nnabla.NdArray`.
+
+    Example:
+
+    .. code-block:: python
+
+        # Create a tensor of an external tool, and encode as an DLPack.
+        import torch
+        from torch.utils.dlpack import to_dlpack
+        t = torch.ones((5, 5), dtype=torch.float32,
+                       device=torch.device('cuda'))
+        dlp = to_dlpack(t)
+
+        # Borrow the DLPack tensor as nnabla.NdArray
+        from nnabla.utils.dlpack import from_dlpack
+        arr = from_dlpack(dlp)
+
+    If you want to move an ownership of DLPack to an exiting ``NdArray``;
+
+    .. code-block:: python
+
+        from nnabla import NdArray
+        arr = NdArray()
+        from_dlpack(dlp, arr=arr)
+
+    Args:
+
+        dlp(PyCapsule):
+            A PyCapsule object of a ``DLManagedTensor`` (as ``"dltensor"``) which
+            internal memory is borrowed by a tensor of an external package.
+            The ownership of the ``DLManagedTensor``
+            is moved to an ``NdArray`` object, and the PyCapsule object is marked
+            as ``"used_dltensor"`` to inform that the ownership has been moved.
+        arr(~nnabla.NdArray):
+            If specified, a given DLPack is decoded to it. Otherwise, it
+            creates a new ``NdArray`` object and decodes the DLPack to it.
+
+    Returns:
+        ~nnabla.NdArray: an ``NdArray`` object borrowing the DLPack tensor.
+
+    '''
     if not PyCapsule_IsValid(dlp, c_str_dltensor):
         raise ValueError("Invalid PyCapsule.")
 
@@ -47,9 +103,53 @@ cdef void delete_unused_dltensor(object dlp):
         call_deleter(<CDLManagedTensor *>PyCapsule_GetPointer(dlp, c_str_dltensor));
 
 
-# The head array of SyncedArray is set in DLPack.
-# If dtype and ctx are given, the array is casted before the setting in DLPack.
 def to_dlpack(a, dtype=None, ctx=None):
+    '''
+    Returns a DLPack which owns an internal array object borrowed by a
+    specified :obj:`~nnabla.NdArray`.
+
+    Example:
+
+    .. code-block:: python
+
+        # Create a nnabla.NdArray in CUDA.
+        import nnabla as nn
+        from nnabla.ext_utils import get_extension_context
+        ctx = get_extension_context('cudnn')
+        a = nn.NdArray.from_numpy_array(np.ones((5, 5), dtype=np.float32))
+        a.cast(np.float32, ctx)
+
+        # Expose as a DLPack.
+        from nnabla.utils.dlpack import to_dlpack
+        dlp = to_dlpack(a)
+
+        # Use the DLPack in PyTorch.
+        import torch
+        from torch.utils.dlpack import from_dlpack
+        t = from_dlpack(dlp)
+
+        # Changing the values in Torch will also be affected in nnabla
+        # because they share memory.
+        t.add_(1)
+        print(a.d)  # All values become 2.
+
+    Args:
+        a (~nnabla.NdArray):
+            An ``NdArray`` object. An internal array which is recently modified
+            or created will be encoded into a DLPack.
+        dtype (numpy.dtype):
+            If specified, in-place cast operation may be performed before
+            encoding it to a DLPack.
+        ctx (~nnabla.Context):
+            If specified, in-place device transfer operation may be performed
+            before encoding it into a DLPack.
+
+    Returns:
+        PyCapsule:
+            A PyCapsule object of a ``DLManagedTensor`` (as ``"dltensor"``) which
+            internal memory is borrowed by the specified ``NdArray``.
+
+    '''
     cdef CDLManagedTensor *cdlp
     cdef CContext cctx
     cdef dtypes cdtype

--- a/python/src/nnabla/utils/dlpack.pyx
+++ b/python/src/nnabla/utils/dlpack.pyx
@@ -1,0 +1,73 @@
+from .._nd_array cimport NdArray
+from dlpack cimport from_dlpack as c_from_dlpack, \
+                    to_dlpack as c_to_dlpack, \
+                    call_deleter
+from cpython.pycapsule cimport *
+from cpython cimport Py_INCREF
+import nnabla as nn
+import numpy as np
+
+'''
+NNabla expects the followings to a borrowed DLPack.
+- The name of PyCapsule is "dltensor".
+- If some framwork borrows the tensor from NNabla,
+  it renames the PyCapsule other than "dltensor".
+- DLManagedTensor::deleter deletes DLManagedTensor itself
+  because NNabla will not do this to avoid double free.
+'''
+
+cdef const char *c_str_dltensor = "dltensor"
+cdef const char *c_str_used_dltensor = "used_dltensor"
+
+
+def from_dlpack(dlp, arr=None):
+    if not PyCapsule_IsValid(dlp, c_str_dltensor):
+        raise ValueError("Invalid PyCapsule.")
+
+    cdef void *cdlp = PyCapsule_GetPointer(dlp, c_str_dltensor)
+    if arr is None:
+        arr = NdArray.create(c_from_dlpack(<CDLManagedTensor*> cdlp))
+    else:
+        c_from_dlpack(<CDLManagedTensor*> cdlp, (<NdArray?> arr).arrp)
+
+    # NNabla gets the ownership of DLManagedTensor.
+    # The rename from "dltensor" to "used_dltensor" informs
+    # that this DLPack is already borrowed by NNabla.
+    PyCapsule_SetName(dlp, c_str_used_dltensor)
+    # The destructor is unset because NNabla will delete the object.
+    PyCapsule_SetDestructor(dlp, NULL)
+
+    return arr
+
+
+# DLManagedTensor in PyCapsule which is not borrwed from any framework
+# is deleted by this destructor of Pycapsule.
+cdef void delete_unused_dltensor(object dlp):
+    if PyCapsule_IsValid(dlp, c_str_dltensor):
+        call_deleter(<CDLManagedTensor *>PyCapsule_GetPointer(dlp, c_str_dltensor));
+
+
+# The head array of SyncedArray is set in DLPack.
+# If dtype and ctx are given, the array is casted before the setting in DLPack.
+def to_dlpack(a, dtype=None, ctx=None):
+    cdef CDLManagedTensor *cdlp
+    cdef CContext cctx
+    cdef dtypes cdtype
+    cdef int type_num
+    
+    if ctx is not None and dtype is not None:
+        cdlp = c_to_dlpack((<NdArray ?> a).arrp)
+    else:
+        if ctx is None:
+            ctx = nn.get_current_context()
+        cctx = <CContext ?> ctx
+
+        if dtype is None:
+            cdtype = (<NdArray ?> a).arrp.array().get().dtype()
+        else:
+            type_num = np.dtype(dtype).num
+            cdtype = <dtypes>type_num
+
+        cdlp = c_to_dlpack((<NdArray ?> a).arrp, cdtype, cctx)
+
+    return PyCapsule_New(<void*>cdlp, c_str_dltensor, &delete_unused_dltensor)

--- a/python/test/utils/test_dlpack.py
+++ b/python/test/utils/test_dlpack.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2018 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import nnabla as nn
+import nnabla.utils.dlpack
+import numpy as np
+from nnabla.ext_utils import list_extensions, \
+                             get_extension_context
+from nnabla.testing import assert_allclose
+
+# Try to import PyTorch
+try:
+    import torch
+    import torch.utils.dlpack
+except ImportError:
+    pytest.skip('PyTorch is not installed.',
+                allow_module_level=True)
+
+
+ext_names = list_extensions()
+types = [[np.float32, torch.float32]]
+
+
+# PyTorch to NNabla
+@pytest.mark.parametrize("ext_name", ext_names)
+@pytest.mark.parametrize("numpy_type, torch_type", types)
+def test_from_dlpack_new(ext_name, numpy_type, torch_type):
+    ctx = get_extension_context(ext_name)
+    device_name = ctx.backend[0].split(':')[0]
+    if device_name == 'cudnn':
+        device_name = 'cuda' # for PyTorch
+    nn.set_default_context(ctx)
+
+    # Init PyTorch Tensor    
+    t = torch.ones((5, 5), dtype=torch_type,
+                   device=torch.device(device_name))
+
+    # PyTorch to DLPack
+    dlp = torch.utils.dlpack.to_dlpack(t)
+
+    # DLPack to NNabla
+    a = nn.utils.dlpack.from_dlpack(dlp)
+    assert a.dtype == numpy_type
+
+    # Check if the memory locations are still same,
+    # which means DlpackArray is not copied to other arrays
+    # in the same ArrayGroup.
+    a += 1
+    assert np.all(a.data == t.to('cpu').detach().numpy().copy())
+
+
+@pytest.mark.parametrize("ext_name", ext_names)
+@pytest.mark.parametrize("numpy_type, torch_type", types)
+def test_from_dlpack_given(ext_name, numpy_type, torch_type):
+    ctx = get_extension_context(ext_name)
+    device_name = ctx.backend[0].split(':')[0]
+    if device_name == 'cudnn':
+        device_name = 'cuda' # for PyTorch
+    nn.set_default_context(ctx)
+
+    # Init PyTorch Tensor    
+    t = torch.ones((5, 5), dtype=torch_type,
+                   device=torch.device(device_name))
+
+    # PyTorch to DLPack
+    dlp = torch.utils.dlpack.to_dlpack(t)
+
+    # DLPack to NNabla
+    a = nn.NdArray()
+    nn.utils.dlpack.from_dlpack(dlp, a)
+    assert a.dtype == numpy_type
+
+    # Check if the memory locations are still same,
+    # which means DlpackArray is not copied to other arrays
+    # in the same ArrayGroup.
+    a += 1
+    assert np.all(a.data == t.to('cpu').detach().numpy().copy())
+
+
+# NNabla to Pytorch
+@pytest.mark.parametrize("ext_name", ext_names)
+@pytest.mark.parametrize("numpy_type, torch_type", types)
+@pytest.mark.parametrize("set_dtype, set_ctx", [(False, False), (True, False),
+                                                (False, True), (True, True)])
+def test_to_dlpack(ext_name, numpy_type, torch_type, set_dtype, set_ctx):
+    ctx = get_extension_context(ext_name)
+    nn.set_default_context(ctx)
+
+    # Init nnabla.NdArray
+    a = nn.NdArray.from_numpy_array(np.ones((5, 5), dtype=numpy_type))
+    a.cast(numpy_type)
+
+    # NNabla to DLPack
+    passed_dtype = numpy_type if set_dtype else None
+    passed_ctx = ctx if set_ctx else None
+    dlp = nn.utils.dlpack.to_dlpack(a, passed_dtype, passed_ctx)
+
+    # DLPack to PyTorch
+    t = torch.utils.dlpack.from_dlpack(dlp)
+    assert t.dtype == torch_type
+
+    # Check if the memory locations are still same.
+    t.add_(1) # in-place add
+    assert np.all(a.data == t.to('cpu').detach().numpy().copy())
+
+
+# NNabla to Pytorch
+@pytest.mark.parametrize("ext_name", ext_names)
+@pytest.mark.parametrize("numpy_type, torch_type", types)
+def test_to_dlpack_no_borrower(ext_name, numpy_type, torch_type):
+    ctx = get_extension_context(ext_name)
+    nn.set_default_context(ctx)
+
+    # Init nnabla.NdArray
+    a = nn.NdArray.from_numpy_array(np.ones((5, 5), dtype=numpy_type))
+
+    # NNabla to DLPack
+    dlp = nn.utils.dlpack.to_dlpack(a)
+
+    # No one borrows dlp. It will be destruct by PyCapsule destructor.

--- a/python/test/utils/test_dlpack.py
+++ b/python/test/utils/test_dlpack.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Sony Corporation. All Rights Reserved.
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -40,10 +40,10 @@ def test_from_dlpack_new(ext_name, numpy_type, torch_type):
     ctx = get_extension_context(ext_name)
     device_name = ctx.backend[0].split(':')[0]
     if device_name == 'cudnn':
-        device_name = 'cuda' # for PyTorch
+        device_name = 'cuda'  # for PyTorch
     nn.set_default_context(ctx)
 
-    # Init PyTorch Tensor    
+    # Init PyTorch Tensor
     t = torch.ones((5, 5), dtype=torch_type,
                    device=torch.device(device_name))
 
@@ -67,10 +67,10 @@ def test_from_dlpack_given(ext_name, numpy_type, torch_type):
     ctx = get_extension_context(ext_name)
     device_name = ctx.backend[0].split(':')[0]
     if device_name == 'cudnn':
-        device_name = 'cuda' # for PyTorch
+        device_name = 'cuda'  # for PyTorch
     nn.set_default_context(ctx)
 
-    # Init PyTorch Tensor    
+    # Init PyTorch Tensor
     t = torch.ones((5, 5), dtype=torch_type,
                    device=torch.device(device_name))
 
@@ -100,7 +100,7 @@ def test_to_dlpack(ext_name, numpy_type, torch_type, set_dtype, set_ctx):
 
     # Init nnabla.NdArray
     a = nn.NdArray.from_numpy_array(np.ones((5, 5), dtype=numpy_type))
-    a.cast(numpy_type)
+    a.cast(numpy_type, ctx)
 
     # NNabla to DLPack
     passed_dtype = numpy_type if set_dtype else None
@@ -112,7 +112,7 @@ def test_to_dlpack(ext_name, numpy_type, torch_type, set_dtype, set_ctx):
     assert t.dtype == torch_type
 
     # Check if the memory locations are still same.
-    t.add_(1) # in-place add
+    t.add_(1)  # in-place add
     assert np.all(a.data == t.to('cpu').detach().numpy().copy())
 
 

--- a/src/nbla/array/cpu_array-internal.hpp
+++ b/src/nbla/array/cpu_array-internal.hpp
@@ -1,0 +1,42 @@
+// Copyright (c) 2017-2020 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_CPU_ARRAY_INTERNAL_HPP_
+#define NBLA_CPU_ARRAY_INTERNAL_HPP_
+#include <nbla/array/cpu_array.hpp>
+
+namespace nbla {
+/** Helper template to copy data from CpuArray with other data type.
+*/
+template <typename Ta, typename Tb>
+void cpu_array_copy(const Array *src, Array *dst) {
+  const Ta *p_src = src->const_pointer<Ta>();
+  Tb *p_dst = dst->pointer<Tb>();
+  if (!src->size()) {
+    // zero-size means scalar
+    *p_dst = *p_src;
+    return;
+  }
+  std::copy(p_src, p_src + src->size(), p_dst);
+}
+
+template <typename T> void cpu_fill(Array *self, float value) {
+  T *ptr = self->pointer<T>();
+  size_t size = self->size();
+  std::fill(ptr, ptr + size, static_cast<T>(value));
+}
+
+NBLA_DEFINE_COPY_WRAPPER(cpu_array_copy);
+} // End of namespace nbla
+#endif

--- a/src/nbla/array/cpu_array.cpp
+++ b/src/nbla/array/cpu_array.cpp
@@ -67,7 +67,6 @@ Context CpuArray::filter_context(const Context &ctx) {
   return Context({}, "CpuArray", "");
 }
 
-NBLA_DEFINE_COPY_WRAPPER(cpu_array_copy);
 NBLA_DEFINE_FUNC_COPY_FROM(CpuArray, cpu_array_copy, cpu);
 NBLA_DEFINE_FUNC_FILL(CpuArray, cpu_fill, cpu);
 

--- a/src/nbla/array/cpu_array.cpp
+++ b/src/nbla/array/cpu_array.cpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // cpu_array.cpp
-#include <nbla/array/cpu_array.hpp>
+#include "./cpu_array-internal.hpp"
 #include <nbla/array_registry.hpp>
 #include <nbla/common.hpp>
 #include <nbla/cpu.hpp>
@@ -41,26 +41,6 @@ CpuArray::~CpuArray() {}
 void CpuArray::zero() {
   std::memset(this->pointer<void>(), 0,
               this->size() * sizeof_dtype(this->dtype_));
-}
-
-/** Helper template to copy data from CpuArray with other data type.
-*/
-template <typename Ta, typename Tb>
-void cpu_array_copy(const Array *src, Array *dst) {
-  const Ta *p_src = src->const_pointer<Ta>();
-  Tb *p_dst = dst->pointer<Tb>();
-  if (!src->size()) {
-    // zero-size means scalar
-    *p_dst = *p_src;
-    return;
-  }
-  std::copy(p_src, p_src + src->size(), p_dst);
-}
-
-template <typename T> void cpu_fill(Array *self, float value) {
-  T *ptr = self->pointer<T>();
-  size_t size = self->size();
-  std::fill(ptr, ptr + size, static_cast<T>(value));
 }
 
 Context CpuArray::filter_context(const Context &ctx) {

--- a/src/nbla/array/cpu_dlpack_array.cpp
+++ b/src/nbla/array/cpu_dlpack_array.cpp
@@ -15,6 +15,8 @@
 #include <nbla/array/cpu_array.hpp>
 #include <nbla/array/cpu_dlpack_array.hpp>
 
+#include <cstring>
+
 namespace nbla {
 
 CpuDlpackArray::CpuDlpackArray(const Size_t size, dtypes dtype,

--- a/src/nbla/array/cpu_dlpack_array.cpp
+++ b/src/nbla/array/cpu_dlpack_array.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <nbla/array/cpu_array.hpp>
+#include "./cpu_array-internal.hpp"
 #include <nbla/array/cpu_dlpack_array.hpp>
 
 #include <cstring>

--- a/src/nbla/array/cpu_dlpack_array.cpp
+++ b/src/nbla/array/cpu_dlpack_array.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array/cpu_dlpack_array.hpp>
+#include <nbla/array/cpu_array.hpp>
+
+namespace nbla {
+
+CpuDlpackArray::CpuDlpackArray(const Size_t size, dtypes dtype,
+                               const Context &ctx)
+  : DlpackArray(size, dtype, ctx) {}
+
+CpuDlpackArray::~CpuDlpackArray() {}
+
+Context CpuDlpackArray::filter_context(const Context &ctx) {
+  return Context({}, "CpuDlpackArray", "");
+}
+
+void CpuDlpackArray::zero() {
+  std::memset(this->pointer<void>(), 0,
+              this->size() * sizeof_dtype(this->dtype_));
+}
+
+NBLA_DEFINE_FUNC_COPY_FROM(CpuDlpackArray, cpu_array_copy, cpu);
+NBLA_DEFINE_FUNC_FILL(CpuDlpackArray, cpu_fill, cpu);
+}

--- a/src/nbla/array/cpu_dlpack_array.cpp
+++ b/src/nbla/array/cpu_dlpack_array.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <nbla/array/cpu_dlpack_array.hpp>
 #include <nbla/array/cpu_array.hpp>
+#include <nbla/array/cpu_dlpack_array.hpp>
 
 namespace nbla {
 
 CpuDlpackArray::CpuDlpackArray(const Size_t size, dtypes dtype,
                                const Context &ctx)
-  : DlpackArray(size, dtype, ctx) {}
+    : DlpackArray(size, dtype, ctx) {}
 
 CpuDlpackArray::~CpuDlpackArray() {}
 

--- a/src/nbla/array/dlpack_array.cpp
+++ b/src/nbla/array/dlpack_array.cpp
@@ -1,0 +1,56 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array/dlpack_array.hpp>
+#include <nbla/utils/dlpack_utils.hpp>
+
+namespace nbla {
+
+DlpackArray::DlpackArray(const Size_t size, dtypes dtype, const Context &ctx)
+  : Array(size, dtype, ctx, AllocatorMemory()) {}
+
+DlpackArray::~DlpackArray() {
+  call_deleter(dlp_); // Call the given deleter to return the borrowed array.
+}
+
+inline void *get_ptr_with_offset(const DLTensor &dl_tensor) {
+  return reinterpret_cast<void*>(reinterpret_cast<char*>(dl_tensor.data)
+                                 + dl_tensor.byte_offset);
+}
+
+void  DlpackArray::borrow(DLManagedTensor *dlp) {
+  dlp_ = dlp;
+  ptr_ = get_ptr_with_offset(dlp->dl_tensor);
+}
+
+void DlpackArray::copy_from(const Array *src_array) {
+  NBLA_ERROR(error_code::not_implemented,
+             "DlpackArray must implement copy_from(const Array *src_array).");
+}
+
+void DlpackArray::zero() {
+  NBLA_ERROR(error_code::not_implemented,
+             "Array must implement zero().");
+}
+
+void DlpackArray::fill(float value) {
+  NBLA_ERROR(error_code::not_implemented,
+             "Array must implement fill(float value).");
+}
+
+Context DlpackArray::filter_context(const Context &ctx) {
+  NBLA_ERROR(error_code::not_implemented,
+            "Array must implement filter_context(const Context&).");
+}
+}

--- a/src/nbla/array/dlpack_array.cpp
+++ b/src/nbla/array/dlpack_array.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,18 +18,18 @@
 namespace nbla {
 
 DlpackArray::DlpackArray(const Size_t size, dtypes dtype, const Context &ctx)
-  : Array(size, dtype, ctx, AllocatorMemory()) {}
+    : Array(size, dtype, ctx, AllocatorMemory()) {}
 
 DlpackArray::~DlpackArray() {
   call_deleter(dlp_); // Call the given deleter to return the borrowed array.
 }
 
 inline void *get_ptr_with_offset(const DLTensor &dl_tensor) {
-  return reinterpret_cast<void*>(reinterpret_cast<char*>(dl_tensor.data)
-                                 + dl_tensor.byte_offset);
+  return reinterpret_cast<void *>(reinterpret_cast<char *>(dl_tensor.data) +
+                                  dl_tensor.byte_offset);
 }
 
-void  DlpackArray::borrow(DLManagedTensor *dlp) {
+void DlpackArray::borrow(DLManagedTensor *dlp) {
   dlp_ = dlp;
   ptr_ = get_ptr_with_offset(dlp->dl_tensor);
 }
@@ -40,8 +40,7 @@ void DlpackArray::copy_from(const Array *src_array) {
 }
 
 void DlpackArray::zero() {
-  NBLA_ERROR(error_code::not_implemented,
-             "Array must implement zero().");
+  NBLA_ERROR(error_code::not_implemented, "Array must implement zero().");
 }
 
 void DlpackArray::fill(float value) {
@@ -51,6 +50,6 @@ void DlpackArray::fill(float value) {
 
 Context DlpackArray::filter_context(const Context &ctx) {
   NBLA_ERROR(error_code::not_implemented,
-            "Array must implement filter_context(const Context&).");
+             "Array must implement filter_context(const Context&).");
 }
 }

--- a/src/nbla/array_registry.cpp
+++ b/src/nbla/array_registry.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2017-2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -42,14 +42,13 @@ string ArrayGroup::get_group(const string &array_class) {
   Registry_t &registry = get_registry();
   try {
     return registry.at(array_class);
-  }
-  catch (std::out_of_range &) {
+  } catch (std::out_of_range &) {
     vector<string> keys;
-      for (auto &kv : registry) {
-        keys.push_back(kv.first);
-      }
-      NBLA_ERROR(error_code::unclassified, "'%s' cannot be found in [%s].",
-                 array_class.c_str(), string_join(keys, ", ").c_str());
+    for (auto &kv : registry) {
+      keys.push_back(kv.first);
+    }
+    NBLA_ERROR(error_code::unclassified, "'%s' cannot be found in [%s].",
+               array_class.c_str(), string_join(keys, ", ").c_str());
   }
 }
 

--- a/src/nbla/array_registry.cpp
+++ b/src/nbla/array_registry.cpp
@@ -25,6 +25,34 @@ using std::shared_ptr;
 using std::string;
 using std::vector;
 
+// Array group
+ArrayGroup::Registry_t &ArrayGroup::get_registry() {
+  static Registry_t registry_;
+  return registry_;
+}
+
+void ArrayGroup::add_group(const string &array_class,
+                           const string &group_name) {
+  Registry_t &registry = get_registry();
+  registry[array_class] = group_name;
+}
+
+string ArrayGroup::get_group(const string &array_class) {
+  init_cpu();
+  Registry_t &registry = get_registry();
+  try {
+    return registry.at(array_class);
+  }
+  catch (std::out_of_range &) {
+    vector<string> keys;
+      for (auto &kv : registry) {
+        keys.push_back(kv.first);
+      }
+      NBLA_ERROR(error_code::unclassified, "'%s' cannot be found in [%s].",
+                 array_class.c_str(), string_join(keys, ", ").c_str());
+  }
+}
+
 // Array Factory
 ArrayCreator::Registry_t &ArrayCreator::get_registry() {
   static Registry_t registry_;

--- a/src/nbla/function/generic/dequantize_linear.cpp
+++ b/src/nbla/function/generic/dequantize_linear.cpp
@@ -75,7 +75,6 @@ void DequantizeLinear<T>::backward_impl(const Variables &inputs,
 
   auto x = inputs[0];
   auto scale = inputs[1];
-  auto zero_point = inputs[2];
   auto y = outputs[0];
 
   auto dx_sptr = make_shared<Variable>(x->shape());

--- a/src/nbla/function/generic/quantize_linear.cpp
+++ b/src/nbla/function/generic/quantize_linear.cpp
@@ -126,7 +126,6 @@ void QuantizeLinear<T>::backward_impl(const Variables &inputs,
 
   auto x = inputs[0];
   auto scale = inputs[1];
-  auto zero_point = inputs[2];
   auto y = outputs[0];
   auto dx_sptr = make_shared<Variable>(x->shape());
   auto dy_sptr = make_shared<Variable>(y->shape());

--- a/src/nbla/init.cpp.tmpl
+++ b/src/nbla/init.cpp.tmpl
@@ -21,7 +21,9 @@
 
 #include <nbla/cpu.hpp>
 #include <nbla/array_registry.hpp>
+#include <nbla/utils/dlpack_array_registry.hpp>
 #include <nbla/array/cpu_array.hpp>
+#include <nbla/array/cpu_dlpack_array.hpp>
 #include <nbla/function_registry.hpp>
 % for name, snake_name, _ in function_list:
 % if name in function_types:
@@ -49,6 +51,21 @@ void init_cpu() {
                                    synchronizer_default);
   NBLA_REGISTER_ARRAY_SYNCHRONIZER(CpuCachedArray, CpuArray,
                                    synchronizer_default);
+  NBLA_REGISTER_ARRAY_CREATOR(CpuDlpackArray);
+  SingletonManager::get<Cpu>()->register_array_class("CpuDlpackArray");
+  NBLA_REGISTER_DLPACK_DEVICE_TYPE_TO_CONTEXT(kDLCPU, cpu, CpuDlpackArray);
+  NBLA_REGISTER_ARRAY_TO_DLPACK_DEVICE_TYPE(CpuArray, kDLCPU);
+  NBLA_REGISTER_ARRAY_TO_DLPACK_DEVICE_TYPE(CpuCachedArray, kDLCPU);
+  // It is not necessary that DlpackArray is converted from other arrays.
+  NBLA_REGISTER_ARRAY_SYNCHRONIZER(CpuDlpackArray, CpuArray,
+                                   synchronizer_default);
+  NBLA_REGISTER_ARRAY_SYNCHRONIZER(CpuDlpackArray, CpuCachedArray,
+                                   synchronizer_default);
+
+  // Array group registration
+  NBLA_REGISTER_ARRAY_GROUP(CpuArray, cpu);
+  NBLA_REGISTER_ARRAY_GROUP(CpuCachedArray, cpu);
+  NBLA_REGISTER_ARRAY_GROUP(CpuDlpackArray, cpu);
 
   // Function registration
 % for name, _, arg_types in function_list:

--- a/src/nbla/memory/allocator.cpp
+++ b/src/nbla/memory/allocator.cpp
@@ -95,6 +95,9 @@ AllocatorMemory::AllocatorMemory(shared_ptr<Memory> memory,
     : memory_(memory), allocator_(allocator) {
   memory->lock();
 }
+
+AllocatorMemory::AllocatorMemory() : memory_(nullptr), allocator_(nullptr)  {}
+
 void AllocatorMemory::release() {
   if (!memory_) {
     return;
@@ -103,6 +106,7 @@ void AllocatorMemory::release() {
   allocator_->free(memory_);
   memory_ = nullptr;
 }
+
 AllocatorMemory::~AllocatorMemory() { this->release(); }
 
 AllocatorMemory::AllocatorMemory(AllocatorMemory &&rhs) {

--- a/src/nbla/memory/allocator.cpp
+++ b/src/nbla/memory/allocator.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2017-2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -96,7 +96,7 @@ AllocatorMemory::AllocatorMemory(shared_ptr<Memory> memory,
   memory->lock();
 }
 
-AllocatorMemory::AllocatorMemory() : memory_(nullptr), allocator_(nullptr)  {}
+AllocatorMemory::AllocatorMemory() : memory_(nullptr), allocator_(nullptr) {}
 
 void AllocatorMemory::release() {
   if (!memory_) {

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -87,6 +87,15 @@ shared_ptr<const Array> SyncedArray::get_sp(dtypes dtype, const Context &ctx) {
   return std::const_pointer_cast<const Array>(array_[desc.key].first);
 }
 
+Array *SyncedArray::head_array() {
+  return head_array_sp().get();
+}
+
+shared_ptr<Array> SyncedArray::head_array_sp() {
+  return array_[head_.key].first;
+}
+
+
 const void *SyncedArray::data_ptr(dtypes dtype, const Context &ctx,
                                   bool write_only) {
   cast_sp(dtype, ctx, write_only);
@@ -108,11 +117,17 @@ void SyncedArray::fill(float value) {
 
 size_t SyncedArray::modification_count() const { return modification_count_; }
 
+inline string create_key(const dtypes &dtype, const Context &ctx) {
+  // Array classes in the same array group are identified in SyncedArray. 
+  return ctx.device_id + ":" + ArrayGroup::get_group(ctx.array_class) + ":" +
+         dtype_to_string(dtype);
+}
+
 SyncedArray::ArrayDesc SyncedArray::sync(dtypes dtype, const Context &ctx_orig,
                                          bool write_only) {
   Context ctx = ArrayCreator::filter_context(ctx_orig);
-  ArrayDesc desc{get_array_key_from_context(ctx) + ":" + dtype_to_string(dtype),
-                 ctx.array_class, dtype};
+  ArrayDesc desc{create_key(dtype, ctx), ctx.array_class, dtype};
+
   // Specified array is not allocated
   if (array_.find(desc.key) == array_.end()) {
     if (array_.size() == 0)

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2017-2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -87,14 +87,11 @@ shared_ptr<const Array> SyncedArray::get_sp(dtypes dtype, const Context &ctx) {
   return std::const_pointer_cast<const Array>(array_[desc.key].first);
 }
 
-Array *SyncedArray::head_array() {
-  return head_array_sp().get();
-}
+Array *SyncedArray::head_array() { return head_array_sp().get(); }
 
 shared_ptr<Array> SyncedArray::head_array_sp() {
   return array_[head_.key].first;
 }
-
 
 const void *SyncedArray::data_ptr(dtypes dtype, const Context &ctx,
                                   bool write_only) {
@@ -118,7 +115,7 @@ void SyncedArray::fill(float value) {
 size_t SyncedArray::modification_count() const { return modification_count_; }
 
 inline string create_key(const dtypes &dtype, const Context &ctx) {
-  // Array classes in the same array group are identified in SyncedArray. 
+  // Array classes in the same array group are identified in SyncedArray.
   return ctx.device_id + ":" + ArrayGroup::get_group(ctx.array_class) + ":" +
          dtype_to_string(dtype);
 }

--- a/src/nbla/utils/dlpack_array_registry.cpp
+++ b/src/nbla/utils/dlpack_array_registry.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/utils/dlpack_array_registry.hpp>
+#include <nbla/utils/dlpack_utils.hpp>
+
+namespace nbla {
+
+DlpackArrayRegistry::ArrayToDLDeviceType
+DlpackArrayRegistry::array_to_device_type_;
+
+DlpackArrayRegistry::DLDeviceTypeToArray
+DlpackArrayRegistry::device_type_to_array_;
+
+DlpackArrayRegistry::DLDeviceTypeToBackend
+DlpackArrayRegistry::device_type_to_backend_;
+
+template <typename K, typename V>
+void raise_error(const map<K, V> &map, const string &key_name,
+                 const string &key) {
+  vector<K> keys;
+  for (const auto &kv : map) {
+    keys.push_back(kv.first);
+  }
+
+  NBLA_ERROR(error_code::unclassified, "%s %s cannot be found in [%s].",
+    key_name, key, string_join(keys, ", ").c_str());
+}
+
+Context DlpackArrayRegistry::create_context(const DLTensor &dl_tensor) {
+  init_cpu();
+
+  // Compute the array size
+  Size_t size = 1;
+  for (int i = 0; i < dl_tensor.ndim; i++) {
+    size *= dl_tensor.shape[i];
+  }
+
+  // Determine NNabla dtype from DLPack
+  const auto dtype = convert_dlpack_type_to_dtype(dl_tensor.dtype);
+
+  // Create NNabla context from DLPack
+  const auto dev_t = dl_tensor.ctx.device_type;
+
+  // Array class
+  string array_class = "";
+  try {
+    array_class = device_type_to_array_.at(dev_t);
+  }
+  catch (std::out_of_range&) {
+    raise_error(device_type_to_array_, "DLDeviceType", std::to_string(dev_t));
+  }
+
+  // Device ID
+  const auto device_id = std::to_string(dl_tensor.ctx.device_id);
+
+  // Backend  
+  string backend = "";
+  try {
+    backend = device_type_to_backend_.at(dev_t);
+  }
+  catch (std::out_of_range&) {
+    raise_error(device_type_to_backend_, "DLDeviceType", std::to_string(dev_t));
+  }
+
+  auto str_dtpe = dtype_to_string(dtype);
+  // Convert FLOAT to float, and HALF to half
+  std::transform(str_dtpe.begin(), str_dtpe.end(), str_dtpe.begin(), ::tolower);
+  backend = string_join(vector<string>{backend, str_dtpe}, ":");
+    
+  return Context({backend}, array_class, device_id);
+}
+
+DLDeviceType
+DlpackArrayRegistry::array_to_device_type(const string &array_class) {
+  try {
+    return array_to_device_type_.at(array_class);
+  }
+  catch (std::out_of_range &) {
+    raise_error(array_to_device_type_, "Array class", array_class);
+  }
+}
+
+void DlpackArrayRegistry::add_map(const DLDeviceType device_type,
+                                  const string &backend,
+                                  const string &array_class) {
+  device_type_to_array_.insert({device_type, array_class});
+  device_type_to_backend_.insert({device_type, backend});
+}
+
+void DlpackArrayRegistry::add_map(const string &array_class,
+                                  const DLDeviceType device_tyep) {
+  array_to_device_type_.insert({array_class, device_tyep});
+}
+}

--- a/src/nbla/utils/dlpack_array_registry.cpp
+++ b/src/nbla/utils/dlpack_array_registry.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,13 +18,13 @@
 namespace nbla {
 
 DlpackArrayRegistry::ArrayToDLDeviceType
-DlpackArrayRegistry::array_to_device_type_;
+    DlpackArrayRegistry::array_to_device_type_;
 
 DlpackArrayRegistry::DLDeviceTypeToArray
-DlpackArrayRegistry::device_type_to_array_;
+    DlpackArrayRegistry::device_type_to_array_;
 
 DlpackArrayRegistry::DLDeviceTypeToBackend
-DlpackArrayRegistry::device_type_to_backend_;
+    DlpackArrayRegistry::device_type_to_backend_;
 
 template <typename K, typename V>
 void raise_error(const map<K, V> &map, const string &key_name,
@@ -35,7 +35,7 @@ void raise_error(const map<K, V> &map, const string &key_name,
   }
 
   NBLA_ERROR(error_code::unclassified, "%s %s cannot be found in [%s].",
-    key_name, key, string_join(keys, ", ").c_str());
+             key_name, key, string_join(keys, ", ").c_str());
 }
 
 Context DlpackArrayRegistry::create_context(const DLTensor &dl_tensor) {
@@ -57,20 +57,18 @@ Context DlpackArrayRegistry::create_context(const DLTensor &dl_tensor) {
   string array_class = "";
   try {
     array_class = device_type_to_array_.at(dev_t);
-  }
-  catch (std::out_of_range&) {
+  } catch (std::out_of_range &) {
     raise_error(device_type_to_array_, "DLDeviceType", std::to_string(dev_t));
   }
 
   // Device ID
   const auto device_id = std::to_string(dl_tensor.ctx.device_id);
 
-  // Backend  
+  // Backend
   string backend = "";
   try {
     backend = device_type_to_backend_.at(dev_t);
-  }
-  catch (std::out_of_range&) {
+  } catch (std::out_of_range &) {
     raise_error(device_type_to_backend_, "DLDeviceType", std::to_string(dev_t));
   }
 
@@ -78,7 +76,7 @@ Context DlpackArrayRegistry::create_context(const DLTensor &dl_tensor) {
   // Convert FLOAT to float, and HALF to half
   std::transform(str_dtpe.begin(), str_dtpe.end(), str_dtpe.begin(), ::tolower);
   backend = string_join(vector<string>{backend, str_dtpe}, ":");
-    
+
   return Context({backend}, array_class, device_id);
 }
 
@@ -86,8 +84,7 @@ DLDeviceType
 DlpackArrayRegistry::array_to_device_type(const string &array_class) {
   try {
     return array_to_device_type_.at(array_class);
-  }
-  catch (std::out_of_range &) {
+  } catch (std::out_of_range &) {
     raise_error(array_to_device_type_, "Array class", array_class);
   }
 }

--- a/src/nbla/utils/dlpack_array_registry.cpp
+++ b/src/nbla/utils/dlpack_array_registry.cpp
@@ -35,7 +35,7 @@ void raise_error(const map<K, V> &map, const string &key_name,
   }
 
   NBLA_ERROR(error_code::unclassified, "%s %s cannot be found in [%s].",
-             key_name, key, string_join(keys, ", ").c_str());
+             key_name.c_str(), key.c_str(), string_join(keys, ", ").c_str());
 }
 
 Context DlpackArrayRegistry::create_context(const DLTensor &dl_tensor) {
@@ -87,6 +87,7 @@ DlpackArrayRegistry::array_to_device_type(const string &array_class) {
   } catch (std::out_of_range &) {
     raise_error(array_to_device_type_, "Array class", array_class);
   }
+  return kDLCPU;
 }
 
 void DlpackArrayRegistry::add_map(const DLDeviceType device_type,

--- a/src/nbla/utils/dlpack_utils.cpp
+++ b/src/nbla/utils/dlpack_utils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+// Copyright (c) 2020 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <nbla/utils/dlpack_utils.hpp>
-#include <nbla/utils/dlpack_array_registry.hpp>
 #include <nbla/array/dlpack_array.hpp>
+#include <nbla/utils/dlpack_array_registry.hpp>
+#include <nbla/utils/dlpack_utils.hpp>
 
 namespace nbla {
 
@@ -24,7 +24,7 @@ inline uint8_t convert_dtype_to_dlpack_code(const dtypes dtype) {
   case dtypes::DTYPE:                                                          \
     code = DLCODE;                                                             \
     break;
-// End of macro
+  // End of macro
 
   uint8_t code;
   switch (dtype) {
@@ -45,7 +45,8 @@ inline uint8_t convert_dtype_to_dlpack_code(const dtypes dtype) {
     SET_CODE(HALF, kDLBfloat);
   default:
     NBLA_ERROR(error_code::type, "dtype %s cannot be converted to "
-                                 "DLDataTypeCode.", dtype_to_string(dtype));
+                                 "DLDataTypeCode.",
+               dtype_to_string(dtype));
     break;
   }
   return code;
@@ -59,7 +60,7 @@ Shape_t get_shape_with_contiguous_memory(DLManagedTensor *dlp) {
   const auto strides = dlp->dl_tensor.strides;
   Shape_t ret_shape(ndim);
   size_t contig_stride = 1;
-  
+
   for (int i = ndim - 1; i >= 0; i--) {
     NBLA_CHECK(strides[i] == contig_stride, error_code::value,
                "The array elements must be contiguous in memery for NNabla. "
@@ -70,7 +71,6 @@ Shape_t get_shape_with_contiguous_memory(DLManagedTensor *dlp) {
 
   return ret_shape;
 }
-
 
 inline bool cmp_bits_dtype(const uint8_t bits, const dtypes dtype) {
   return bits == sizeof_dtype(dtype) * 8;
@@ -88,58 +88,45 @@ dtypes convert_dlpack_type_to_dtype(const DLDataType &dlp_type) {
   // determines which type is chosen.
   if (code == kDLBfloat && cmp_bits_dtype(bits, dtypes::HALF)) {
     return dtypes::HALF;
-  }
-  else if (code == kDLFloat) {
+  } else if (code == kDLFloat) {
     if (cmp_bits_dtype(bits, dtypes::FLOAT)) {
       return dtypes::FLOAT;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::DOUBLE)) {
+    } else if (cmp_bits_dtype(bits, dtypes::DOUBLE)) {
       return dtypes::DOUBLE;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::LONGDOUBLE)) {
+    } else if (cmp_bits_dtype(bits, dtypes::LONGDOUBLE)) {
       return dtypes::LONGDOUBLE;
     }
-  }
-  else if (code == kDLInt) {
+  } else if (code == kDLInt) {
     if (cmp_bits_dtype(bits, dtypes::INT)) {
       return dtypes::INT;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::BYTE)) {
+    } else if (cmp_bits_dtype(bits, dtypes::BYTE)) {
       return dtypes::BYTE;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::SHORT)) {
+    } else if (cmp_bits_dtype(bits, dtypes::SHORT)) {
       return dtypes::SHORT;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::LONG)) {
+    } else if (cmp_bits_dtype(bits, dtypes::LONG)) {
       return dtypes::LONG;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::LONGLONG)) {
+    } else if (cmp_bits_dtype(bits, dtypes::LONGLONG)) {
       return dtypes::LONGLONG;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::BOOL)) {
+    } else if (cmp_bits_dtype(bits, dtypes::BOOL)) {
       return dtypes::BOOL;
     }
-  }
-  else if (code == kDLUInt) {
+  } else if (code == kDLUInt) {
     if (cmp_bits_dtype(bits, dtypes::UINT)) {
       return dtypes::UINT;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::UBYTE)) {
+    } else if (cmp_bits_dtype(bits, dtypes::UBYTE)) {
       return dtypes::UBYTE;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::USHORT)) {
+    } else if (cmp_bits_dtype(bits, dtypes::USHORT)) {
       return dtypes::USHORT;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::ULONG)) {
+    } else if (cmp_bits_dtype(bits, dtypes::ULONG)) {
       return dtypes::ULONG;
-    }
-    else if (cmp_bits_dtype(bits, dtypes::ULONGLONG)) {
+    } else if (cmp_bits_dtype(bits, dtypes::ULONGLONG)) {
       return dtypes::ULONGLONG;
     }
   }
 
   NBLA_ERROR(error_code::type, "No matching types between NNabla dtypes and "
-             "DLPack DLDataType. code: %d, bits: %d", code, bits);
+                               "DLPack DLDataType. code: %d, bits: %d",
+             code, bits);
 }
 
 NdArrayPtr from_dlpack(DLManagedTensor *from) {
@@ -151,9 +138,9 @@ NdArrayPtr from_dlpack(DLManagedTensor *from) {
 void from_dlpack(DLManagedTensor *from, NdArray *to) {
   const auto shape = get_shape_with_contiguous_memory(from);
   to->reshape(shape, true);
-  dynamic_cast<DlpackArray*>(
-    to->cast(convert_dlpack_type_to_dtype(from->dl_tensor.dtype),
-             DlpackArrayRegistry::create_context(from->dl_tensor), true))
+  dynamic_cast<DlpackArray *>(
+      to->cast(convert_dlpack_type_to_dtype(from->dl_tensor.dtype),
+               DlpackArrayRegistry::create_context(from->dl_tensor), true))
       ->borrow(from);
 }
 
@@ -164,7 +151,7 @@ public:
   manager_ctx(const shared_ptr<Array> &array) : array_(array) {}
 };
 
-void deleter(struct DLManagedTensor* self) {
+void deleter(struct DLManagedTensor *self) {
   // Delete the members
   delete[] self->dl_tensor.shape;
   delete[] self->dl_tensor.strides;
@@ -174,7 +161,7 @@ void deleter(struct DLManagedTensor* self) {
   delete self;
 }
 
-DLManagedTensor* to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
+DLManagedTensor *to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
                                 const Shape_t &shape, const Shape_t &strides) {
   const auto dtype = arr_ptr->dtype();
   const auto ctx = arr_ptr->context();
@@ -183,22 +170,22 @@ DLManagedTensor* to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
   DLTensor dl_tensor;
 
   // data
-  dl_tensor.data = arr_ptr->pointer<void*>();
+  dl_tensor.data = arr_ptr->pointer<void *>();
 
   // DLContext
   // DLDeviceType
-  dl_tensor.ctx.device_type
-    = DlpackArrayRegistry::array_to_device_type(ctx.array_class);
+  dl_tensor.ctx.device_type =
+      DlpackArrayRegistry::array_to_device_type(ctx.array_class);
 
   // Map string device_id in NNabla to int device_id in DLPack
   dl_tensor.ctx.device_id = 0;
   if (ctx.device_id != "") { // map "" to 0
     try {
       dl_tensor.ctx.device_id = std::stoi(ctx.device_id);
-    }
-    catch (...) {
+    } catch (...) {
       NBLA_ERROR(error_code::value, "device_id %s cannot be converted to "
-        "integer.", ctx.device_id);
+                                    "integer.",
+                 ctx.device_id);
     }
   }
 
@@ -238,7 +225,8 @@ DLManagedTensor* to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
   dl_managed_tensor->dl_tensor = dl_tensor;
 
   // manager_ctx
-  dl_managed_tensor->manager_ctx = static_cast<void*>(new manager_ctx(arr_ptr));
+  dl_managed_tensor->manager_ctx =
+      static_cast<void *>(new manager_ctx(arr_ptr));
 
   // deleter
   dl_managed_tensor->deleter = deleter;
@@ -246,18 +234,16 @@ DLManagedTensor* to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
   return dl_managed_tensor;
 }
 
-DLManagedTensor* to_dlpack(NdArray *array) {
+DLManagedTensor *to_dlpack(NdArray *array) {
   const auto arr_ptr = array->array()->head_array_sp();
   return to_dlpack_impl(arr_ptr, array->shape(), array->strides());
 }
 
-DLManagedTensor* to_dlpack(NdArray *array, const dtypes dtype,
+DLManagedTensor *to_dlpack(NdArray *array, const dtypes dtype,
                            const Context &ctx) {
   const auto arr_ptr = array->cast_sp(dtype, ctx);
   return to_dlpack_impl(arr_ptr, array->shape(), array->strides());
 }
 
-void call_deleter(DLManagedTensor *dlp) {
-  dlp->deleter(dlp);
-}
+void call_deleter(DLManagedTensor *dlp) { dlp->deleter(dlp); }
 }

--- a/src/nbla/utils/dlpack_utils.cpp
+++ b/src/nbla/utils/dlpack_utils.cpp
@@ -1,0 +1,263 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/utils/dlpack_utils.hpp>
+#include <nbla/utils/dlpack_array_registry.hpp>
+#include <nbla/array/dlpack_array.hpp>
+
+namespace nbla {
+
+inline uint8_t convert_dtype_to_dlpack_code(const dtypes dtype) {
+// Local macro (undef locally)
+#define SET_CODE(DTYPE, DLCODE)                                                \
+  case dtypes::DTYPE:                                                          \
+    code = DLCODE;                                                             \
+    break;
+// End of macro
+
+  uint8_t code;
+  switch (dtype) {
+    SET_CODE(BOOL, kDLInt);
+    SET_CODE(BYTE, kDLInt);
+    SET_CODE(SHORT, kDLInt);
+    SET_CODE(INT, kDLInt);
+    SET_CODE(LONG, kDLInt);
+    SET_CODE(LONGLONG, kDLInt);
+    SET_CODE(UBYTE, kDLUInt);
+    SET_CODE(USHORT, kDLUInt);
+    SET_CODE(UINT, kDLUInt);
+    SET_CODE(ULONG, kDLUInt);
+    SET_CODE(ULONGLONG, kDLUInt);
+    SET_CODE(FLOAT, kDLFloat);
+    SET_CODE(DOUBLE, kDLFloat);
+    SET_CODE(LONGDOUBLE, kDLFloat);
+    SET_CODE(HALF, kDLBfloat);
+  default:
+    NBLA_ERROR(error_code::type, "dtype %s cannot be converted to "
+                                 "DLDataTypeCode.", dtype_to_string(dtype));
+    break;
+  }
+  return code;
+
+#undef SET_CODE
+}
+
+Shape_t get_shape_with_contiguous_memory(DLManagedTensor *dlp) {
+  const auto ndim = dlp->dl_tensor.ndim;
+  const auto shape = dlp->dl_tensor.shape;
+  const auto strides = dlp->dl_tensor.strides;
+  Shape_t ret_shape(ndim);
+  size_t contig_stride = 1;
+  
+  for (int i = ndim - 1; i >= 0; i--) {
+    NBLA_CHECK(strides[i] == contig_stride, error_code::value,
+               "The array elements must be contiguous in memery for NNabla. "
+               "Check strides in DLPack DLTensor.");
+    contig_stride *= shape[i];
+    ret_shape[i] = shape[i];
+  }
+
+  return ret_shape;
+}
+
+
+inline bool cmp_bits_dtype(const uint8_t bits, const dtypes dtype) {
+  return bits == sizeof_dtype(dtype) * 8;
+}
+
+dtypes convert_dlpack_type_to_dtype(const DLDataType &dlp_type) {
+  const auto code = dlp_type.code;
+  const auto bits = dlp_type.bits;
+
+  NBLA_CHECK(dlp_type.lanes == 1, error_code::value,
+             "NNabla does not have vectrized types.");
+
+  // When some dtypes have the same bit size, for example long and long long
+  // have 32 bits in some architectures, the order of following "if" statements
+  // determines which type is chosen.
+  if (code == kDLBfloat && cmp_bits_dtype(bits, dtypes::HALF)) {
+    return dtypes::HALF;
+  }
+  else if (code == kDLFloat) {
+    if (cmp_bits_dtype(bits, dtypes::FLOAT)) {
+      return dtypes::FLOAT;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::DOUBLE)) {
+      return dtypes::DOUBLE;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::LONGDOUBLE)) {
+      return dtypes::LONGDOUBLE;
+    }
+  }
+  else if (code == kDLInt) {
+    if (cmp_bits_dtype(bits, dtypes::INT)) {
+      return dtypes::INT;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::BYTE)) {
+      return dtypes::BYTE;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::SHORT)) {
+      return dtypes::SHORT;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::LONG)) {
+      return dtypes::LONG;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::LONGLONG)) {
+      return dtypes::LONGLONG;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::BOOL)) {
+      return dtypes::BOOL;
+    }
+  }
+  else if (code == kDLUInt) {
+    if (cmp_bits_dtype(bits, dtypes::UINT)) {
+      return dtypes::UINT;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::UBYTE)) {
+      return dtypes::UBYTE;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::USHORT)) {
+      return dtypes::USHORT;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::ULONG)) {
+      return dtypes::ULONG;
+    }
+    else if (cmp_bits_dtype(bits, dtypes::ULONGLONG)) {
+      return dtypes::ULONGLONG;
+    }
+  }
+
+  NBLA_ERROR(error_code::type, "No matching types between NNabla dtypes and "
+             "DLPack DLDataType. code: %d, bits: %d", code, bits);
+}
+
+NdArrayPtr from_dlpack(DLManagedTensor *from) {
+  auto to = make_shared<NdArray>();
+  from_dlpack(from, to.get());
+  return to;
+}
+
+void from_dlpack(DLManagedTensor *from, NdArray *to) {
+  const auto shape = get_shape_with_contiguous_memory(from);
+  to->reshape(shape, true);
+  dynamic_cast<DlpackArray*>(
+    to->cast(convert_dlpack_type_to_dtype(from->dl_tensor.dtype),
+             DlpackArrayRegistry::create_context(from->dl_tensor), true))
+      ->borrow(from);
+}
+
+class manager_ctx {
+  shared_ptr<Array> array_;
+
+public:
+  manager_ctx(const shared_ptr<Array> &array) : array_(array) {}
+};
+
+void deleter(struct DLManagedTensor* self) {
+  // Delete the members
+  delete[] self->dl_tensor.shape;
+  delete[] self->dl_tensor.strides;
+  delete self->manager_ctx;
+
+  // Finally delete itself.
+  delete self;
+}
+
+DLManagedTensor* to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
+                                const Shape_t &shape, const Shape_t &strides) {
+  const auto dtype = arr_ptr->dtype();
+  const auto ctx = arr_ptr->context();
+
+  // Create a DLTensor
+  DLTensor dl_tensor;
+
+  // data
+  dl_tensor.data = arr_ptr->pointer<void*>();
+
+  // DLContext
+  // DLDeviceType
+  dl_tensor.ctx.device_type
+    = DlpackArrayRegistry::array_to_device_type(ctx.array_class);
+
+  // Map string device_id in NNabla to int device_id in DLPack
+  dl_tensor.ctx.device_id = 0;
+  if (ctx.device_id != "") { // map "" to 0
+    try {
+      dl_tensor.ctx.device_id = std::stoi(ctx.device_id);
+    }
+    catch (...) {
+      NBLA_ERROR(error_code::value, "device_id %s cannot be converted to "
+        "integer.", ctx.device_id);
+    }
+  }
+
+  // ndim
+  // It is a down-sized cast, but int type should be large enough for ndim
+  dl_tensor.ndim = static_cast<int>(shape.size());
+
+  // DLDataType
+  // code
+  dl_tensor.dtype.code = convert_dtype_to_dlpack_code(dtype);
+
+  // bits
+  dl_tensor.dtype.bits = sizeof_dtype(dtype) * 8;
+
+  // lanes
+  dl_tensor.dtype.lanes = 1;
+
+  // shape
+  dl_tensor.shape = new int64_t[dl_tensor.ndim]; // will deleted in deleter.
+  for (int i = 0; i < dl_tensor.ndim; i++) {
+    dl_tensor.shape[i] = shape[i];
+  }
+
+  // strides
+  dl_tensor.strides = new int64_t[dl_tensor.ndim]; // will deleted in deleter.
+  for (int i = 0; i < dl_tensor.ndim; i++) {
+    dl_tensor.strides[i] = strides[i];
+  }
+
+  // byte_offset
+  dl_tensor.byte_offset = 0;
+
+  // Create a DLManagedTensor
+  auto dl_managed_tensor = new DLManagedTensor();
+
+  // dl_tensor
+  dl_managed_tensor->dl_tensor = dl_tensor;
+
+  // manager_ctx
+  dl_managed_tensor->manager_ctx = static_cast<void*>(new manager_ctx(arr_ptr));
+
+  // deleter
+  dl_managed_tensor->deleter = deleter;
+
+  return dl_managed_tensor;
+}
+
+DLManagedTensor* to_dlpack(NdArray *array) {
+  const auto arr_ptr = array->array()->head_array_sp();
+  return to_dlpack_impl(arr_ptr, array->shape(), array->strides());
+}
+
+DLManagedTensor* to_dlpack(NdArray *array, const dtypes dtype,
+                           const Context &ctx) {
+  const auto arr_ptr = array->cast_sp(dtype, ctx);
+  return to_dlpack_impl(arr_ptr, array->shape(), array->strides());
+}
+
+void call_deleter(DLManagedTensor *dlp) {
+  dlp->deleter(dlp);
+}
+}

--- a/src/nbla/utils/dlpack_utils.cpp
+++ b/src/nbla/utils/dlpack_utils.cpp
@@ -46,7 +46,7 @@ inline uint8_t convert_dtype_to_dlpack_code(const dtypes dtype) {
   default:
     NBLA_ERROR(error_code::type, "dtype %s cannot be converted to "
                                  "DLDataTypeCode.",
-               dtype_to_string(dtype));
+               dtype_to_string(dtype).c_str());
     break;
   }
   return code;
@@ -155,7 +155,7 @@ void deleter(struct DLManagedTensor *self) {
   // Delete the members
   delete[] self->dl_tensor.shape;
   delete[] self->dl_tensor.strides;
-  delete self->manager_ctx;
+  delete static_cast<manager_ctx *>(self->manager_ctx);
 
   // Finally delete itself.
   delete self;
@@ -185,7 +185,7 @@ DLManagedTensor *to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
     } catch (...) {
       NBLA_ERROR(error_code::value, "device_id %s cannot be converted to "
                                     "integer.",
-                 ctx.device_id);
+                 ctx.device_id.c_str());
     }
   }
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -51,4 +51,8 @@ endif()
 if(BUILD_CPP_UTILS)
   download_and_extract_library(cmdline-master .zip https://github.com/tanakh/cmdline/archive/master.zip)
 endif()
-  
+
+download_and_extract_library(dlpack .zip https://github.com/dmlc/dlpack/archive/v0.3.zip)
+if(NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/dlpack)
+  file(RENAME ${CMAKE_SOURCE_DIR}/third_party/dlpack-0.3 ${CMAKE_SOURCE_DIR}/third_party/dlpack)
+endif()

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -51,8 +51,3 @@ endif()
 if(BUILD_CPP_UTILS)
   download_and_extract_library(cmdline-master .zip https://github.com/tanakh/cmdline/archive/master.zip)
 endif()
-
-download_and_extract_library(dlpack .zip https://github.com/dmlc/dlpack/archive/v0.3.zip)
-if(NOT IS_DIRECTORY ${CMAKE_SOURCE_DIR}/third_party/dlpack)
-  file(RENAME ${CMAKE_SOURCE_DIR}/third_party/dlpack-0.3 ${CMAKE_SOURCE_DIR}/third_party/dlpack)
-endif()

--- a/third_party/LICENSES.md
+++ b/third_party/LICENSES.md
@@ -792,6 +792,10 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ## [DLPack](https://github.com/dmlc/dlpack/)
 
+A file [dlpack.h](../include/third_party/dlpack/dlpack.h) is copied from
+[dlpack v0.3](https://github.com/dmlc/dlpack/archive/v0.3.zip),
+and is provided under a license below.
+
 ```
                                  Apache License
                            Version 2.0, January 2004

--- a/third_party/LICENSES.md
+++ b/third_party/LICENSES.md
@@ -9,6 +9,7 @@
 * [cmdline](#cmdline)
 * [libarchive](#libarchive)
 * [OpenMPI](#openmpi)
+* [DLPack](#dlpack)
 
 ## [Eigen](eigen.tuxfamily.org/index.php)
 
@@ -787,4 +788,210 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+```
+
+## [DLPack](https://github.com/dmlc/dlpack/)
+
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2017 by Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
 ```


### PR DESCRIPTION
DLPack is an open in-memory tensor structure which enables you to share tensors among frameworks without copy. This PR integrates DLPack into nnabla.