### PR TITLE
Fix bugs in clear buffer during forward propagation

### DIFF
--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -79,6 +79,7 @@ class CgVariable {
   enum NeedGrad { NG_NONE, NG_FALSE, NG_TRUE };
   struct FunctionReferenceInfo {
     bool need_setup{false};
+    size_t count{0};
   };
   NeedGrad need_grad_{NG_NONE}; ///< Whether the variable requires gradients.
   NeedGrad need_grad_state_{
@@ -91,8 +92,9 @@ class CgVariable {
   unordered_map<CgFunction *,
                 pair<std::weak_ptr<CgFunction>, FunctionReferenceInfo>>
       function_references_;
-  bool allow_modify_data_{true}; ///< Whether the data can be in-placed.
-  bool persistent_{false};       ///<Persistency flag against clearing.
+  size_t function_reference_count_{0}; ///< Number of function references
+  bool allow_modify_data_{true};       ///< Whether the data can be in-placed.
+  bool persistent_{false};             ///<Persistency flag against clearing.
   bool prohibit_clear_data_{false};
   string name_{""};
 
@@ -271,9 +273,7 @@ public:
 
   /**
    */
-  inline int function_reference_count() const {
-    return function_references_.size();
-  }
+  size_t function_reference_count() const;
 
   /**
    */

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -408,6 +408,12 @@ cdef class NdArray:
         type_num = <int > self.arrp.array().get().dtype()
         return np.dtype(np.PyArray_TypeObjectFromType(type_num))
 
+    @property
+    def modification_count(self):
+        '''Returns how many times modified after memory allocation or clearing buffer.
+        '''
+        return self.arrp.array().get().modification_count()
+
     def __pos__(self):
         return AOP.pos(self)
 

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -360,11 +360,13 @@ def test_no_need_grad_backward():
     assert np.isclose(y.g, 1.5)
 
 
-def test_no_need_grad_forward():
+@pytest.mark.parametrize("clear_buffer", [False, True])
+def test_no_need_grad_forward(clear_buffer):
     '''
-    Previously, an intermediate variable with need_grad=False
-    causes unexpected data clearing if it's used from multiple functions
-    and some conditions meet. This test checks if it is resolved.
+    This tests a previously existing bug where an intermediate variable
+    has been unexpectedly cleared before the end of life if
+    it is used in an in-place function and
+    another function at the same time.
     '''
     import nnabla as nn
     import nnabla.functions as F
@@ -378,5 +380,5 @@ def test_no_need_grad_forward():
 
     x.data.fill(1)
 
-    d.forward(clear_no_need_grad=True)
+    d.forward(clear_no_need_grad=True, clear_buffer=clear_buffer)
     assert np.isclose(d.d, 1.0)

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -382,3 +382,23 @@ def test_no_need_grad_forward(clear_buffer):
 
     d.forward(clear_no_need_grad=True, clear_buffer=clear_buffer)
     assert np.isclose(d.d, 1.0)
+
+
+def test_no_need_grad_forward_double():
+    '''
+    This tests a previously existing bug where a variable used
+    twice by a single function caused an unexpected clear due to
+    incorrect count of function references.
+    '''
+    import nnabla as nn
+    import nnabla.functions as F
+    nn.prefer_cached_array(False)
+
+    x = nn.Variable(tuple())
+    xx = x * 1
+    y = xx * xx
+    z = xx * 1
+    a = y * z
+    x.data.fill(1)
+    a.forward(clear_no_need_grad=True)
+    assert np.isclose(a.d, 1.0)

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -358,3 +358,25 @@ def test_no_need_grad_backward():
     d.backward(clear_buffer=True, function_pre_hook=hook)
 
     assert np.isclose(y.g, 1.5)
+
+
+def test_no_need_grad_forward():
+    '''
+    Previously, an intermediate variable with need_grad=False
+    causes unexpected data clearing if it's used from multiple functions
+    and some conditions meet. This test checks if it is resolved.
+    '''
+    import nnabla as nn
+    import nnabla.functions as F
+    nn.prefer_cached_array(False)
+
+    x = nn.Variable(tuple(), need_grad=False)
+    xx = x * 1
+    a = xx.reshape(x.shape)
+    b = xx * 1
+    d = a * b
+
+    x.data.fill(1)
+
+    d.forward(clear_no_need_grad=True)
+    assert np.isclose(d.d, 1.0)

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -138,6 +138,9 @@ public:
           func->function()->inplace_data(i) || vi->prohibit_clear_data()) {
         continue;
       }
+      if (inplace_variable_set_.find(vi) != inplace_variable_set_.end()) {
+        continue;
+      }
       if (clear_buffer_) {
         ret[i] = true;
         continue;
@@ -146,9 +149,6 @@ public:
         // Not clear if any function requiring gradient computation uses this
         // variable.
         if (need_grad_variable_set_.find(vi) != need_grad_variable_set_.end()) {
-          continue;
-        }
-        if (inplace_variable_set_.find(vi) != inplace_variable_set_.end()) {
           continue;
         }
         ret[i] = true;

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -181,6 +181,7 @@ void SyncedArray::copy_from(const SyncedArray *src) {
 void SyncedArray::clear() {
   array_.clear();
   this->clear_flags();
+  modification_count_ = 0;
 }
 
 // Reset head state


### PR DESCRIPTION
Some variables are cleared unexpectedly during forward propagation due to bugs in logic for clearing buffers. Please look at the added test cases for more detailed descriptions of the bugs.

This PR fixes three bugs at the 1st, 2nd and 4th commits (the 3rd commit is a change for easier debugging).