### PR TITLE
Use the new h5py v3 data access method.

### DIFF
--- a/python/src/nnabla/utils/data_source.py
+++ b/python/src/nnabla/utils/data_source.py
@@ -295,7 +295,7 @@ class DataSourceWithFileCache(DataSource):
                 h5 = h5py.File(self._cache_file_names[cache_file_index], 'r')
                 self._current_cache_data = {}
                 for k, v in h5.items():
-                    self._current_cache_data[k] = v.value
+                    self._current_cache_data[k] = v[()]
                 h5.close()
 
         d = [self._current_cache_data[v][cache_data_position]

--- a/python/src/nnabla/utils/data_source_implements.py
+++ b/python/src/nnabla/utils/data_source_implements.py
@@ -195,7 +195,7 @@ class CacheDataSource(DataSource):
             next_data = {}
             with self._filereader.open_cache(filename) as cache:
                 for k, v in cache.items():
-                    next_data[k] = v.value
+                    next_data[k] = v[()]
 
         if current_communicator():
             if set(self._variables) != set(next_data.keys()):


### PR DESCRIPTION
**Update h5py data access method**

With the new h5py version 3 the data access method must use the dataset interface and the key-value `v.value` accessor was removed.