### PR TITLE
Improve NNabla converter doc.

### DIFF
--- a/doc/python/file_format_converter/file_format_converter.rst
+++ b/doc/python/file_format_converter/file_format_converter.rst
@@ -151,7 +151,17 @@ File format converter supports C source code output for `nnabla-c-runtime`_.
 Tensorflow
 ^^^^^^^^^^
 
-Through onnx, tensorflow import and export is partially supported.
+.. _Dockerfile: https://github.com/sony/nnabla/blob/master/docker/development/Dockerfile.tf-test
+
+Limitation
+++++++++++
+
+- Currently python3.8 is not supported.
+- Tensorflow version is required to be 1.14.
+- ONNX version is 1.6.0.
+- onnx_tf, tf2onnx needs to be patched based on specified revision.
+
+Bridged by onnx, tensorflow import and export is supported with some limitations.
 
 As for the importer, 3 formats tends to be supported:
    - .pb, tensorflow frozen graph format
@@ -161,7 +171,7 @@ As for the importer, 3 formats tends to be supported:
 As for the exporter, some of Neural Network Console projects are supported. See :any:`Model_Support_Status`.
 The output of converter is tensorflow frozen graph format(e.g. *.pb)
 
-Before using this converter, please refer to :any:`../docker` to install tensorflow and related packages.
+Before using this converter, please refer to `Dockerfile`_ to prepare the environment for converter.
 
 
 Process
@@ -343,6 +353,14 @@ For checkpoint version 2:
 
 In the same directory of input.ckpt.meta, the related files, such as checkpoint, *.ckpt.index, ... and
 so on are required to exist.
+
+
+Convert NNP to Tensorflow Lite
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: none
+
+   $ nnabla_cli convert input.nnp output.tflite
 
 
 Splitting network

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -147,7 +147,6 @@ RUN umask 0 \
     && conda update --all -y \
     && conda install -y numpy scipy scikit-image six \
     && pip install -r /tmp/deps/setup_requirements.txt \
-    && sed -i '/tensorflow/d' /tmp/deps/requirements.txt \
     && pip install -r /tmp/deps/requirements.txt \
     && pip install -r /tmp/deps/test_requirements.txt \
     && conda clean -y --all \

--- a/docker/development/Dockerfile.onnx-test-ppc64le
+++ b/docker/development/Dockerfile.onnx-test-ppc64le
@@ -124,7 +124,6 @@ RUN umask 0 \
     && pip install -U numpy \
     && pip install scipy\<1.4 \
     && pip install -r /tmp/deps/setup_requirements.txt \
-    && sed -i '/tensorflow/d' /tmp/deps/requirements.txt \
     && pip install -r /tmp/deps/requirements.txt \
     && pip install -r /tmp/deps/test_requirements.txt \
     && conda clean -y --all \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -12,5 +12,4 @@ requests
 scipy
 six
 tqdm
-tensorflow==1.14
 ply


### PR DESCRIPTION
This commit is important for passing CI build:
   - Python3.8 does not support tensorflow==1.14, we removed the line from requirement.txt
   - Update document to tell user how to prepare tensorflow converter's running environment