### PR TITLE
fix forward_all to keep values of all given variables

### DIFF
--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -43,6 +43,9 @@ def scope_function():
     # keep context
     ctx = nn.get_current_context()
 
+    # use cached array
+    nn.prefer_cached_array(True)
+
     yield
 
     # restore context


### PR DESCRIPTION
Set persistent=true for all given variables of forward_all to keep values.
Before this change, forward_all([h, y], clear_buffer=True) cleared the value of h if h is an intermediate variable. This is not intuitive for users. Setting persistent = True for all variables given to forward_all, now all given variables will be kept from being cleared.