### PR TITLE
fix window build bug

### DIFF
--- a/build-tools/msvc/build_cpplib.bat
+++ b/build-tools/msvc/build_cpplib.bat
@@ -67,6 +67,7 @@ cmake -G "%generate_target%" ^
 
 cmake --build . --config %build_type% || GOTO :error
 cmake --build . --config %build_type% --target test_nbla_utils || GOTO :error
+SET PATH="%ProgramFiles%\Cmake\bin";%PATH%
 cpack -G ZIP -C %build_type%
 
 GOTO :end


### PR DESCRIPTION
Fix window build bug, according to bug report, we change the order of path before call cpack, so that chocolate's pack is placed behide cmake's cpack.