### PR TITLE
add import to fix

### DIFF
--- a/python/src/nnabla/models/imagenet/base.py
+++ b/python/src/nnabla/models/imagenet/base.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import
+import nnabla as nn
 from nnabla.utils.nnp_graph import NnpLoader
 
 from ..utils import *


### PR DESCRIPTION
I found a bug in imagenet models, and fix it

this bug can be confirmed with below code:
```
from nnabla.models.imagenet import ResNet18
model = ResNet18()
tmp = model(None)
```
this outputs:
```
~/Library/Python/3.7/lib/python/site-packages/nnabla/models/imagenet/resnet.py in __call__(self, input_var, use_from, use_up_to, training, force_global_pooling, check_global_pooling, returns_net, verbose)
     66 
     67         assert use_from is None, 'This should not be set because it is for forward compatibility.'
---> 68         input_var = self.get_input_var(input_var)
     69 
     70         callback = NnpNetworkPass(verbose)

~/Library/Python/3.7/lib/python/site-packages/nnabla/models/imagenet/base.py in get_input_var(self, input_var)
     76         default_shape = (1,) + self.input_shape
     77         if input_var is None:
---> 78             input_var = nn.Variable(default_shape)
     79         assert input_var.ndim == 4, "input_var must be 4 dimensions. Given {}.".format(
     80             input_var.ndim)

NameError: name 'nn' is not defined
```