### PR TITLE
Make scatter_nd work in static graph mode.

### DIFF
--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -3933,10 +3933,14 @@ Array Manipulation:
         doc: N-D array input data.
       indices:
         doc: N-D array scatter indices.
+      out:
+        doc: existing output array
+        optional: true
     arguments:
       shape:
         doc: Shape of output variable.
         type: repeated int64
+        default: None
     outputs:
       y:
         doc: N-D array of given `shape`.

--- a/include/nbla/function/scatter_nd.hpp
+++ b/include/nbla/function/scatter_nd.hpp
@@ -86,6 +86,14 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "ScatterNd"; }
+  virtual int inplace_data(int i) const {
+    return i == 2 ? Function::INPLACE : Function::NOT_INPLACE;
+  }
+  virtual int inplace_data_with(int i) const { return 0; }
+  virtual int inplace_grad(int i) const {
+    return i == 2 ? Function::INPLACE : Function::NOT_INPLACE;
+  }
+  virtual int inplace_grad_with(int i) const { return 0; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -1061,4 +1061,13 @@ cdef class Variable:
         return IDX.getitem(self, key)
 
     def __setitem__(self, key, value):
-        IDX.setitem(self, key, value)
+        if self.parent:
+            if not isinstance(value, Variable):
+                if isinstance(value, NdArray):
+                    value = Variable(value.shape).apply(data=value)
+                else:
+                    value = Variable.from_numpy_array(value)
+            var = self.get_unlinked_variable().apply(parent=self.parent)
+            self.rewire_on(IDX.setitem(var, key, value))
+        else:
+            IDX.setitem(self, key, value)

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -1140,17 +1140,12 @@ def scatter_nd(data, indices, shape=None, out=None):
     if shape and out:
         raise TypeError("Only one of `shape` or `out` argument may be used.")
     if out:
-        if isinstance(out, nn.Variable):
-            out = out.data
-        if not isinstance(out, nn.NdArray):
+        if not isinstance(out, (nn.Variable, nn.NdArray)):
             raise TypeError("`out` argument must be NdArray or Variable type.")
         shape = out.shape
-        outputs = [out]
-    else:
-        if isinstance(shape, np.ndarray):
-            shape = shape.tolist()
-        outputs = None
-    return scatter_nd_base(data, indices, shape, outputs=outputs)
+    elif isinstance(shape, np.ndarray):
+        shape = shape.tolist()
+    return scatter_nd_base(data, indices, out, shape)
 
 
 def multi_head_attention(query, key, value, num_heads, q_weight, k_weight, v_weight, out_weight, q_bias=None, k_bias=None, v_bias=None, out_bias=None, attn_bias_k=None, attn_bias_v=None, dropout=0.0, additive_mask=None, key_padding_mask=None):


### PR DESCRIPTION
**Bugfix: Python-syntax indexing setter**

Fix the indexing setter in the python-syntax by rewiring the function graph when an update gets assigned to an existing connection via a setitem operation.