### PR TITLE
feat: use multiprocess to create cache and add the test file of create_cache

### DIFF
--- a/python/src/nnabla/utils/cli/conv_dataset.py
+++ b/python/src/nnabla/utils/cli/conv_dataset.py
@@ -42,6 +42,11 @@ def _convert(args, source):
 
 
 def conv_dataset_command(args):
+    if isinstance(args.process_num, int) and args.process_num <= 0:
+        print(
+            "The numbers of CPU cores [{}] must be positive integer.".format(args.process_num))
+        return False
+
     if os.path.exists(args.destination):
         if not args.force:
             print(
@@ -57,12 +62,13 @@ def conv_dataset_command(args):
             return False
     else:
         os.mkdir(args.destination)
-    datasource = None
+
     _, ext = os.path.splitext(args.source)
     if ext.lower() == '.csv':
 
         if os.path.exists(args.source):
-            cc = CreateCache(args.source, shuffle=args.shuffle)
+            cc = CreateCache(args.source, shuffle=args.shuffle,
+                             process_num=args.process_num)
             print('Number of Data: {}'.format(cc._size))
             print('Shuffle:        {}'.format(cc._shuffle))
             print('Normalize:      {}'.format(args.normalize))
@@ -89,6 +95,9 @@ def add_conv_dataset_command(subparsers):
         '-S', '--shuffle', action='store_true', help='shuffle data', required=False)
     subparser.add_argument('-N', '--normalize', action='store_true',
                            help='normalize data range', required=False)
+    subparser.add_argument('-p', '--process_num', type=int,
+                           help='default to half of cpu count. if the picture pixel is \
+                           too large, please specify process_num as 1.', required=False)
     subparser.add_argument('source')
     subparser.add_argument('destination')
     subparser.set_defaults(func=conv_dataset_command)

--- a/python/src/nnabla/utils/create_cache.py
+++ b/python/src/nnabla/utils/create_cache.py
@@ -1,17 +1,114 @@
-import collections
-import csv
-import numpy
 import os
+import csv
+import h5py
+import numpy
 import shutil
-import time
-
+import collections
+import multiprocessing
+from contextlib import closing
+from types import SimpleNamespace
 
 from nnabla.utils.data_source_implements import CsvDataSource
-from nnabla.utils.data_source_loader import FileReader
+from nnabla.utils.data_source_loader import FileReader, load
 
 from nnabla.config import nnabla_config
 from nnabla.logger import logger
 from nnabla.utils.progress import progress
+
+
+def multiprocess_save_cache(create_cache_args):
+
+    def _process_row(row, args):
+        def _get_value(value, is_vector=False):
+            try:
+                if is_vector:
+                    value = [float(value)]
+                else:
+                    value = float(value)
+                return value
+            except ValueError:
+                pass
+            ext = (os.path.splitext(value)[1]).lower()
+            with args._filereader.open(value) as f:
+                value = load(ext)(f, normalize=args._normalize)
+            return value
+
+        values = collections.OrderedDict()
+        if len(row) == len(args._columns):
+            for column, column_value in enumerate(row):
+                variable, index, label = args._columns[column]
+                if index is None:
+                    values[variable] = _get_value(
+                        column_value, is_vector=True)
+                else:
+                    if variable not in values:
+                        values[variable] = []
+                    values[variable].append(_get_value(column_value))
+        return values.values()
+
+    (position, cache_csv), cc_args = create_cache_args
+    cc_args = SimpleNamespace(**cc_args)
+    cache_data = []
+    for row in cache_csv:
+        cache_data.append(tuple(_process_row(row, cc_args)))
+
+    if len(cache_data) > 0:
+        start_position = position + 1 - len(cache_data)
+        end_position = position
+        cache_filename = os.path.join(
+            cc_args._cache_dir, '{}_{:08d}_{:08d}{}'.format(cc_args._cache_file_name_prefix,
+                                                            start_position,
+                                                            end_position,
+                                                            cc_args._cache_file_format))
+
+        logger.info('Creating cache file {}'.format(cache_filename))
+
+        data = collections.OrderedDict(
+            [(n, []) for n in cc_args._variables])
+        for pos, cd in enumerate(cache_data):
+            for i, n in enumerate(cc_args._variables):
+                if isinstance(cd[i], numpy.ndarray):
+                    d = cd[i]
+                else:
+                    d = numpy.array(cd[i]).astype(numpy.float32)
+                data[n].append(d)
+        try:
+            if cc_args._cache_file_format == ".h5":
+                h5 = h5py.File(cache_filename, 'w')
+                for k, v in data.items():
+                    h5.create_dataset(k, data=v)
+                h5.close()
+            else:
+                retry_count = 1
+                is_create_cache_incomplete = True
+                while is_create_cache_incomplete:
+                    try:
+                        with open(cache_filename, 'wb') as f:
+                            for v in data.values():
+                                numpy.save(f, v)
+                        is_create_cache_incomplete = False
+                    except OSError:
+                        retry_count += 1
+                        if retry_count > 10:
+                            raise
+                        logger.info(
+                            'Creating cache retry {}/10'.format(retry_count))
+        except:
+            logger.critical(
+                'An error occurred while creating cache file from dataset.')
+            for k, v in data.items():
+                size = v[0].shape
+                for d in v:
+                    if size != d.shape:
+                        logger.critical('The sizes of data "{}" are not the same. ({} != {})'.format(
+                            k, size, d.shape))
+            raise
+
+        cc_args._cache_file_name_and_data_nums_q.put(
+            (cache_filename, len(cache_data)))
+        progress(
+            'Create cache',
+            cc_args._cache_file_name_and_data_nums_q.qsize() / cc_args._cache_file_count)
 
 
 class CreateCache(CsvDataSource):
