### PR TITLE
pass keyword argument to pytest.fixture to fix PytestDeprecationWarning

### DIFF
--- a/python/test/function/test_weight_standardization.py
+++ b/python/test/function/test_weight_standardization.py
@@ -8,7 +8,7 @@ from nnabla.testing import assert_allclose
 from nnabla.normalization_functions import _get_axes_excluding
 
 
-@pytest.fixture("function")
+@pytest.fixture(scope="function")
 def rng():
     nn.clear_parameters()
     yield np.random.RandomState(313)


### PR DESCRIPTION
In the latest 6.0.0 pytest. PytestDeprecationWarning is considered to be Error.
Passing argument to pytest.fixture as a keyword argument to fix this Error, instead of positional arguments.