### PR TITLE
fix error when no .protobuf file and parameter [] operator.

### DIFF
--- a/src/nbla/parametric_functions.cpp
+++ b/src/nbla/parametric_functions.cpp
@@ -54,8 +54,12 @@ ParameterDirectory::ParameterDirectory()
       ordered_keys_(make_shared<vector<string>>()) {}
 
 ParameterDirectory ParameterDirectory::operator[](string name) {
-  auto new_scope_path = name;
-  return ParameterDirectory(new_scope_path, param_dict_, ordered_keys_);
+  string param_path;
+  if (!scope_path_.empty())
+    param_path = scope_path_ + "/" + name;
+  else
+    param_path = name;
+  return ParameterDirectory(param_path, param_dict_, ordered_keys_);
 }
 
 vector<pair<string, VariablePtr>> ParameterDirectory::get_parameters() {

--- a/src/nbla_utils/parameters.cpp
+++ b/src/nbla_utils/parameters.cpp
@@ -416,8 +416,8 @@ void load_parameters(ParameterDirectory &pd, string filename) {
   bool ret = load_parameters(pv, filename);
 
   if (!ret) {
-    NBLA_ERROR(error_code::value, "Cannot load parameter file:%s",
-               filename.c_str());
+    NBLA_LOG_INFO("Cannot load parameter file: %s\n", filename.c_str());
+    return;
   }
 
   for (auto it = pv.begin(); it != pv.end(); ++it) {


### PR DESCRIPTION
This commit fix the following issue:
 - When user initially run this training program, there is no .protobuf parameter file, `no file  error` should be informed and ignored,
   instead of exit.
- parameter operator [] should derived the scope name prefix from parent, or say we should join its owned scope name to the name which will be used for its child object.
(This modification tends to fix the problem to run `train_resnet_classifier`)