@@ -21,67 +118,7 @@ class CreateCache(CsvDataSource):
 
     '''
 
-    def _save_cache(self):
-        if len(self._cache_data) > 0:
-            start_position = self._position + 1 - len(self._cache_data)
-            end_position = self._position
-            cache_filename = os.path.join(
-                self._cache_dir, '{}_{:08d}_{:08d}{}'.format(self._cache_file_name_prefix,
-                                                             start_position,
-                                                             end_position,
-                                                             self._cache_file_format))
-
-            logger.info('Creating cache file {}'.format(cache_filename))
-
-            data = collections.OrderedDict(
-                [(n, []) for n in self._variables])
-            for pos, cd in enumerate(self._cache_data):
-                for i, n in enumerate(self._variables):
-                    if isinstance(cd[i], numpy.ndarray):
-                        d = cd[i]
-                    else:
-                        d = numpy.array(cd[i]).astype(numpy.float32)
-                    data[n].append(d)
-
-            try:
-                if self._cache_file_format == ".h5":
-                    h5 = h5py.File(cache_filename, 'w')
-                    for k, v in data.items():
-                        h5.create_dataset(k, data=v)
-                    h5.close()
-                else:
-                    retry_count = 1
-                    is_create_cache_incomplete = True
-                    while is_create_cache_incomplete:
-                        try:
-                            with open(cache_filename, 'wb') as f:
-                                for v in data.values():
-                                    numpy.save(f, v)
-                            is_create_cache_incomplete = False
-                        except OSError:
-                            retry_count += 1
-                            if retry_count > 10:
-                                raise
-                            logger.info(
-                                'Creating cache retry {}/10'.format(retry_count))
-            except:
-                logger.critical(
-                    'An error occurred while creating cache file from dataset.')
-                for k, v in data.items():
-                    size = v[0].shape
-                    for d in v:
-                        if size != d.shape:
-                            logger.critical('The sizes of data "{}" are not the same. ({} != {})'.format(
-                                k, size, d.shape))
-                raise
-
-            self._cache_file_names.append(cache_filename)
-            self._cache_file_order.append(len(self._cache_file_order))
-            self._cache_file_data_orders.append(
-                list(range(len(self._cache_data))))
-            self._cache_positions = []
-
-    def __init__(self, input_csv_filename, rng=None, shuffle=False):
+    def __init__(self, input_csv_filename, rng=None, shuffle=False, process_num=None):
         self._cache_size = int(nnabla_config.get(
             'DATA_ITERATOR', 'data_source_file_cache_size'))
         logger.info('Cache size is {}'.format(self._cache_size))
@@ -94,36 +131,34 @@ class CreateCache(CsvDataSource):
             self._rng = rng
         self._shuffle = shuffle
 
-        # Binary mode is required to use seek and tell function.
-        self._file = open(input_csv_filename, 'rb')
+        # read index.csv
+        self._file = open(input_csv_filename, 'r')
+        csvreader = csv.reader(self._file)
 
-        self._line_positions = []
-        line = self._file.readline().decode('utf-8')
-        csvreader = csv.reader([line])
         self._process_header(next(csvreader))
-
-        # Store file positions of each data.
-        self._size = 0
-        while True:
-            self._line_positions.append(self._file.tell())
-            line = self._file.readline()
-            if line is None or len(line) == 0:
-                break
-            self._size += 1
-
-        # rewind
-        self._file.seek(0)
-
-        self._original_order = list(range(self._size))
-        self._order = list(range(self._size))
         self._variables = tuple(self._variables_dict.keys())
 
-        # Shuffle
+        # Store file positions of each data.
+        self._csv_data = list(csvreader)
+        self._size = len(self._csv_data)
+
+        self._file.close()
+
+        self._original_order = list(range(self._size))
+
+        # Shuffle, the order is processing csv file order
         if self._shuffle:
             self._order = list(
                 self._rng.permutation(list(range(self._size))))
         else:
             self._order = list(range(self._size))
+
+        # multiprocess num
+        if process_num:
+            self._process_num = process_num
+        else:
+            self._process_num = multiprocessing.cpu_count()
+        logger.info('Num of process is {}'.format(self._process_num))
 
     def create(self, output_cache_dirname, normalize=True, cache_file_name_prefix='cache'):
 
@@ -138,48 +173,54 @@ class CreateCache(CsvDataSource):
 
         progress(None)
 
-        self._cache_file_order = []
-        self._cache_file_data_orders = []
-        self._cache_file_names = []
+        self._cache_file_name_and_data_nums_q = multiprocessing.Manager().Queue()
 
-        self._cache_data = []
+        self._csv_position_and_data = []
+        csv_row = []
+        for _position in range(self._size):
+            csv_row.append(self._csv_data[self._order[_position]])
+            if len(csv_row) == self._cache_size:
+                self._csv_position_and_data.append((_position, csv_row))
+                csv_row = []
+        if len(csv_row):
+            self._csv_position_and_data.append((self._size-1, csv_row))
+
+        self_args = {
+            '_cache_file_name_prefix': self._cache_file_name_prefix,
+            '_cache_file_format': self._cache_file_format,
+            '_cache_file_name_and_data_nums_q': self._cache_file_name_and_data_nums_q,
+            '_cache_dir': self._cache_dir,
+            '_variables': self._variables,
+            '_filereader': self._filereader,
+            '_normalize': self._normalize,
+            '_columns': self._columns,
+            '_cache_file_count': len(self._csv_position_and_data)
+        }
+
         progress('Create cache', 0)
-        last_time = time.time()
-        for self._position in range(self._size):
-            if time.time() >= last_time + 1.0:
-                progress('Create cache', self._position / self._size)
-                last_time = time.time()
-            self._file.seek(self._line_positions[self._order[self._position]])
-            line = self._file.readline().decode('utf-8')
-            csvreader = csv.reader([line])
-            row = next(csvreader)
-            self._cache_data.append(tuple(self._process_row(row)))
-
-            if len(self._cache_data) >= self._cache_size:
-                self._save_cache()
-                self._cache_data = []
-
-        self._save_cache()
+        with closing(multiprocessing.Pool(self._process_num)) as pool:
+            pool.map(multiprocess_save_cache,
+                     ((i, self_args) for i in self._csv_position_and_data))
         progress('Create cache', 1.0)
 
-        # Adjust data size into reseted position. In most case it means
-        # multiple of bunch(mini-batch) size.
-        num_of_cache_files = int(numpy.ceil(
-            float(self._size) / self._cache_size))
-        self._cache_file_order = self._cache_file_order[
-            0:num_of_cache_files]
-        self._cache_file_data_orders = self._cache_file_data_orders[
-            0:num_of_cache_files]
-        if self._size % self._cache_size != 0:
-            self._cache_file_data_orders[num_of_cache_files - 1] = self._cache_file_data_orders[
-                num_of_cache_files - 1][0:self._size % self._cache_size]
+        logger.info('The total of cache files is {}'.format(
+            self._cache_file_name_and_data_nums_q.qsize()))
 
         # Create Index
         index_filename = os.path.join(self._cache_dir, "cache_index.csv")
+        cache_index_rows = []
+        while True:
+            try:
+                cache_index_rows.append(
+                    self._cache_file_name_and_data_nums_q.get(block=False))
+            except Exception:
+                break
+        cache_index_rows = sorted(cache_index_rows, key=lambda x: x[0])
         with open(index_filename, 'w') as f:
             writer = csv.writer(f, lineterminator='\n')
-            for fn, orders in zip(self._cache_file_names, self._cache_file_data_orders):
-                writer.writerow((os.path.basename(fn), len(orders)))
+            for file_name, data_nums in cache_index_rows:
+                writer.writerow((os.path.basename(file_name), data_nums))
+
         # Create Info
         if self._cache_file_format == ".npy":
             info_filename = os.path.join(self._cache_dir, "cache_info.csv")

--- a/python/src/nnabla/utils/data_source_implements.py
+++ b/python/src/nnabla/utils/data_source_implements.py
@@ -81,7 +81,7 @@ class CachePrefetcher(object):
             if retry > 10:
                 logger.log(99, 'read_cache() retry count over give up.')
                 logger.log(
-                    99, 'Cache file {} not found.'.format(file_name))
+                    99, 'Cache file {} not found. pid={}'.format(file_name, os.getpid()))
                 logger.log(99, 'Fatal Error! send SIGKILL to myself.')
                 os.kill(os.getpid(), 9)
 
@@ -96,10 +96,12 @@ class CachePrefetcher(object):
                     logger.log(
                         99, 'read_cache() fails retrying count {}/10.'.format(retry))
                     retry += 1
+                    sleep(0.5)
             except:
                 logger.log(
                     99, 'Cache file {} not found, retry count {}.'.format(file_name, retry))
                 retry += 1
+                sleep(0.5)
 
         return result
 

--- a/python/test/utils/test_create_cache.py
+++ b/python/test/utils/test_create_cache.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import os
+import csv
+import pytest
+import tempfile
+from shutil import rmtree
+from contextlib import contextmanager
+
+# from nnabla
+from nnabla.config import nnabla_config
+from nnabla.utils.create_cache import CreateCache
+from nnabla.utils.data_source_implements import CacheDataSource, CsvDataSource
+from nnabla.testing import assert_allclose
+
+from .conftest import test_data_csv_csv_20, test_data_csv_png_20
+
+
+@contextmanager
+def create_temp_with_dir():
+    tmpdir = tempfile.mkdtemp()
+    yield tmpdir
+    rmtree(tmpdir, ignore_errors=True)
+
+
+def associate_variables_and_data(source) -> dict:
+    data_dict = {}
+    for v, data in zip(source.variables, source.next()):
+        data_dict[v] = data
+    return data_dict
+
+
+def check_relative_csv_file_result(cache_file_fmt, csvfilename, cachedir):
+    # check cache_index.csv
+    cache_info_csv_path = os.path.join(cachedir, 'cache_index.csv')
+    assert os.path.exists(cache_info_csv_path)
+
+    with open(cache_info_csv_path, 'r') as f:
+        for row in csv.reader(f):
+            assert os.path.exists(os.path.join(cachedir, row[0]))
+
+    # check cache_info.csv
+    if cache_file_fmt == '.npy':
+        assert os.path.exists(os.path.join(cachedir, 'cache_info.csv'))
+
+    # check order.csv
+    assert os.path.exists(os.path.join(cachedir, 'order.csv'))
+
+    # check original.csv
+    original_csv_path = os.path.join(cachedir, 'original.csv')
+    assert os.path.exists(original_csv_path)
+
+    with open(original_csv_path, 'r') as of, open(csvfilename, 'r') as cf:
+        for row in of:
+            assert row == cf.readline()
+
+
+@pytest.mark.parametrize('input_file_fmt', ['png', 'csv'])
+@pytest.mark.parametrize('cache_file_fmt', ['.npy', '.h5'])
+@pytest.mark.parametrize('shuffle', [False, True])
+@pytest.mark.parametrize('normalize', [False, True])
+@pytest.mark.parametrize('process_num', [i+1 for i in range(8)])
+def test_create_cache(test_data_csv_csv_20,
+                      test_data_csv_png_20,
+                      input_file_fmt,
+                      cache_file_fmt,
+                      shuffle,
+                      normalize,
+                      process_num):
+    if input_file_fmt == 'csv':
+        csvfilename = test_data_csv_csv_20
+    else:
+        csvfilename = test_data_csv_png_20
+
+    nnabla_config.set('DATA_ITERATOR', 'cache_file_format', cache_file_fmt)
+
+    with create_temp_with_dir() as tmpdir:
+        cc = CreateCache(csvfilename, shuffle=shuffle, process_num=process_num)
+        cc.create(tmpdir, normalize=normalize)
+
+        # get cache data source and csv file data source
+        cache_source = CacheDataSource(tmpdir)
+        csv_source = CsvDataSource(csvfilename, normalize=normalize)
+
+        check_relative_csv_file_result(cache_file_fmt, csvfilename, tmpdir)
+
+        assert cache_source.size == csv_source.size
+        assert set(cache_source.variables) == set(csv_source.variables)
+
+        if shuffle:
+            with open(os.path.join(tmpdir, 'order.csv'), 'r') as f:
+                csv_source._order = [int(row[1]) for row in csv.reader(f)]
+
+        for _ in range(cache_source.size):
+            cache_data = associate_variables_and_data(cache_source)
+            csv_data = associate_variables_and_data(csv_source)
+
+            for v in cache_source.variables:
+                assert_allclose(cache_data[v], csv_data[v])


### PR DESCRIPTION
This modification is in utils and test:

- add process_num option in conv_dataset command
- change the create_cache way from single process to multiprocess
- add create_cache test
- increase echo retry time by 0.5s when don't find cache file