### PR TITLE
Fix the docs related to the output maps

### DIFF
--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -476,7 +476,7 @@ Neural Network Layer:
         doc: :math:`(1 + N)`-D array (:math:`C \times K_1 \times ... \times K_N`).
         parameter: true
       bias:
-        doc: Bias vector (:math:`C`).
+        doc: Bias vector (:math:`C'`).
         optional: true
         parameter: true
     arguments:
@@ -546,7 +546,7 @@ Neural Network Layer:
         doc: :math:`(B + 1 + N)`-D array (:math:`M_1 \times ... \times M_B \times
           C \times L_1 \times ... \times L_N`).
       weight:
-        doc: :math:`(2 + N)`-D array (:math:`C' \times C \times K_1 \times ... \times
+        doc: :math:`(2 + N)`-D array (:math:`C \times C' \times K_1 \times ... \times
           K_N`).
         parameter: true
       bias:
@@ -615,7 +615,7 @@ Neural Network Layer:
         doc: :math:`(1 + N)`-D array (:math:`C \times K_1 \times ... \times K_N`).
         parameter: true
       bias:
-        doc: Bias vector (:math:`C`).
+        doc: Bias vector (:math:`C'`).
         optional: true
         parameter: true
     arguments:


### PR DESCRIPTION
Fix the following docs:
- the order of the dimension of weight of the deconvolution
- the bias of the depthwise_convolution
- the bias of the depthwise_deconvolution