### PR TITLE
Correct the copy index generation when unfolding.

### DIFF
--- a/python/test/function/test_tile.py
+++ b/python/test/function/test_tile.py
@@ -22,8 +22,8 @@ ctxs = list_context('Tile')
 
 @pytest.mark.parametrize("ctx, func_name", ctxs)
 @pytest.mark.parametrize("seed", [314])
-@pytest.mark.parametrize("inshape", [(12,), (3, 5), (2, 3, 4)])
-@pytest.mark.parametrize("reps", [(2,), (3, 2), (3, 2, 3)])
+@pytest.mark.parametrize("inshape", [(12,), (3, 5), (2, 3, 4), (4, 3, 8, 8)])
+@pytest.mark.parametrize("reps", [(2,), (3, 2), (3, 2, 3), (3, 2, 3, 5)])
 def test_tile_forward_backward(inshape, reps, seed, ctx, func_name):
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*inshape).astype(np.float32)]

--- a/src/nbla/function/generic/tile.cpp
+++ b/src/nbla/function/generic/tile.cpp
@@ -70,14 +70,12 @@ void Tile<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   // the requested number of copies (tiles) for that dimension (this is a bit
   // like unfolding a cross folded piece of paper).
   for (int axis = reps.size() - 2; axis > 0; axis--) {
-    auto src = idx;
     do {
-      auto dst = idx + ndi::nd2flat(src_index, idxmap_.strides());
+      auto src = dst = idx + ndi::nd2flat(src_index, idxmap_.strides());
       auto cnt = ndi::inner_size(map_shape, axis) / reps.at(axis);
       for (int rep = 1; rep < reps.at(axis); rep++) {
         std::memcpy(dst + rep * cnt, src, cnt * sizeof(int));
       }
-      src += ndi::inner_size(map_shape, axis);
     } while (ndi::increment(src_index, src_shape, axis - 1));
   }
 }


### PR DESCRIPTION
This PR corrects the copy index generation when unfolding tiles for repetition. The source index of memcopy must not monotonically increase but derive from the current N-D src_index.