### PR TITLE
Check shape length before checking first element.

### DIFF
--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -261,7 +261,7 @@ class NnpNetwork(object):
         pvar = v.proto
         name = pvar.name
         shape = list(pvar.shape.dim)
-        if shape[0] < 0:
+        if len(shape) > 0 and shape[0] < 0:
             shape[0] = self.batch_size
         shape = tuple(shape)
         assert np.all(np.array(shape) >


### PR DESCRIPTION
**Fix an error when loading a scalar variable from a model file.**

A scalar variable has no dimension and the shape tuple thus has no elements. Code that checks the value of the first dimension must first check the length of the tuple.