### PR TITLE
Fix segmentation fault caused by use of uninitilized variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ if(BUILD_CPP_LIB)
     endif(CCACHE_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
   endif()
-  nbla_warnings_disable(CMAKE_CXX_FLAGS -Wno-sign-compare -Wno-uninitialized /wd4099)
+  nbla_warnings_disable(CMAKE_CXX_FLAGS -Wno-sign-compare /wd4099)
 
   # Setting output directory naively
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,7 +202,7 @@ if(BUILD_CPP_LIB)
     endif(CCACHE_FOUND)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC -Wall")
   endif()
-  nbla_warnings_disable(CMAKE_CXX_FLAGS -Wno-sign-compare /wd4099)
+  nbla_warnings_disable(CMAKE_CXX_FLAGS /wd4099)
 
   # Setting output directory naively
   set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/include/nbla/common.hpp
+++ b/include/nbla/common.hpp
@@ -24,6 +24,7 @@ maybe because they are uncategorized.
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <numeric>
 #include <sstream>
 #include <string>
 #include <tuple>
@@ -51,15 +52,12 @@ enum AsyncFlag { NONE = 0b0, ASYNC = 0b1, UNSAFE = 0b10, OFFREC = 0b100 };
 */
 inline Size_t compute_size_by_shape(const Shape_t &shape, Size_t axis = 0) {
   axis = std::max(static_cast<Size_t>(0), axis);
-  NBLA_CHECK(axis <= shape.size(), error_code::value,
+  NBLA_CHECK(axis <= static_cast<Size_t>(shape.size()), error_code::value,
              "axis must be less than or equal to size of shape. "
              "axis: %ld > size of shape: %ld.",
              axis, shape.size());
-  Size_t ret = 1;
-  for (int i = axis; i < shape.size(); ++i) {
-    ret *= shape[i];
-  }
-  return ret;
+  return std::accumulate(shape.begin() + axis, shape.end(), 1,
+                         std::multiplies<int>());
 }
 
 /** Helper for getting strides of C contiguous memory arrangement.
@@ -83,7 +81,7 @@ inline string string_join(const vector<T> &vec, const string &delim) {
   if (vec.empty()) {
     return "";
   }
-  for (int i = 0; i < vec.size() - 1; ++i) {
+  for (typename vector<T>::size_type i = 0; i < vec.size() - 1; ++i) {
     oss << vec[i] << delim;
   }
   oss << vec[vec.size() - 1];
@@ -138,7 +136,7 @@ template <typename T> void hash_combine(size_t &seed, T const &v) {
 template <typename T>
 vector<T *> as_pointer_array(const vector<shared_ptr<T>> &vec) {
   vector<T *> ret(vec.size());
-  for (int i = 0; i < vec.size(); ++i) {
+  for (unsigned int i = 0; i < vec.size(); ++i) {
     ret[i] = vec[i].get();
   }
   return ret;

--- a/include/nbla/computation_graph/utils.hpp
+++ b/include/nbla/computation_graph/utils.hpp
@@ -39,11 +39,11 @@ inline shared_ptr<CgVariable> get_item_nd(const Context &ctx,
   Shape_t in_shape = in->variable()->shape();
   vector<int> stop{in_shape.begin(), in_shape.end()};
 
-  for (int i = 0; i < slice_shape.size(); i++) {
+  for (vector<int>::size_type i = 0; i < slice_shape.size(); i++) {
     start[i] += slice_shape[i];
   }
 
-  for (int i = 0; i < slice_shape.size(); i++) {
+  for (vector<int>::size_type i = 0; i < slice_shape.size(); i++) {
     if (start[i] + 1 < stop[i])
       stop[i] = start[i] + 1;
   }

--- a/include/nbla/utils/nd_index.hpp
+++ b/include/nbla/utils/nd_index.hpp
@@ -198,11 +198,11 @@ inline std::vector<Ta> multiply(const std::vector<Ta> &a,
   std::vector<Ta> r(std::max(a.size(), b.size()), 1);
   if (a.size() < b.size()) {
     std::copy_backward(a.begin(), a.end(), r.end());
-    for (int i = 0; i < r.size(); i++)
+    for (typename std::vector<Ta>::size_type i = 0; i < r.size(); i++)
       r.at(i) *= b.at(i);
   } else {
     std::copy_backward(b.begin(), b.end(), r.end());
-    for (int i = 0; i < r.size(); i++)
+    for (typename std::vector<Ta>::size_type i = 0; i < r.size(); i++)
       r.at(i) *= a.at(i);
   }
   return r;

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -75,7 +75,7 @@ vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
 
   // check if data can be cleared or not.
   bool persistent = false, inplace = false, prohibit_clear = false;
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < inputs.size(); ++i) {
     auto inp = inputs[i];
     persistent |= inp->rank() == 0 || inp->persistent();
     prohibit_clear |= inp->prohibit_clear_data();
@@ -96,15 +96,15 @@ vector<CgVariablePtr> connect(CgFunctionPtr cg_f,
   // Function inputs and outputs must be Variables.
   vector<Variable *> finputs(inputs.size());
   vector<Variable *> foutputs(outputs.size());
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < inputs.size(); ++i) {
     finputs[i] = inputs[i]->variable().get();
   }
-  for (int i = 0; i < outputs.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < outputs.size(); ++i) {
     foutputs[i] = outputs[i]->variable().get();
   }
 
   // Set array reference to function output buffer if size matches.
-  for (int i = 0; i < outputs.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < outputs.size(); ++i) {
     if (i >= inplace_outputs.size() || !inplace_outputs[i])
       continue;
     NBLA_CHECK(inplace_outputs[i]->size() == foutputs[i]->size(),
@@ -174,13 +174,13 @@ void forward_all(const vector<CgVariablePtr> variables, bool clear_buffer,
 
   // Revert persistent flags after the end of forward_all
   DestructorCallback persistent_flag_restorer([&]() -> void {
-    for (int i = 0; i < variables.size(); ++i) {
+    for (vector<CgVariablePtr>::size_type i = 0; i < variables.size(); ++i) {
       variables[i]->set_persistent(orig_persistent_flags[i]);
     }
   });
 
   unordered_set<CgFunctionPtr> fclosed;
-  for (int i = 0; i < variables.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < variables.size(); ++i) {
     variables[i]->forward(clear_buffer, clear_no_need_grad, &fclosed,
                           function_pre_hook, function_post_hook);
   }

--- a/src/nbla/computation_graph/function.cpp
+++ b/src/nbla/computation_graph/function.cpp
@@ -66,7 +66,7 @@ void CgFunction::check_data_inplace(int i, CgVariablePtr input,
   auto f = this->function();
   // Always not allow modifying data if grad depends the output data.
   if (input->need_grad_state()) {
-    for (int o = 0; o < outputs.size(); ++o) {
+    for (vector<CgVariablePtr>::size_type o = 0; o < outputs.size(); ++o) {
       // If function gradient computation at i-th variable depends on o-th
       // output data, inplacing o-th variable data is prohibited.
       if (f->grad_depends_output_data(i, o)) {
@@ -100,14 +100,14 @@ void CgFunction::verify_during_forward() {
   }
   auto inputs = this->inputs();
   auto outputs = this->outputs();
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < inputs.size(); ++i) {
     this->check_data_inplace(i, inputs[i], outputs);
   }
 }
 
 void CgFunction::set_outputs(const vector<CgVariablePtr> &outputs) {
   outputs_.resize(outputs.size());
-  for (int i = 0; i < outputs.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < outputs.size(); ++i) {
     outputs[i]->set_rank_(rank_ + 1);
     outputs_[i].set(outputs[i]);
   }
@@ -115,7 +115,7 @@ void CgFunction::set_outputs(const vector<CgVariablePtr> &outputs) {
 
 vector<CgVariablePtr> CgFunction::outputs() {
   vector<CgVariablePtr> outputs(outputs_.size());
-  for (int i = 0; i < outputs_.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < outputs_.size(); ++i) {
     outputs[i] = outputs_[i].get();
   }
   return outputs;
@@ -123,7 +123,7 @@ vector<CgVariablePtr> CgFunction::outputs() {
 
 vector<Variable *> CgFunction::function_inputs() {
   vector<Variable *> ret(inputs_.size());
-  for (int i = 0; i < inputs_.size(); ++i) {
+  for (vector<CgVariablePtr>::size_type i = 0; i < inputs_.size(); ++i) {
     ret[i] = inputs_[i]->variable().get();
   }
   return ret;

--- a/src/nbla/function.cpp
+++ b/src/nbla/function.cpp
@@ -35,7 +35,8 @@ void Function::setup(const Variables &inputs, const Variables &outputs) {
   // classes.
   int array_class_index =
       0; // Default array is 0-th array_class in allowed_array_classes().
-  for (int i = 0; i < this->allowed_array_classes().size(); ++i) {
+  for (vector<string>::size_type i = 0;
+       i < this->allowed_array_classes().size(); ++i) {
     if (ctx_.array_class == this->allowed_array_classes()[i]) {
       array_class_index = i;
     }
@@ -45,10 +46,12 @@ void Function::setup(const Variables &inputs, const Variables &outputs) {
   // Check number of inputs and outputs
   auto &&in_types = this->in_types();
   auto &&out_types = this->out_types();
-  NBLA_CHECK(this->min_inputs() <= inputs.size(), error_code::value,
+  auto min_inputs = static_cast<Variables::size_type>(this->min_inputs());
+  auto min_outputs = static_cast<Variables::size_type>(this->min_outputs());
+  NBLA_CHECK(min_inputs <= inputs.size(), error_code::value,
              "%s needs at least %d inputs (given %d). ", this->name().c_str(),
              this->min_inputs(), inputs.size());
-  NBLA_CHECK(this->min_outputs() <= outputs.size(), error_code::value,
+  NBLA_CHECK(min_outputs <= outputs.size(), error_code::value,
              "%s needs at least %d outputs (given %d). ", this->name().c_str(),
              this->min_outputs(), outputs.size());
 
@@ -62,10 +65,10 @@ void Function::setup(const Variables &inputs, const Variables &outputs) {
   // Memorize shapes
   in_shapes.clear();
   out_shapes.clear();
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (Variables::size_type i = 0; i < inputs.size(); ++i) {
     in_shapes.push_back(make_shared<Shape_t>(inputs[i]->shape()));
   }
-  for (int i = 0; i < outputs.size(); ++i) {
+  for (Variables::size_type i = 0; i < outputs.size(); ++i) {
     out_shapes.push_back(make_shared<Shape_t>(outputs[i]->shape()));
   }
 }
@@ -82,7 +85,7 @@ static void check_shapes(Function *function, const Variables &inputs,
              "Num of outputs has been changed since setup is called in %s. "
              "Given: %d != previously: %d. ",
              function->name().c_str(), outputs.size(), out_shapes.size());
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (Variables::size_type i = 0; i < inputs.size(); ++i) {
     NBLA_CHECK(*in_shapes[i] == inputs[i]->shape(), error_code::value,
                "Inconsistent shape in input %d of %s. "
                "Setup: (%s) != Given: (%s).",
@@ -90,7 +93,7 @@ static void check_shapes(Function *function, const Variables &inputs,
                string_join(*(in_shapes[i]), string(", ")).c_str(),
                string_join(inputs[i]->shape(), string(", ")).c_str());
   }
-  for (int i = 0; i < outputs.size(); ++i) {
+  for (Variables::size_type i = 0; i < outputs.size(); ++i) {
     NBLA_CHECK(*out_shapes[i] == outputs[i]->shape(), error_code::value,
                "Inconsistent shape in output %d of %s. "
                "Setup: (%s) != Given: (%s).",
@@ -147,7 +150,7 @@ void Function::backward(const Variables &inputs, const Variables &outputs,
   // Variable::cast* function resets all lazy-evaluation flags before getting an
   // array instance.
   if (!this->prohibit_zero_input_grad()) {
-    for (int i = 0; i < inputs.size(); i++) {
+    for (Variables::size_type i = 0; i < inputs.size(); i++) {
       if (propagate_down[i] && !accum[i]) {
         inputs[i]->grad()->zero();
       }

--- a/src/nbla/function/generic/add_n.cpp
+++ b/src/nbla/function/generic/add_n.cpp
@@ -26,7 +26,7 @@ template <typename T>
 void AddN<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   NBLA_CHECK(inputs.size() >= 2, error_code::value,
              "minimum 2 inputs must be given");
-  for (int i = 1; i < inputs.size(); i++) {
+  for (Variables::size_type i = 1; i < inputs.size(); i++) {
     NBLA_CHECK(inputs[0]->shape() == inputs[i]->shape(), error_code::value,
                "shape of all inputs must be shame");
   }
@@ -37,12 +37,12 @@ template <typename T>
 void AddN<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   std::unique_ptr<const T *[]> xs(new const T *[inputs.size()]);
-  for (int i = 0; i < inputs.size(); i++) {
+  for (Variables::size_type i = 0; i < inputs.size(); i++) {
     xs[i] = inputs[i]->get_data_pointer<T>(this->ctx_);
   }
   for (int j = 0; j < inputs[0]->size(); j++) {
     T val = (T)(0);
-    for (int i = 0; i < inputs.size(); ++i) {
+    for (Variables::size_type i = 0; i < inputs.size(); ++i) {
       val += xs[i][j];
     }
     y[j] = val;
@@ -68,7 +68,7 @@ void AddN<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   }
   const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
   Size_t size = inputs[0]->size();
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (Variables::size_type i = 0; i < inputs.size(); ++i) {
     if (propagate_down[i]) {
       T *dx = inputs[i]->cast_grad_and_get_pointer<T>(this->ctx_, !(accum[i]));
       if (accum[i])

--- a/src/nbla/function/generic/affine.cpp
+++ b/src/nbla/function/generic/affine.cpp
@@ -31,7 +31,10 @@ void Affine<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   Shape_t shape_weights = inputs[1]->shape();
   NBLA_CHECK(shape_weights.size() >= 2, error_code::value,
              "Weights(inputs[1]) must be matrix or tensor.");
-  NBLA_CHECK(base_axis_ < shape_data.size(), error_code::value,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis must be a positive number, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(this->base_axis_);
+  NBLA_CHECK(base_axis < shape_data.size(), error_code::value,
              "Base_axis must be less than ndim of input data(inputs[0]). "
              "base_axis: %d >= ndim of input: %d.",
              base_axis_, shape_data.size());
@@ -49,7 +52,7 @@ void Affine<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   for (int i = 0; i < base_axis_; ++i) {
     shape_out.push_back(shape_data[i]);
   }
-  for (int i = 1; i < shape_weights.size(); ++i) {
+  for (Shape_t::size_type i = 1; i < shape_weights.size(); ++i) {
     shape_out.push_back(shape_weights[i]);
   }
   outputs[0]->reshape(shape_out, true);
@@ -63,7 +66,7 @@ void Affine<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
                "Length of bias(inputs[2]) and weights(inputs[1]) mismatch. "
                "bias length: %d != weights length-1: %d.",
                shape_bias.size(), shape_weights.size() - 1);
-    for (int i = 0; i < shape_bias.size(); ++i) {
+    for (Shape_t::size_type i = 0; i < shape_bias.size(); ++i) {
       NBLA_CHECK(shape_bias[i] == shape_weights[i + 1], error_code::value,
                  "Shape of bias(inputs[2]) and weights(inputs[1]) mismatch. "
                  "shape_bias[%d]: %d != shape_weights[%d + 1]: %d.",

--- a/src/nbla/function/generic/binary_connect_affine.cpp
+++ b/src/nbla/function/generic/binary_connect_affine.cpp
@@ -47,7 +47,7 @@ void BinaryConnectAffine<T>::setup_impl(const Variables &inputs,
              "Binary and float weights must have same size. "
              "Ndim of inputs[1]: %d != ndim of inputs[2]: %d.",
              inputs[1]->shape().size(), inputs[2]->shape().size());
-  for (int i = 0; i < inputs[1]->shape().size(); ++i) {
+  for (Shape_t::size_type i = 0; i < inputs[1]->shape().size(); ++i) {
     NBLA_CHECK(inputs[1]->shape()[i] == inputs[2]->shape()[i],
                error_code::value,
                "Binary and float weights must have same size. "

--- a/src/nbla/function/generic/binary_connect_convolution.cpp
+++ b/src/nbla/function/generic/binary_connect_convolution.cpp
@@ -55,7 +55,7 @@ void BinaryConnectConvolution<T>::setup_impl(const Variables &inputs,
              "Binary and float weights must have same size. "
              "Ndim of inputs[1]: %d != ndim of inputs[2]: %d.",
              inputs[1]->shape().size(), inputs[2]->shape().size());
-  for (int i = 0; i < inputs[1]->shape().size(); ++i) {
+  for (Shape_t::size_type i = 0; i < inputs[1]->shape().size(); ++i) {
     NBLA_CHECK(inputs[1]->shape()[i] == inputs[2]->shape()[i],
                error_code::value,
                "Binary and float weights must have same size. "

--- a/src/nbla/function/generic/binary_weight_affine.cpp
+++ b/src/nbla/function/generic/binary_weight_affine.cpp
@@ -45,7 +45,7 @@ void BinaryWeightAffine<T>::setup_impl(const Variables &inputs,
              "Binary and float weights must have same size. "
              "Ndim of inputs[1]: %d != ndim of inputs[2]: %d.",
              inputs[1]->shape().size(), inputs[2]->shape().size());
-  for (int i = 0; i < inputs[1]->shape().size(); ++i) {
+  for (Shape_t::size_type i = 0; i < inputs[1]->shape().size(); ++i) {
     NBLA_CHECK(inputs[1]->shape()[i] == inputs[2]->shape()[i],
                error_code::value,
                "Binary and float weights must have same size. "

--- a/src/nbla/function/generic/binary_weight_convolution.cpp
+++ b/src/nbla/function/generic/binary_weight_convolution.cpp
@@ -48,7 +48,7 @@ void BinaryWeightConvolution<T>::setup_impl(const Variables &inputs,
              "Binary and float weights must have same size. "
              "Ndim of inputs[1]: %d != ndim of inputs[2]: %d.",
              inputs[1]->shape().size(), inputs[2]->shape().size());
-  for (int i = 0; i < inputs[1]->shape().size(); ++i) {
+  for (Shape_t::size_type i = 0; i < inputs[1]->shape().size(); ++i) {
     NBLA_CHECK(inputs[1]->shape()[i] == inputs[2]->shape()[i],
                error_code::value,
                "Binary and float weights must have same size. "

--- a/src/nbla/function/generic/broadcast.cpp
+++ b/src/nbla/function/generic/broadcast.cpp
@@ -30,9 +30,9 @@ template <typename T>
 void Broadcast<T>::setup_impl(const Variables &inputs,
                               const Variables &outputs) {
   auto inshape = inputs[0]->shape();
-  int ndim = inputs[0]->ndim();
+  auto ndim = inputs[0]->ndim();
   if (ndim > 0) {
-    NBLA_CHECK(shape_.size() == ndim, error_code::value,
+    NBLA_CHECK(shape_.size() == static_cast<unsigned>(ndim), error_code::value,
                "Number of dimension must match. Shape: %d != input: %d.",
                shape_.size(), ndim);
   }
@@ -96,7 +96,7 @@ template <> struct strided_index<0> {
 template <int Ndim, typename T>
 void broadcast(size_t size, const T *x, const int *stride_x, const int *shape_y,
                T *y) {
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     int j = strided_index<Ndim>::get(i, stride_x, shape_y);
     y[i] = x[j];
   }
@@ -129,7 +129,7 @@ template <typename T> struct switch_broadcast<-1, T> {
 template <int Ndim, typename T>
 void broadcast_backward(size_t size, const T *dy, const int *stride_x,
                         const int *shape_y, T *g) {
-  for (int i = 0; i < size; ++i) {
+  for (size_t i = 0; i < size; ++i) {
     int j = strided_index<Ndim>::get(i, stride_x, shape_y);
     g[j] += dy[i];
   }

--- a/src/nbla/function/generic/categorical_cross_entropy.cpp
+++ b/src/nbla/function/generic/categorical_cross_entropy.cpp
@@ -33,16 +33,17 @@ void CategoricalCrossEntropy<T, Tl>::setup_impl(const Variables &inputs,
 
   Shape_t in_shape = inputs[0]->shape();
   Shape_t label_shape = inputs[1]->shape();
-  NBLA_CHECK(axis_ < in_shape.size(), error_code::value,
+  auto axis = static_cast<Shape_t::size_type>(this->axis_);
+  NBLA_CHECK(axis < in_shape.size(), error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of inputs[0]: %d.",
-             axis_, in_shape.size());
+             this->axis_, in_shape.size());
   NBLA_CHECK(label_shape.size() == in_shape.size(), error_code::value,
              "The length of each input dimension must match. "
              "inputs[1] length: %d != inputs[0] length: %d.",
              label_shape.size(), in_shape.size());
-  for (int axis = 0; axis < label_shape.size(); ++axis) {
-    if (axis == axis_) {
+  for (axis = 0; axis < label_shape.size(); ++axis) {
+    if (axis == static_cast<Shape_t::size_type>(this->axis_)) {
       NBLA_CHECK(label_shape[axis] == 1, error_code::value,
                  "Dimensions of axis of inputs[1] must be 1. "
                  "label_shape[axis]: %d != 1.",

--- a/src/nbla/function/generic/celu.cpp
+++ b/src/nbla/function/generic/celu.cpp
@@ -28,7 +28,10 @@ NBLA_REGISTER_FUNCTION_SOURCE(CELU, double, int);
 template <typename T>
 void CELU<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   Shape_t in_shape = inputs[0]->shape();
-  NBLA_CHECK(axis_ < in_shape.size() && axis_ >= 0, error_code::value,
+  NBLA_CHECK(axis_ >= 0, error_code::value,
+             "axis must not be less than zero, got %d", axis_);
+  auto axis = static_cast<Shape_t::size_type>(axis_);
+  NBLA_CHECK(axis < in_shape.size(), error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of input: %d.",
              axis_, in_shape.size());

--- a/src/nbla/function/generic/clip_grad_by_value.cpp
+++ b/src/nbla/function/generic/clip_grad_by_value.cpp
@@ -37,7 +37,7 @@ void ClipGradByValue<T>::setup_impl(const Variables &inputs,
              shape2.size());
 
   // Shape check
-  for (int i = 0; i < shape0.size(); i++) {
+  for (Shape_t::size_type i = 0; i < shape0.size(); i++) {
     NBLA_CHECK(shape0[i] && shape1[i] && shape2[i], error_code::value,
                "Size at shape[%d] differs %d, %d, and %d", i, shape0[i],
                shape1[i], shape2[i])

--- a/src/nbla/function/generic/confusion_matrix.cpp
+++ b/src/nbla/function/generic/confusion_matrix.cpp
@@ -30,7 +30,10 @@ void ConfusionMatrix<T, T1>::setup_impl(const Variables &inputs,
                                         const Variables &outputs) {
   Shape_t in_shape = inputs[0]->shape();
   Shape_t label_shape = inputs[1]->shape();
-  NBLA_CHECK(axis_ < in_shape.size(), error_code::value,
+  NBLA_CHECK(axis_ >= 0, error_code::value,
+             "axis must not be less than zero, got %d", axis_);
+  auto axis = static_cast<Shape_t::size_type>(this->axis_);
+  NBLA_CHECK(axis < in_shape.size(), error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());
@@ -38,8 +41,8 @@ void ConfusionMatrix<T, T1>::setup_impl(const Variables &inputs,
              "The length of each input dimension must match. "
              "inputs[1] length: %d != inputs[0] length: %d.",
              label_shape.size(), in_shape.size());
-  for (int axis = 0; axis < label_shape.size(); ++axis) {
-    if (axis == axis_) {
+  for (axis = 0; axis < label_shape.size(); ++axis) {
+    if (axis == static_cast<Shape_t::size_type>(this->axis_)) {
       NBLA_CHECK(label_shape[axis] == 1, error_code::value,
                  "Dimensions of axis of inputs[1] must be 1. "
                  "label_shape[axis]: %d != 1.",

--- a/src/nbla/function/generic/convolution.cpp
+++ b/src/nbla/function/generic/convolution.cpp
@@ -42,13 +42,17 @@ void Convolution<T>::setup_impl(const Variables &inputs,
   // Shape check
   Shape_t shape_data = inputs[0]->shape();
   Shape_t shape_weights = inputs[1]->shape();
-  NBLA_CHECK(base_axis_ < shape_data.size() - 1, error_code::unclassified,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis may not be less than zero, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis < shape_data.size() - 1, error_code::unclassified,
              "base_axis must be less than ndim - 1 of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0] - 1: %d.",
              base_axis_, shape_data.size() - 1);
-  spatial_dims_ = shape_data.size() - base_axis_ - 1;
-  NBLA_CHECK(shape_weights.size() == 2 + spatial_dims_, error_code::value,
+  size_t spatial_dims = shape_data.size() - base_axis - 1;
+  NBLA_CHECK(shape_weights.size() == 2 + spatial_dims, error_code::value,
              "Weights must be a tensor more than 3D.");
+  this->spatial_dims_ = spatial_dims;
   // Storing shape variables
   size_t channel_axis = base_axis_ + (channel_last_ ? spatial_dims_ : 0);
   size_t first_spatial_axis = base_axis_ + (channel_last_ ? 0 : 1);
@@ -72,13 +76,13 @@ void Convolution<T>::setup_impl(const Variables &inputs,
              "Number of grouped channel mismatch. "
              "Input: %d != Weights[%zu]: %d.",
              channels_i_ / group_, weight_channel_axis, channels_g_);
-  NBLA_CHECK(pad_.size() == spatial_dims_, error_code::value,
+  NBLA_CHECK(pad_.size() == spatial_dims, error_code::value,
              "pad size mismatch. pad size: %d != spatial dims: %d.",
              pad_.size(), spatial_dims_);
-  NBLA_CHECK(stride_.size() == spatial_dims_, error_code::value,
+  NBLA_CHECK(stride_.size() == spatial_dims, error_code::value,
              "stride size mismatch. stride size: %d != spatial dims: %d.",
              stride_.size(), spatial_dims_);
-  NBLA_CHECK(dilation_.size() == spatial_dims_, error_code::value,
+  NBLA_CHECK(dilation_.size() == spatial_dims, error_code::value,
              "dilation size mismatch. dilation size: %d != spatial dims: %d.",
              dilation_.size(), spatial_dims_);
   kernel_.clear();

--- a/src/nbla/function/generic/convolution.cpp
+++ b/src/nbla/function/generic/convolution.cpp
@@ -164,7 +164,7 @@ void Convolution<T>::forward_impl(const Variables &inputs,
   const T *w = inputs[1]->get_data_pointer<T>(this->ctx_);
   T *col = col_.cast_data_and_get_pointer<T>(this->ctx_, true);
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
-  const T *b;
+  const T *b = nullptr;
   if (inputs.size() == 3) {
     b = inputs[2]->get_data_pointer<T>(this->ctx_);
   }
@@ -206,9 +206,12 @@ void Convolution<T>::backward_impl(const Variables &inputs,
 
   using namespace ::nbla::eigen;
   const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
-  const T *x;
-  const T *w;
-  T *dx, *dw, *db, *col;
+  const T *x = nullptr;
+  const T *w = nullptr;
+  T *dx = nullptr;
+  T *dw = nullptr;
+  T *db = nullptr;
+  T *col = nullptr;
   std::unique_ptr<ColVectorMap<T>> mdb;
 
   if (propagate_down[0] || propagate_down[1]) {

--- a/src/nbla/function/generic/crelu.cpp
+++ b/src/nbla/function/generic/crelu.cpp
@@ -27,14 +27,17 @@ NBLA_REGISTER_FUNCTION_SOURCE(CReLU, int);
 template <typename T>
 void CReLU<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   Shape_t in_shape = inputs[0]->shape();
-  NBLA_CHECK(axis_ < in_shape.size() && axis_ >= 0, error_code::value,
+  NBLA_CHECK(axis_ >= 0, error_code::value,
+             "axis may not be less than zero, got %d", axis_);
+  auto axis = static_cast<Shape_t::size_type>(axis_);
+  NBLA_CHECK(axis < in_shape.size(), error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of input: %d.",
              axis_, in_shape.size());
-  in_shape[axis_] *= 2;
+  in_shape[axis] *= 2;
   outputs[0]->reshape(in_shape, true);
   Size_t size = inputs[0]->size();
-  size0_ = inputs[0]->size(axis_);
+  size0_ = inputs[0]->size(axis);
   size1_ = size / size0_;
   NBLA_CHECK(size0_ * size1_ == size, error_code::unclassified,
              "An error occurred during setup CReLU function.");

--- a/src/nbla/function/generic/deconvolution.cpp
+++ b/src/nbla/function/generic/deconvolution.cpp
@@ -45,19 +45,23 @@ void Deconvolution<T>::setup_impl(const Variables &inputs,
   // Shape check
   Shape_t shape_out = inputs[0]->shape();
   Shape_t shape_weights = inputs[1]->shape();
-  NBLA_CHECK(base_axis_ < shape_out.size() - 1, error_code::unclassified,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis may not be less than zero, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis + 1 < shape_out.size(), error_code::value,
              "base_axis must be less than ndim - 1 of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0] - 1: %d.",
              base_axis_, shape_out.size() - 1);
 
-  spatial_dims_ = shape_out.size() - base_axis_ - 1;
-  NBLA_CHECK(shape_weights.size() == 2 + spatial_dims_, error_code::value,
+  size_t spatial_dims = shape_out.size() - base_axis - 1;
+  NBLA_CHECK(shape_weights.size() == 2 + spatial_dims, error_code::value,
              "Weights must be a tensor more than 3D.");
+  this->spatial_dims_ = static_cast<int>(spatial_dims);
 
-  auto channel_axis = base_axis_ + (channel_last_ ? spatial_dims_ : 0);
-  auto first_spatial_axis = base_axis_ + (channel_last_ ? 0 : 1);
-  auto weight_channel_axis = 1 + (channel_last_ ? spatial_dims_ : 0);
-  auto weight_first_spatial_axis = channel_last_ ? 1 : 2;
+  size_t channel_axis = base_axis + (channel_last_ ? spatial_dims : 0);
+  size_t first_spatial_axis = base_axis + (channel_last_ ? 0 : 1);
+  size_t weight_channel_axis = 1 + (channel_last_ ? spatial_dims : 0);
+  size_t weight_first_spatial_axis = channel_last_ ? 1 : 2;
 
   // Storing shape variables
   channels_i_ = shape_weights[weight_channel_axis] * group_;
@@ -84,16 +88,16 @@ void Deconvolution<T>::setup_impl(const Variables &inputs,
              "Number of grouped channel mismatch."
              "Input: %d != Weights[%d]: %d",
              channels_i_ / group_, weight_channel_axis, channels_g_);
-  NBLA_CHECK(pad_.size() == spatial_dims_, error_code::value,
+  NBLA_CHECK(pad_.size() == spatial_dims, error_code::value,
              "pad size mismatch. pad size: %d != spatial dims: %d.",
              pad_.size(), spatial_dims_);
-  NBLA_CHECK(stride_.size() == spatial_dims_, error_code::value,
+  NBLA_CHECK(stride_.size() == spatial_dims, error_code::value,
              "stride size mismatch. stride size: %d != spatial dims: %d.",
              stride_.size(), spatial_dims_);
-  NBLA_CHECK(dilation_.size() == spatial_dims_, error_code::value,
+  NBLA_CHECK(dilation_.size() == spatial_dims, error_code::value,
              "dilation size mismatch. dilation size: %d != spatial dims: %d.",
              dilation_.size(), spatial_dims_);
-  NBLA_CHECK(output_padding_.size() == spatial_dims_, error_code::value,
+  NBLA_CHECK(output_padding_.size() == spatial_dims, error_code::value,
              "output_padding size mismatch: %d != spatial dims: %d.",
              output_padding_.size(), spatial_dims_);
 

--- a/src/nbla/function/generic/deconvolution.cpp
+++ b/src/nbla/function/generic/deconvolution.cpp
@@ -185,7 +185,7 @@ void Deconvolution<T>::forward_impl(const Variables &inputs,
   const T *w = inputs[1]->get_data_pointer<T>(this->ctx_);
   T *col = col_.cast_data_and_get_pointer<T>(this->ctx_, true);
   T *x = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
-  const T *b;
+  const T *b = nullptr;
   if (inputs.size() == 3) {
     b = inputs[2]->get_data_pointer<T>(this->ctx_);
   }
@@ -234,9 +234,12 @@ void Deconvolution<T>::backward_impl(const Variables &inputs,
 
   using namespace ::nbla::eigen;
   const T *dx = outputs[0]->get_grad_pointer<T>(this->ctx_);
-  const T *y;
-  const T *w;
-  T *dy, *dw, *db, *col;
+  const T *y = nullptr;
+  const T *w = nullptr;
+  T *dy = nullptr;
+  T *dw = nullptr;
+  T *db = nullptr;
+  T *col = nullptr;
   std::unique_ptr<ColVectorMap<T>> mdb;
 
   if (propagate_down[0] || propagate_down[1]) {

--- a/src/nbla/function/generic/depthwise_convolution.cpp
+++ b/src/nbla/function/generic/depthwise_convolution.cpp
@@ -213,8 +213,12 @@ void DepthwiseConvolution<T>::backward_impl(const Variables &inputs,
   Variable *const bias = (inputs.size() == 3) ? inputs[2] : nullptr;
 
   const T *outmap_grad = output->get_grad_pointer<T>(this->ctx_);
-  const T *sample_data, *weight_data;
-  T *sample_grad, *weight_grad, *bias_grad, *col;
+  const T *sample_data = nullptr;
+  const T *weight_data = nullptr;
+  T *sample_grad = nullptr;
+  T *weight_grad = nullptr;
+  T *bias_grad = nullptr;
+  T *col = nullptr;
 
   if (propagate_down[0] || propagate_down[1]) {
     col = col_.cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -283,7 +287,7 @@ void DepthwiseConvolution<T>::backward_impl(const Variables &inputs,
       sample_data += sample_channels_ * sample_size_;
     }
 
-    if (bias_grad && propagate_down[2]) { // backprop to bias gradient
+    if (bias && propagate_down[2]) { // backprop to bias gradient
       ConstMatrixMap<T> outmap(outmap_grad, outmap_channels_, outmap_size_);
       ColVectorMap<T>(bias_grad, outmap_channels_) += outmap.rowwise().sum();
     }

--- a/src/nbla/function/generic/depthwise_convolution.cpp
+++ b/src/nbla/function/generic/depthwise_convolution.cpp
@@ -60,12 +60,15 @@ void DepthwiseConvolution<T>::setup_impl(const Variables &inputs,
   Shape_t input_shape = input->shape();
   Shape_t weight_shape = weights->shape();
 
-  NBLA_CHECK(base_axis_ < input_shape.size() - 1, error_code::unclassified,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis may not be less than zero, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis < input_shape.size() - 1, error_code::value,
              "base_axis must be less than ndim - 1 of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0] - 1: %d.",
              base_axis_, input_shape.size() - 1);
 
-  auto kernel_dims = input_shape.size() - base_axis_ - 1;
+  auto kernel_dims = input_shape.size() - base_axis - 1;
 
   NBLA_CHECK(kernel_dims <= 2, error_code::unclassified,
              "Depthwise convolution requires 1D or 2D image shape.");
@@ -119,7 +122,7 @@ void DepthwiseConvolution<T>::setup_impl(const Variables &inputs,
 
   outmap_shape_.clear();
   outmap_shape_.reserve(kernel_shape_.size());
-  for (int i = 0; i < kernel_shape_.size(); i++) {
+  for (vector<int>::size_type i = 0; i < kernel_shape_.size(); i++) {
     auto kernel = dilation_[i] * (kernel_shape_[i] - 1) + 1; // dilated kernel
     auto padded = sample_shape_[i] + 2 * padding_[i];        // padded sample
     outmap_shape_.push_back(1 + (padded - kernel) / stride_[i]);

--- a/src/nbla/function/generic/depthwise_deconvolution.cpp
+++ b/src/nbla/function/generic/depthwise_deconvolution.cpp
@@ -219,8 +219,12 @@ void DepthwiseDeconvolution<T>::backward_impl(
   Variable *const bias = (inputs.size() == 3) ? inputs[2] : nullptr;
 
   const T *outmap_grad = output->get_grad_pointer<T>(this->ctx_);
-  const T *sample_data, *weight_data;
-  T *sample_grad, *weight_grad, *bias_grad, *col;
+  const T *sample_data = nullptr;
+  const T *weight_data = nullptr;
+  T *sample_grad = nullptr;
+  T *weight_grad = nullptr;
+  T *bias_grad = nullptr;
+  T *col = nullptr;
 
   if (propagate_down[0] || propagate_down[1]) {
     col = col_.cast_data_and_get_pointer<T>(this->ctx_, true);

--- a/src/nbla/function/generic/depthwise_deconvolution.cpp
+++ b/src/nbla/function/generic/depthwise_deconvolution.cpp
@@ -59,12 +59,15 @@ void DepthwiseDeconvolution<T>::setup_impl(const Variables &inputs,
   Shape_t input_shape = input->shape();
   Shape_t weight_shape = weights->shape();
 
-  NBLA_CHECK(base_axis_ < input_shape.size() - 1, error_code::unclassified,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis may not be less than zero, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis < input_shape.size() - 1, error_code::value,
              "base_axis must be less than ndim - 1 of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0] - 1: %d.",
              base_axis_, input_shape.size() - 1);
 
-  auto kernel_dims = input_shape.size() - base_axis_ - 1;
+  auto kernel_dims = input_shape.size() - base_axis - 1;
 
   NBLA_CHECK(kernel_dims <= 2, error_code::unclassified,
              "Depthwise deconvolution requires 1D or 2D sample shape.");
@@ -118,7 +121,7 @@ void DepthwiseDeconvolution<T>::setup_impl(const Variables &inputs,
 
   outmap_shape_.clear();
   outmap_shape_.reserve(kernel_shape_.size());
-  for (int i = 0; i < kernel_shape_.size(); ++i) {
+  for (vector<int>::size_type i = 0; i < kernel_shape_.size(); ++i) {
     auto shape = sample_shape_[i];
     auto k = kernel_shape_[i];
     auto d = dilation_[i];

--- a/src/nbla/function/generic/fused_batch_normalization.cpp
+++ b/src/nbla/function/generic/fused_batch_normalization.cpp
@@ -40,7 +40,6 @@ void relu_backward(int size, T *dx, const T *dy, const T *y) {
 
 template <typename T>
 void add2_backward(int size, T *dx1, const T *dx, bool accum) {
-  bool accum_bn = false; // Whatever since it's inplaced.
   for (int i = 0; i < size; i++) {
     dx1[i] = accum ? dx1[i] + dx[i] : dx[i];
   }

--- a/src/nbla/function/generic/gather_nd.cpp
+++ b/src/nbla/function/generic/gather_nd.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cassert>
 #include <nbla/array.hpp>
 #include <nbla/common.hpp>
 #include <nbla/function/gather_nd.hpp>
@@ -35,7 +36,9 @@ void GatherNd<T>::setup_impl(const Variables &inputs,
   NBLA_CHECK(indices_shape.size() >= 2, error_code::value,
              "gather_nd requires the map to have at least 2 dimensions");
 
-  NBLA_CHECK(indices_shape.at(0) <= srcdata_shape.size(), error_code::value,
+  assert(indices_shape.at(0) >= 0);
+  auto indices_at_zero = static_cast<Shape_t::size_type>(indices_shape.at(0));
+  NBLA_CHECK(indices_at_zero <= srcdata_shape.size(), error_code::value,
              "Number of indices exceeds data dimension");
 
   Shape_t outdata_shape(indices_shape.size() - 1 + srcdata_shape.size() -

--- a/src/nbla/function/generic/gru.cpp
+++ b/src/nbla/function/generic/gru.cpp
@@ -295,7 +295,7 @@ vector<vector<CgVariablePtr>> GRU<T>::create_fixed_length_gru_graph(
           cg_utils::get_item_nd(this->ctx_, in_b, vector<int>{i, 0}); // b[i, 0]
     }
 
-    for (int k = 0; k < xs.size(); k++) {
+    for (vector<CgVariablePtr>::size_type k = 0; k < xs.size(); k++) {
       hf_var = gru_cell(xs[k], hf_var, wf_var, bf_var);
       hs.push_back(hf_var);
     }
@@ -317,7 +317,7 @@ vector<vector<CgVariablePtr>> GRU<T>::create_fixed_length_gru_graph(
       std::reverse(std::begin(xs), std::end(xs));
     }
 
-    for (int k = 0; k < xs.size(); k++) {
+    for (vector<CgVariablePtr>::size_type k = 0; k < xs.size(); k++) {
       int j = xs.size() - 1 - k;
       hb_var = gru_cell(xs[k], hb_var, wb_var, bb_var);
       auto concatenate =

--- a/src/nbla/function/generic/image_augmentation.cpp
+++ b/src/nbla/function/generic/image_augmentation.cpp
@@ -43,7 +43,7 @@ void ImageAugmentation<T>::setup_impl(const Variables &inputs,
 
   Shape_t shape_y = inputs[0]->shape();
   int dim_offset = shape_y.size() - shape_.size();
-  for (int i = 0; i < shape_.size(); i++) {
+  for (Shape_t::size_type i = 0; i < shape_.size(); i++) {
     shape_y[i + dim_offset] = shape_[i];
   }
 

--- a/src/nbla/function/generic/inq_affine.cpp
+++ b/src/nbla/function/generic/inq_affine.cpp
@@ -37,7 +37,7 @@ void INQAffine<T, T1>::setup_impl(const Variables &inputs,
              "Indicators and weights must have same size. "
              "Ndim of weights: %d != ndim of indicators: %d.",
              inputs[1]->shape().size(), inputs[2]->shape().size());
-  for (int i = 0; i < inputs[1]->shape().size(); ++i) {
+  for (Shape_t::size_type i = 0; i < inputs[1]->shape().size(); ++i) {
     NBLA_CHECK(inputs[1]->shape()[i] == inputs[2]->shape()[i],
                error_code::value,
                "Indicators and weights must have same size. "

--- a/src/nbla/function/generic/inq_convolution.cpp
+++ b/src/nbla/function/generic/inq_convolution.cpp
@@ -38,7 +38,7 @@ void INQConvolution<T, T1>::setup_impl(const Variables &inputs,
              "Indicators and weights must have same size. "
              "Ndim of weights: %d != ndim of indicators: %d.",
              inputs[1]->shape().size(), inputs[2]->shape().size());
-  for (int i = 0; i < inputs[1]->shape().size(); ++i) {
+  for (Shape_t::size_type i = 0; i < inputs[1]->shape().size(); ++i) {
     NBLA_CHECK(inputs[1]->shape()[i] == inputs[2]->shape()[i],
                error_code::value,
                "Indicators and weights must have same size. "

--- a/src/nbla/function/generic/interpolate.cpp
+++ b/src/nbla/function/generic/interpolate.cpp
@@ -342,7 +342,7 @@ void Interpolate<T>::setup_impl(const Variables &inputs,
   Shape_t out_shape(inputs[0]->shape());
   auto offset = channel_last_ ? out_shape.size() - output_size_.size() - 1
                               : out_shape.size() - output_size_.size();
-  for (int d = 0; d < output_size_.size(); d++) {
+  for (Shape_t::size_type d = 0; d < output_size_.size(); d++) {
     out_shape[d + offset] = output_size_[d];
   }
   outputs[0]->reshape(out_shape, true);

--- a/src/nbla/function/generic/kl_multinomial.cpp
+++ b/src/nbla/function/generic/kl_multinomial.cpp
@@ -35,16 +35,20 @@ void KLMultinomial<T>::setup_impl(const Variables &inputs,
              string_join(inputs[1]->shape(), string(", ")).c_str());
 
   Shape_t inshape = inputs[0]->shape();
-  NBLA_CHECK(base_axis_ < inshape.size(), error_code::value,
+
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis may not be less than zero, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis < inshape.size(), error_code::value,
              "base_axis must be less than ndim of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0]: %d.",
              base_axis_, inshape.size());
 
-  Shape_t outshape(base_axis_ + 1);
-  for (int i = 0; i < base_axis_; i++) {
+  Shape_t outshape(base_axis + 1);
+  for (Shape_t::size_type i = 0; i < base_axis; i++) {
     outshape[i] = inshape[i];
   }
-  outshape[base_axis_] = 1;
+  outshape[base_axis] = 1;
 
   outputs[0]->reshape(outshape, true);
 }

--- a/src/nbla/function/generic/log_softmax.cpp
+++ b/src/nbla/function/generic/log_softmax.cpp
@@ -29,16 +29,21 @@ template <typename T>
 void LogSoftmax<T>::setup_impl(const Variables &inputs,
                                const Variables &outputs) {
   Shape_t in_shape = inputs[0]->shape();
-  NBLA_CHECK(axis_ < in_shape.size(), error_code::value,
+
+  NBLA_CHECK(axis_ >= 0, error_code::value,
+             "axis may not be less than zero, got %d", axis_);
+  auto axis = static_cast<Shape_t::size_type>(axis_);
+  NBLA_CHECK(axis < in_shape.size(), error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());
+
   outputs[0]->reshape(in_shape, true);
   Size_t size = inputs[0]->size();
-  Size_t size_axis = inputs[0]->size(axis_);
-  size0_ = size / size_axis;          // Batch size.
-  size1_ = inputs[0]->shape()[axis_]; // Size of specified axis.
-  size2_ = size / size0_ / size1_;    // Size of rest.
+  Size_t size_axis = inputs[0]->size(axis);
+  size0_ = size / size_axis;         // Batch size.
+  size1_ = inputs[0]->shape()[axis]; // Size of specified axis.
+  size2_ = size / size0_ / size1_;   // Size of rest.
 }
 
 template <typename T>

--- a/src/nbla/function/generic/lstm.cpp
+++ b/src/nbla/function/generic/lstm.cpp
@@ -263,7 +263,7 @@ vector<vector<CgVariablePtr>> LSTM<T>::create_fixed_length_lstm_graph(
           cg_utils::get_item_nd(this->ctx_, in_b, vector<int>{i, 0}); // b[i, 0]
     }
 
-    for (int k = 0; k < xs.size(); k++) {
+    for (vector<CgVariablePtr>::size_type k = 0; k < xs.size(); k++) {
       auto tmp = lstm_cell(xs[k], hf_var, cf_var, wf_var, bf_var);
       hf_var = (tmp[0])[0];
       cf_var = (tmp[1])[0];
@@ -290,7 +290,7 @@ vector<vector<CgVariablePtr>> LSTM<T>::create_fixed_length_lstm_graph(
     if (xs.size() > 1) {
       std::reverse(std::begin(xs), std::end(xs));
     }
-    for (int k = 0; k < xs.size(); k++) {
+    for (vector<CgVariablePtr>::size_type k = 0; k < xs.size(); k++) {
       int j = xs.size() - 1 - k;
       auto tmp = lstm_cell(xs[k], hb_var, cb_var, wb_var, bb_var);
       hb_var = (tmp[0])[0];

--- a/src/nbla/function/generic/matrix_diag_part.cpp
+++ b/src/nbla/function/generic/matrix_diag_part.cpp
@@ -38,7 +38,7 @@ void MatrixDiagPart<T>::setup_impl(const Variables &inputs,
 
   // Create new shape and compute part size
   Shape_t shape_y;
-  for (int i = 0; i < shape_x.size() - 1; ++i) {
+  for (Shape_t::size_type i = 0; i < shape_x.size() - 1; ++i) {
     shape_y.push_back(shape_x[i]);
   }
 

--- a/src/nbla/function/generic/mean_subtraction.cpp
+++ b/src/nbla/function/generic/mean_subtraction.cpp
@@ -39,7 +39,10 @@ void MeanSubtraction<T>::setup_impl(const Variables &inputs,
 
   // Check shape
   Shape_t shape_i = inputs[0]->shape();
-  NBLA_CHECK(base_axis_ < shape_i.size(), error_code::value,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis may not be less than zero, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis < shape_i.size(), error_code::value,
              "base_axis must be less than ndim of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0]: %d.",
              base_axis_, shape_i.size());

--- a/src/nbla/function/generic/min_max_quantize.cpp
+++ b/src/nbla/function/generic/min_max_quantize.cpp
@@ -88,7 +88,7 @@ void MinMaxQuantize<T>::setup_impl(const Variables &inputs,
   }
   // Compute broadcast shape
   std::vector<int> bshape(x->shape().size());
-  for (int i = 0; i < x->shape().size(); i++) {
+  for (Shape_t::size_type i = 0; i < x->shape().size(); i++) {
     bshape[i] = x->shape()[i];
   }
   // Create functions needed to compute the min-max quantization

--- a/src/nbla/function/generic/mul_n.cpp
+++ b/src/nbla/function/generic/mul_n.cpp
@@ -26,7 +26,7 @@ template <typename T>
 void MulN<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   NBLA_CHECK(inputs.size() >= 2, error_code::value,
              "minimum 2 inputs must be given");
-  for (int i = 1; i < inputs.size(); i++) {
+  for (Variables::size_type i = 1; i < inputs.size(); i++) {
     NBLA_CHECK(inputs[0]->shape() == inputs[i]->shape(), error_code::value,
                "shape of all inputs must be shame");
   }
@@ -37,12 +37,12 @@ template <typename T>
 void MulN<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   std::unique_ptr<const T *[]> xs(new const T *[inputs.size()]);
-  for (int i = 0; i < inputs.size(); i++) {
+  for (Variables::size_type i = 0; i < inputs.size(); i++) {
     xs[i] = inputs[i]->get_data_pointer<T>(this->ctx_);
   }
   for (int j = 0; j < inputs[0]->size(); j++) {
     T val = (T)(1);
-    for (int i = 0; i < inputs.size(); ++i) {
+    for (Variables::size_type i = 0; i < inputs.size(); ++i) {
       val *= xs[i][j];
     }
     y[j] = val;
@@ -69,7 +69,7 @@ void MulN<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
   const T *y = outputs[0]->get_data_pointer<T>(this->ctx_);
   Size_t size = inputs[0]->size();
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (Variables::size_type i = 0; i < inputs.size(); ++i) {
     if (propagate_down[i]) {
       T *dx = inputs[i]->cast_grad_and_get_pointer<T>(this->ctx_, !(accum[i]));
       const T *x = inputs[i]->get_data_pointer<T>(this->ctx_);

--- a/src/nbla/function/generic/one_hot.cpp
+++ b/src/nbla/function/generic/one_hot.cpp
@@ -19,6 +19,7 @@
 #include <nbla/variable.hpp>
 
 #include <algorithm>
+#include <cassert>
 
 namespace nbla {
 
@@ -28,8 +29,9 @@ template <typename T, typename T1>
 void OneHot<T, T1>::setup_impl(const Variables &inputs,
                                const Variables &outputs) {
   Shape_t shape_x = inputs[0]->shape();
+  assert(shape_x.size() >= 1);
   dim_ = shape_x[shape_x.size() - 1];
-  NBLA_CHECK(shape_.size() == dim_, error_code::value,
+  NBLA_CHECK(shape_.size() == static_cast<size_t>(dim_), error_code::value,
              "Shape size does not match last dimension of inputs[0]."
              "shape size: %d != input dim: %d.",
              shape_.size(), dim_);
@@ -37,7 +39,7 @@ void OneHot<T, T1>::setup_impl(const Variables &inputs,
   Shape_t shape_y = shape_x;
   shape_y.erase(shape_y.begin() + shape_y.size() - 1);
   size_ = 1;
-  for (int i = 0; i < shape_.size(); ++i) {
+  for (Shape_t::size_type i = 0; i < shape_.size(); ++i) {
     size_ *= shape_[i];
     shape_y.push_back(shape_[i]);
   }

--- a/src/nbla/function/generic/pack_padded_sequence.cpp
+++ b/src/nbla/function/generic/pack_padded_sequence.cpp
@@ -67,7 +67,7 @@ void PackPaddedSequence<U>::forward_impl(const Variables &inputs,
   auto packed_sequence = outputs[0];
   auto batch_sizes = outputs[1];
 
-  auto N = packed_sequence->shape()[0];
+  //   N = packed_sequence->shape()[0];
   auto T = batch_sizes->shape()[0];
   auto B = lengths->shape()[0];
   auto D = packed_sequence->ndim() == 1 ? 1 : packed_sequence->size(1);
@@ -107,7 +107,7 @@ void PackPaddedSequence<U>::backward_impl(const Variables &inputs,
   auto batch_sizes = outputs[1];
 
   // TODO: batch_first
-  auto N = packed_sequence->shape()[0];
+  //   N = packed_sequence->shape()[0];
   auto T = batch_sizes->shape()[0];
   auto B = lengths->shape()[0];
   auto D = packed_sequence->ndim() == 1 ? 1 : packed_sequence->size(1);

--- a/src/nbla/function/generic/pad.cpp
+++ b/src/nbla/function/generic/pad.cpp
@@ -28,7 +28,7 @@ inline void init_index_map(const Shape_t &dst_ndi, Size_t *idx_map,
                            const Shape_t &dst_shape, const PadList &padding) {
   const auto dst_idx = ndi::nd2flat(dst_ndi, dst_stride);
   Shape_t::value_type src_idx = 0;
-  for (int axis = 0; axis < dst_shape.size(); axis++) {
+  for (Shape_t::size_type axis = 0; axis < dst_shape.size(); axis++) {
     if ((dst_ndi[axis] < padding[axis].first) ||
         (dst_ndi[axis] >= dst_shape[axis] - padding[axis].second)) {
       return;
@@ -47,7 +47,7 @@ inline void pad_forward(const Shape_t &dst_ndi, const T *src, T *dst,
                         const T constant_value) {
   const auto dst_idx = ndi::nd2flat(dst_ndi, dst_stride);
   Shape_t::value_type src_idx = 0;
-  for (int axis = 0; axis < dst_shape.size(); axis++) {
+  for (Shape_t::size_type axis = 0; axis < dst_shape.size(); axis++) {
     if ((dst_ndi[axis] < padding[axis].first) ||
         (dst_ndi[axis] >= dst_shape[axis] - padding[axis].second)) {
       dst[dst_idx] = constant_value;
@@ -64,7 +64,7 @@ inline void pad_backward(const Shape_t &src_ndi, const T *src, T *dst,
                          const Shape_t &src_shape, const PadList &padding) {
   const auto src_idx = ndi::nd2flat(src_ndi, src_stride);
   Shape_t::value_type dst_idx = 0;
-  for (int axis = 0; axis < src_shape.size(); axis++) {
+  for (Shape_t::size_type axis = 0; axis < src_shape.size(); axis++) {
     if ((src_ndi[axis] < padding[axis].first) ||
         (src_ndi[axis] >= src_shape[axis] - padding[axis].second)) {
       return;

--- a/src/nbla/function/generic/pad_packed_sequence.cpp
+++ b/src/nbla/function/generic/pad_packed_sequence.cpp
@@ -70,7 +70,7 @@ void PadPackedSequence<U>::forward_impl(const Variables &inputs,
   auto padded_sequence = outputs[0];
   auto lengths = outputs[1];
 
-  auto N = packed_sequence->shape()[0];
+  //   N = packed_sequence->shape()[0];
   auto T = batch_sizes->shape()[0];
   auto B = lengths->shape()[0];
   auto D = packed_sequence->ndim() == 1 ? 1 : packed_sequence->size(1);
@@ -119,7 +119,7 @@ void PadPackedSequence<U>::backward_impl(const Variables &inputs,
   auto padded_sequence = outputs[0];
   auto lengths = outputs[1];
 
-  auto N = packed_sequence->shape()[0];
+  //   N = packed_sequence->shape()[0];
   auto T = batch_sizes->shape()[0];
   auto B = lengths->shape()[0];
   auto D = packed_sequence->ndim() == 1 ? 1 : packed_sequence->size(1);

--- a/src/nbla/function/generic/prelu.cpp
+++ b/src/nbla/function/generic/prelu.cpp
@@ -30,17 +30,20 @@ void PReLU<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   Shape_t shape_x = inputs[0]->shape();
   Shape_t shape_w = inputs[1]->shape();
 
-  NBLA_CHECK(base_axis_ < shape_x.size(), error_code::value,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis may not be less than zero, got %d", base_axis_);
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis < shape_x.size(), error_code::value,
              "base_axis must be less than ndim of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0]: %d.",
              base_axis_, shape_x.size());
   NBLA_CHECK(inputs[1]->size() == 1 ||
-                 (shape_w.size() == 1 && shape_w[0] == shape_x[base_axis_]),
+                 (shape_w.size() == 1 && shape_w[0] == shape_x[base_axis]),
              error_code::value, "The negative slope must be a 1d "
                                 "tensor or a scalar.");
   Shape_t stride_x = get_c_contiguous_strides(shape_x);
-  base_shape_ = shape_x[base_axis_];
-  base_stride_ = stride_x[base_axis_];
+  base_shape_ = shape_x[base_axis];
+  base_stride_ = stride_x[base_axis];
   outputs[0]->reshape(shape_x, true);
 }
 

--- a/src/nbla/function/generic/random_erase.cpp
+++ b/src/nbla/function/generic/random_erase.cpp
@@ -325,9 +325,8 @@ void RandomErase<T>::backward_impl(const Variables &inputs,
             xe_start = random_coords[idx + 2];
             ye_end = random_coords[idx + 3];
             xe_end = random_coords[idx + 4];
-            if ((eprob <= prob_) &&
-                (ye_start <= static_cast<size_t>(h) &&
-                 static_cast<size_t>(h) <= ye_end) &&
+            if ((eprob <= prob_) && (ye_start <= static_cast<size_t>(h) &&
+                                     static_cast<size_t>(h) <= ye_end) &&
                 (xe_start <= static_cast<size_t>(w) &&
                  static_cast<size_t>(w) <= xe_end)) {
               fall = true;

--- a/src/nbla/function/generic/random_erase.cpp
+++ b/src/nbla/function/generic/random_erase.cpp
@@ -70,15 +70,15 @@ void generate_random_coords(float *random_coords, const size_t N,
   };
 
   if (share) {
-    for (int n = 0; n < N; n++) {
-      for (int b = 0; b < B; b++) {
+    for (int n = 0; static_cast<size_t>(n) < N; n++) {
+      for (int b = 0; static_cast<size_t>(b) < B; b++) {
         random_coords = generate_coords_and_next(random_coords);
       }
     }
   } else {
-    for (int n = 0; n < N; n++) {
-      for (int b = 0; b < B; b++) {
-        for (size_t c = 0; c < C; c++) {
+    for (int n = 0; static_cast<size_t>(n) < N; n++) {
+      for (int b = 0; static_cast<size_t>(b) < B; b++) {
+        for (size_t c = 0; static_cast<size_t>(c) < C; c++) {
           random_coords = generate_coords_and_next(random_coords);
         }
       }
@@ -201,7 +201,7 @@ void RandomErase<T>::setup_impl(const Variables &inputs,
   NBLA_CHECK(n_ > 0, error_code::value, "n must be positive. n = %d.", n_);
   NBLA_CHECK(replacements_.size() == 2, error_code::value,
              "Length of replacements must be 2.");
-  NBLA_CHECK(base_axis_ < inputs[0]->shape().size(), error_code::value,
+  NBLA_CHECK((size_t)base_axis_ < inputs[0]->shape().size(), error_code::value,
              "base_axis must be less than ndim of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0]: %d.",
              base_axis_, inputs[0]->shape().size());
@@ -325,8 +325,11 @@ void RandomErase<T>::backward_impl(const Variables &inputs,
             xe_start = random_coords[idx + 2];
             ye_end = random_coords[idx + 3];
             xe_end = random_coords[idx + 4];
-            if ((eprob <= prob_) && (ye_start <= h && h <= ye_end) &&
-                (xe_start <= w && w <= xe_end)) {
+            if ((eprob <= prob_) &&
+                (ye_start <= static_cast<size_t>(h) &&
+                 static_cast<size_t>(h) <= ye_end) &&
+                (xe_start <= static_cast<size_t>(w) &&
+                 static_cast<size_t>(w) <= xe_end)) {
               fall = true;
               break;
             }

--- a/src/nbla/function/generic/random_flip.cpp
+++ b/src/nbla/function/generic/random_flip.cpp
@@ -46,7 +46,7 @@ void RandomFlip<T>::flip_recursive(const Variable *inp, const T *x, T *y,
     current_x_offset += x_stride * (size - 1);
     x_stride = -x_stride;
   }
-  if (dim == inp->shape().size() - 1) {
+  if (static_cast<Shape_t::size_type>(dim) == inp->shape().size() - 1) {
     const T *current_x = x + current_x_offset;
     const T *end_x = current_x + size * x_stride;
     T *current_y = y + current_y_offset;
@@ -83,9 +83,10 @@ template <typename T>
 void RandomFlip<T>::forward_impl(const Variables &inputs,
                                  const Variables &outputs) {
   flip_.resize(size_);
+  auto input0_shape_size = inputs[0]->shape().size();
   for (int i = 0; i < size_; i++) {
-    flip_[i].resize(inputs[0]->shape().size());
-    for (int id = 0; id < inputs[0]->shape().size(); id++) {
+    flip_[i].resize(input0_shape_size);
+    for (int id = 0; static_cast<size_t>(id) < input0_shape_size; id++) {
       auto itr = std::find(axes_.begin(), axes_.end(), id);
       flip_[i][id] = (rgen_() % 2) && (itr != axes_.end());
     }

--- a/src/nbla/function/generic/random_shift.cpp
+++ b/src/nbla/function/generic/random_shift.cpp
@@ -73,7 +73,7 @@ void RandomShift<T>::shift_recursive(const Variable *inp, const T *x, T *y,
   const int stride = inp->strides()[dim];
   const int size = inp->shape()[dim];
   const std::vector<int> &table = addr_table_[shift_index][dim];
-  if (dim == inp->shape().size() - 1) {
+  if (static_cast<Shape_t::size_type>(dim) == inp->shape().size() - 1) {
     for (int i = 0; i < size; ++i) {
       y[current_y_offset] = x[x_offset + table[i]];
       current_y_offset += stride;
@@ -98,7 +98,7 @@ void RandomShift<T>::shift_backward_recursive(const Variable *inp, const T *dy,
   const int stride = inp->strides()[dim];
   const int size = inp->shape()[dim];
   const std::vector<int> &table = addr_table_[shift_index][dim];
-  if (dim == inp->shape().size() - 1) {
+  if (static_cast<Shape_t::size_type>(dim) == inp->shape().size() - 1) {
     for (int i = 0; i < size; ++i) {
       dx[x_offset + table[i]] += dy[current_y_offset];
       current_y_offset += stride;
@@ -121,7 +121,7 @@ void RandomShift<T>::forward_impl(const Variables &inputs,
   addr_table_.resize(size_);
   for (int i = 0; i < size_; i++) {
     vector<int> shifts;
-    for (int id = 0; id < shifts_.size(); id++) {
+    for (Shape_t::size_type id = 0; id < shifts_.size(); id++) {
       shifts.push_back(rgen_() % (shifts_[id] * 2 + 1) - shifts_[id]);
     }
     addr_table_[i] = prepare_addr_table(inputs, shifts);

--- a/src/nbla/function/generic/reshape.cpp
+++ b/src/nbla/function/generic/reshape.cpp
@@ -31,7 +31,7 @@ void Reshape<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   int tsize = inputs[0]->size();
   int rest_size = 1;
   int shape_infer_index = -1;
-  for (int s = 0; s < shape_.size(); s++) {
+  for (int s = 0; static_cast<Shape_t::size_type>(s) < shape_.size(); s++) {
     if (shape_[s] < 0) {
       NBLA_CHECK(shape_infer_index < 0, error_code::value,
                  "The shape option in Reshape function can take negative size "

--- a/src/nbla/function/generic/rnn.cpp
+++ b/src/nbla/function/generic/rnn.cpp
@@ -187,7 +187,7 @@ vector<vector<CgVariablePtr>> RNN<T>::create_fixed_length_rnn_graph(
       bf_var =
           cg_utils::get_item_nd(this->ctx_, in_b, vector<int>{i, 0}); // b[i, 0]
     }
-    for (int k = 0; k < xs.size(); k++) {
+    for (vector<CgVariablePtr>::size_type k = 0; k < xs.size(); k++) {
       hf_var = rnn_cell(xs[k], hf_var, wf_var, bf_var);
       hs.push_back(hf_var);
     }
@@ -207,7 +207,7 @@ vector<vector<CgVariablePtr>> RNN<T>::create_fixed_length_rnn_graph(
     if (xs.size() > 1) {
       std::reverse(std::begin(xs), std::end(xs));
     }
-    for (int k = 0; k < xs.size(); k++) {
+    for (vector<CgVariablePtr>::size_type k = 0; k < xs.size(); k++) {
       int j = xs.size() - 1 - k;
       hb_var = rnn_cell(xs[k], hb_var, wb_var, bb_var);
       auto concatenate =

--- a/src/nbla/function/generic/scatter_add.cpp
+++ b/src/nbla/function/generic/scatter_add.cpp
@@ -30,7 +30,7 @@ void ScatterAdd<T>::setup_impl(const Variables &inputs,
   auto axis = (axis_ < 0) ? inputs.at(0)->ndim() + axis_ : axis_;
   NBLA_CHECK(axis <= inputs.at(0)->ndim(), error_code::value,
              "Shape error, input dimension must be greater than axis");
-  for (int i = 1; i < inputs.size(); ++i) {
+  for (Variables::size_type i = 1; i < inputs.size(); ++i) {
     NBLA_CHECK(inputs.at(0)->ndim() == inputs.at(i)->ndim(), error_code::value,
                "Shape error. all inputs must have same dimension");
   }
@@ -38,7 +38,7 @@ void ScatterAdd<T>::setup_impl(const Variables &inputs,
   auto x0_shape = inputs.at(0)->shape();
   auto indices_shape = inputs.at(1)->shape();
   auto x1_shape = inputs.at(2)->shape();
-  for (int i = 0; i < indices_shape.size(); ++i) {
+  for (int i = 0; static_cast<size_t>(i) < indices_shape.size(); ++i) {
     if (i != axis) {
       NBLA_CHECK(indices_shape[i] <= x0_shape[i], error_code::value,
                  "Shape error. indices size: %d at axis %d is greater than x0 "

--- a/src/nbla/function/generic/scatter_nd.cpp
+++ b/src/nbla/function/generic/scatter_nd.cpp
@@ -31,7 +31,8 @@ void ScatterNd<T>::setup_impl(const Variables &inputs,
   NBLA_CHECK(indices->ndim() >= 2, error_code::value,
              "scatter_nd requires indices to have at least 2 dimensions");
 
-  NBLA_CHECK(static_cast<Shape_t::size_type>(indices->shape().at(0)) <= shape_.size(),
+  NBLA_CHECK(static_cast<Shape_t::size_type>(indices->shape().at(0)) <=
+                 shape_.size(),
              error_code::value, "Number of indices exceeds output dimension");
 
   auto N = data->ndim();

--- a/src/nbla/function/generic/scatter_nd.cpp
+++ b/src/nbla/function/generic/scatter_nd.cpp
@@ -31,14 +31,15 @@ void ScatterNd<T>::setup_impl(const Variables &inputs,
   NBLA_CHECK(indices->ndim() >= 2, error_code::value,
              "scatter_nd requires indices to have at least 2 dimensions");
 
-  NBLA_CHECK(indices->shape().at(0) <= shape_.size(), error_code::value,
-             "Number of indices exceeds output dimension");
+  NBLA_CHECK(static_cast<Shape_t::size_type>(indices->shape().at(0)) <= shape_.size(),
+             error_code::value, "Number of indices exceeds output dimension");
 
   auto N = data->ndim();
   auto M = indices->shape().at(0);
   auto K = indices->ndim() - 1;
 
-  NBLA_CHECK(shape_.size() == N + M - K, error_code::value,
+  NBLA_CHECK(shape_.size() == static_cast<Shape_t::size_type>(N + M - K),
+             error_code::value,
              "Output shape size does not match input data and indices.");
 
   for (int i = 0; i < K; i++) {
@@ -48,7 +49,7 @@ void ScatterNd<T>::setup_impl(const Variables &inputs,
                data->shape()[i], i + 1, indices->shape()[i + 1]);
   }
 
-  for (int i = 0; i < shape_.size() - M; i++) {
+  for (int i = 0; static_cast<Shape_t::size_type>(i) < shape_.size() - M; i++) {
     NBLA_CHECK(data->shape().at(K + i) == shape_.at(M + i), error_code::value,
                "Shape error: data shape[%d] %d != output shape[%d] %d", K + i,
                data->shape()[K + i], M + i, indices->shape()[M + i]);

--- a/src/nbla/function/generic/shift.cpp
+++ b/src/nbla/function/generic/shift.cpp
@@ -55,7 +55,7 @@ void Shift<T>::shift_recursive(Variable *inp, const T *src, T *dst,
     }
 
     // Copy src values to dst with shifted index recursively.
-    if (dim == inp->shape().size() - 1) {
+    if (static_cast<Shape_t::size_type>(dim) == inp->shape().size() - 1) {
       if (is_backward) {
         // In backward, dy is accumulated to dx.
         dst[x_offset + j] += src[current_y_offset];

--- a/src/nbla/function/generic/slice.cpp
+++ b/src/nbla/function/generic/slice.cpp
@@ -30,7 +30,7 @@ NBLA_REGISTER_FUNCTION_SOURCE(Slice, const vector<int> &, // start
 template <typename T>
 void Slice<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   Shape_t shape_x = inputs[0]->shape();
-  const int size = shape_x.size();
+  const auto size = shape_x.size();
 
   // Size check for start, stop, and step
   NBLA_CHECK(stop_[0].size() == start_[0].size(), error_code::value,
@@ -64,7 +64,7 @@ void Slice<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 
   // Index range check, then convert negative start and stop
   Shape_t shape_y(size);
-  for (int i = 0; i < size; i++) {
+  for (auto i = decltype(size){0}; i < size; i++) {
     // Step 1: step 0 check
     NBLA_CHECK(step_[0][i] != 0, error_code::value,
                "slice step cannot be zero. "
@@ -131,7 +131,7 @@ void Slice<T>::slice_forward_recursive(const Variable *inp, Variable *outp,
   current_x_offset += inp->strides()[dim] * start_[slice_index][dim];
   const int size = outp->shape()[dim];
 
-  if (dim == inp->shape().size() - 1) {
+  if (static_cast<Shape_t::size_type>(dim) == inp->shape().size() - 1) {
     const T *current_x = x + current_x_offset;
     T *current_y = y + current_y_offset;
     if (x_stride == 1) {
@@ -168,7 +168,7 @@ void Slice<T>::slice_backward_recursive(Variable *outp, const Variable *inp,
   current_x_offset += outp->strides()[dim] * start_[slice_index][dim];
   const int size = inp->shape()[dim];
 
-  if (dim == outp->shape().size() - 1) {
+  if (static_cast<Shape_t::size_type>(dim) == outp->shape().size() - 1) {
     T *current_dx = dx + current_x_offset;
     const T *current_dy = dy + current_y_offset;
     T *end_dx = current_dx + size * x_stride;

--- a/src/nbla/function/generic/softmax.cpp
+++ b/src/nbla/function/generic/softmax.cpp
@@ -28,7 +28,7 @@ NBLA_REGISTER_FUNCTION_SOURCE(Softmax, int);
 template <typename T>
 void Softmax<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   Shape_t in_shape = inputs[0]->shape();
-  NBLA_CHECK(axis_ < in_shape.size(), error_code::value,
+  NBLA_CHECK(static_cast<unsigned>(axis_) < in_shape.size(), error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());

--- a/src/nbla/function/generic/softmax_cross_entropy.cpp
+++ b/src/nbla/function/generic/softmax_cross_entropy.cpp
@@ -35,7 +35,7 @@ void SoftmaxCrossEntropy<T, Tl>::setup_impl(const Variables &inputs,
 
   Shape_t in_shape = inputs[0]->shape();
   Shape_t label_shape = inputs[1]->shape();
-  NBLA_CHECK(axis_ < in_shape.size(), error_code::value,
+  NBLA_CHECK(static_cast<unsigned>(axis_) < in_shape.size(), error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());
@@ -43,7 +43,7 @@ void SoftmaxCrossEntropy<T, Tl>::setup_impl(const Variables &inputs,
              "The length of each input dimension must match. "
              "inputs[1] length: %d != inputs[0] length: %d.",
              label_shape.size(), in_shape.size());
-  for (int axis = 0; axis < label_shape.size(); ++axis) {
+  for (int axis = 0; static_cast<unsigned>(axis) < label_shape.size(); ++axis) {
     if (axis == axis_) {
       NBLA_CHECK(label_shape[axis] == 1, error_code::value,
                  "Dimensions of axis of inputs[1] must be 1. %d != 1.",

--- a/src/nbla/function/generic/sort.cpp
+++ b/src/nbla/function/generic/sort.cpp
@@ -27,7 +27,8 @@ NBLA_REGISTER_FUNCTION_SOURCE(Sort, int, bool, bool, bool);
 template <typename T>
 void Sort<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   if (this->axis > 0) {
-    NBLA_CHECK(this->axis < inputs[0]->shape().size(), error_code::value,
+    NBLA_CHECK(static_cast<unsigned>(this->axis) < inputs[0]->shape().size(),
+               error_code::value,
                "Sort axis must be less than the number of input dimensions "
                "but axis %d >= ndim of x %d.",
                this->axis, inputs[0]->shape().size());
@@ -92,7 +93,7 @@ void Sort<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
                   [&](size_t i1, size_t i2) { return x[i1 * s] < x[i2 * s]; });
       }
 
-      for (size_t i = 0; i < shape[this->axis]; i++) {
+      for (size_t i = 0; i < static_cast<size_t>(shape[this->axis]); i++) {
         inner_i_ptr[i * stride] = temp_index_ptr[i];
       }
       inner_x_ptr++;
@@ -115,7 +116,7 @@ void Sort<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
       auto inner_i_ptr = outer_i_ptr;
 
       while (inner_x_ptr < outer_x_ptr + this->inner_size) {
-        for (size_t i = 0; i < shape[this->axis]; i++) {
+        for (size_t i = 0; i < static_cast<size_t>(shape[this->axis]); i++) {
           const auto sort_index = inner_i_ptr[i * stride];
           inner_y_ptr[i * stride] = inner_x_ptr[sort_index * stride];
         }
@@ -162,12 +163,12 @@ void Sort<T>::backward_impl(const Variables &inputs, const Variables &outputs,
 
     while (inner_y_ptr < outer_y_ptr + this->inner_size) {
       if (accum[0]) {
-        for (size_t i = 0; i < shape[this->axis]; i++) {
+        for (size_t i = 0; i < static_cast<size_t>(shape[this->axis]); i++) {
           const auto sort_index = inner_i_ptr[i * stride];
           inner_x_ptr[i * stride] += inner_y_ptr[sort_index * stride];
         }
       } else {
-        for (size_t i = 0; i < shape[this->axis]; i++) {
+        for (size_t i = 0; i < static_cast<size_t>(shape[this->axis]); i++) {
           const auto sort_index = inner_i_ptr[i * stride];
           inner_x_ptr[i * stride] = inner_y_ptr[sort_index * stride];
         }

--- a/src/nbla/function/generic/split.cpp
+++ b/src/nbla/function/generic/split.cpp
@@ -28,9 +28,8 @@ void Split<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   NBLA_CHECK(axis_ >= 0, error_code::value,
              "axis must not be less than zero, got %d", axis_);
   NBLA_CHECK(static_cast<Shape_t::size_type>(axis_) < in_shape.size(),
-             error_code::value,
-             "axis must be less than ndim of inputs[0]. "
-             "axis: %d >= ndim of inputs[0]: %d.",
+             error_code::value, "axis must be less than ndim of inputs[0]. "
+                                "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());
   num_outputs_ = in_shape[axis_];
   NBLA_CHECK(static_cast<Shape_t::size_type>(num_outputs_) == outputs.size(),

--- a/src/nbla/function/generic/split.cpp
+++ b/src/nbla/function/generic/split.cpp
@@ -25,12 +25,16 @@ NBLA_REGISTER_FUNCTION_SOURCE(Split, int);
 template <typename T>
 void Split<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   const Shape_t in_shape = inputs[0]->shape();
-  NBLA_CHECK(axis_ < in_shape.size() && axis_ >= 0, error_code::value,
+  NBLA_CHECK(axis_ >= 0, error_code::value,
+             "axis must not be less than zero, got %d", axis_);
+  NBLA_CHECK(static_cast<Shape_t::size_type>(axis_) < in_shape.size(),
+             error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());
   num_outputs_ = in_shape[axis_];
-  NBLA_CHECK(num_outputs_ == outputs.size(), error_code::value,
+  NBLA_CHECK(static_cast<Shape_t::size_type>(num_outputs_) == outputs.size(),
+             error_code::value,
              "inputs[0].shape[axis] must be the same number as the outputs. "
              "inputs[0].shape[axis]: %d, outputs: %d.",
              num_outputs_, outputs.size());

--- a/src/nbla/function/generic/stack.cpp
+++ b/src/nbla/function/generic/stack.cpp
@@ -25,7 +25,10 @@ NBLA_REGISTER_FUNCTION_SOURCE(Stack, int);
 template <typename T>
 void Stack<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   const Shape_t in_shape = inputs[0]->shape();
-  NBLA_CHECK(axis_ <= in_shape.size() && axis_ >= 0, error_code::value,
+  NBLA_CHECK(axis_ >= 0, error_code::value,
+             "axis must not be less than zero, got %d", axis_);
+  NBLA_CHECK(static_cast<Shape_t::size_type>(axis_) <= in_shape.size(),
+             error_code::value,
              "axis must be less than or equal to ndim of input. "
              "axis: %d > ndim of inputs[0]: %d.",
              axis_, in_shape.size());

--- a/src/nbla/function/generic/top_k_data.cpp
+++ b/src/nbla/function/generic/top_k_data.cpp
@@ -31,7 +31,10 @@ void TopKData<T>::setup_impl(const Variables &inputs,
   const auto base_axis = base_axis_;
   Shape_t x_shape = x->shape();
 
-  NBLA_CHECK(base_axis < x_shape.size(), error_code::value,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis must not be less than zero, got %d", base_axis_);
+  NBLA_CHECK(static_cast<Shape_t::size_type>(base_axis_) < x_shape.size(),
+             error_code::value,
              "base_axis must be less than dimensions of x, but "
              "base_axis %d >= dimensions of x %d",
              base_axis, x_shape.size());
@@ -112,7 +115,7 @@ void TopKData<T>::backward_impl(const Variables &inputs,
   auto tk_idx = top_k_idx_.get_data_pointer<size_t>(ctx_);
 
   if (!reduce_) {
-    for (size_t i = 0; i < x->size(); i++) {
+    for (Size_t i = 0; i < x->size(); i++) {
       x_grad[i] += y_grad[i];
     }
   } else {

--- a/src/nbla/function/generic/top_k_grad.cpp
+++ b/src/nbla/function/generic/top_k_grad.cpp
@@ -31,7 +31,10 @@ void TopKGrad<T>::setup_impl(const Variables &inputs,
   const auto base_axis = base_axis_;
   Shape_t x_shape = x->shape();
 
-  NBLA_CHECK(base_axis < x_shape.size(), error_code::value,
+  NBLA_CHECK(base_axis_ >= 0, error_code::value,
+             "base_axis must not be less than zero, got %d", base_axis_);
+  NBLA_CHECK(static_cast<Shape_t::size_type>(base_axis_) < x_shape.size(),
+             error_code::value,
              "base_axis must be less than dimensions of x, but "
              "base_axis %d >= dimensions of x %d",
              base_axis, x_shape.size());

--- a/src/nbla/function/generic/top_n_error.cpp
+++ b/src/nbla/function/generic/top_n_error.cpp
@@ -27,7 +27,10 @@ void TopNError<T, T1>::setup_impl(const Variables &inputs,
                                   const Variables &outputs) {
   Shape_t in_shape = inputs[0]->shape();
   Shape_t label_shape = inputs[1]->shape();
-  NBLA_CHECK(axis_ < in_shape.size(), error_code::value,
+  NBLA_CHECK(axis_ >= 0, error_code::value,
+             "axis must not be less than zero, got %d", axis_);
+  NBLA_CHECK(static_cast<Shape_t::size_type>(axis_) < in_shape.size(),
+             error_code::value,
              "axis must be less than ndim of inputs[0]. "
              "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());
@@ -35,7 +38,7 @@ void TopNError<T, T1>::setup_impl(const Variables &inputs,
              "The length of each input dimension must match. "
              "inputs[1] length: %d != inputs[0] length: %d.",
              label_shape.size(), in_shape.size());
-  for (int axis = 0; axis < label_shape.size(); ++axis) {
+  for (int axis = 0; static_cast<size_t>(axis) < label_shape.size(); ++axis) {
     if (axis == axis_) {
       NBLA_CHECK(label_shape[axis] == 1, error_code::value,
                  "Dimensions of axis of inputs[1] must be 1. %d != 1.",

--- a/src/nbla/function/generic/top_n_error.cpp
+++ b/src/nbla/function/generic/top_n_error.cpp
@@ -30,9 +30,8 @@ void TopNError<T, T1>::setup_impl(const Variables &inputs,
   NBLA_CHECK(axis_ >= 0, error_code::value,
              "axis must not be less than zero, got %d", axis_);
   NBLA_CHECK(static_cast<Shape_t::size_type>(axis_) < in_shape.size(),
-             error_code::value,
-             "axis must be less than ndim of inputs[0]. "
-             "axis: %d >= ndim of inputs[0]: %d.",
+             error_code::value, "axis must be less than ndim of inputs[0]. "
+                                "axis: %d >= ndim of inputs[0]: %d.",
              axis_, in_shape.size());
   NBLA_CHECK(label_shape.size() == in_shape.size(), error_code::value,
              "The length of each input dimension must match. "

--- a/src/nbla/function/generic/transpose.cpp
+++ b/src/nbla/function/generic/transpose.cpp
@@ -27,7 +27,7 @@ void Transpose<T>::setup_impl(const Variables &inputs,
   vector<int> axes = this->axes_;
   const int ndim = inputs[0]->ndim();
 
-  NBLA_CHECK(ndim == axes.size(), error_code::value,
+  NBLA_CHECK(static_cast<size_t>(ndim) == axes.size(), error_code::value,
              "Length of axes must be same as ndim of input. Given %d != %d.",
              ndim, axes.size());
 
@@ -52,7 +52,7 @@ void Transpose<T>::setup_impl(const Variables &inputs,
   // transposing shape (16, 3, 100, 100) by axes (0, 2, 3, 1) will be reduced
   // to transposing (16, 3, 10000) by axes (0, 2, 1).
   volatile auto axes_size = axes.size();
-  for (int i = 1; i < axes_size;) {
+  for (size_t i = 1; i < axes_size;) {
     auto this_axis = axes[i];
     auto prev_axis = axes[i - 1];
     if (this_axis == prev_axis + 1) {
@@ -60,7 +60,7 @@ void Transpose<T>::setup_impl(const Variables &inputs,
       ishape.erase(ishape.begin() + this_axis);
       axes.erase(axes.begin() + i);
       axes_size = axes.size();
-      for (int j = 0; j < axes_size; j++) {
+      for (size_t j = 0; j < axes_size; j++) {
         if (axes[j] > this_axis)
           axes[j] -= 1;
       }
@@ -73,14 +73,14 @@ void Transpose<T>::setup_impl(const Variables &inputs,
 
   this->x_shape_ = ishape;
   this->y_shape_.resize(axes.size());
-  for (int i = 0; i < axes.size(); i++) {
+  for (size_t i = 0; i < axes.size(); i++) {
     this->y_shape_[i] = this->x_shape_[axes[i]];
   }
   this->x_strides_ = ndi::strides(this->x_shape_);
   this->y_strides_ = ndi::strides(this->y_shape_);
   this->x_strides_transposed_.resize(axes.size());
   this->y_strides_transposed_.resize(axes.size());
-  for (int i = 0; i < axes.size(); i++) {
+  for (size_t i = 0; i < axes.size(); i++) {
     this->x_strides_transposed_[i] = this->x_strides_[axes[i]];
     this->y_strides_transposed_[axes[i]] = this->y_strides_[i];
   }

--- a/src/nbla/function/generic/unpooling.cpp
+++ b/src/nbla/function/generic/unpooling.cpp
@@ -56,8 +56,9 @@ void Unpooling<T>::unpooling_forward_recursive(const Variable *inp,
   auto kdim = this->kernel_.size();
   const int x_stride = inp->strides()[dim];
   const int y_stride = outp->strides()[dim];
-  const int kernel =
-      (static_cast<unsigned>(dim) < (ndim - kdim)) ? 1 : this->kernel_[dim - (ndim - kdim)];
+  const int kernel = (static_cast<unsigned>(dim) < (ndim - kdim))
+                         ? 1
+                         : this->kernel_[dim - (ndim - kdim)];
   const int size = outp->shape()[dim];
 
   if (static_cast<unsigned>(dim) == inp->shape().size() - 1) {
@@ -114,8 +115,9 @@ void Unpooling<T>::unpooling_backward_recursive(Variable *outp,
   auto kdim = this->kernel_.size();
   const int x_stride = outp->strides()[dim];
   const int y_stride = inp->strides()[dim];
-  const int kernel =
-      (static_cast<unsigned>(dim) < (ndim - kdim)) ? 1 : this->kernel_[dim - (ndim - kdim)];
+  const int kernel = (static_cast<unsigned>(dim) < (ndim - kdim))
+                         ? 1
+                         : this->kernel_[dim - (ndim - kdim)];
   const int size = inp->shape()[dim];
 
   if (static_cast<unsigned>(dim) == inp->shape().size() - 1) {

--- a/src/nbla/function/generic/unpooling.cpp
+++ b/src/nbla/function/generic/unpooling.cpp
@@ -40,7 +40,7 @@ void Unpooling<T>::setup_impl(const Variables &inputs,
   auto ndim = inputs[0]->ndim();
   auto kdim = kernel_.size();
   auto offset = channel_last_ ? (ndim - kdim - 1) : (ndim - kdim);
-  for (int i = 0; i < kdim; i++) {
+  for (auto i = decltype(kdim){0}; i < kdim; i++) {
     outshape[offset + i] = inshape[offset + i] * kernel_[i];
   }
   outputs[0]->reshape(outshape, true);
@@ -57,10 +57,10 @@ void Unpooling<T>::unpooling_forward_recursive(const Variable *inp,
   const int x_stride = inp->strides()[dim];
   const int y_stride = outp->strides()[dim];
   const int kernel =
-      (dim < (ndim - kdim)) ? 1 : this->kernel_[dim - (ndim - kdim)];
+      (static_cast<unsigned>(dim) < (ndim - kdim)) ? 1 : this->kernel_[dim - (ndim - kdim)];
   const int size = outp->shape()[dim];
 
-  if (dim == inp->shape().size() - 1) {
+  if (static_cast<unsigned>(dim) == inp->shape().size() - 1) {
     const T *current_x = x + current_x_offset;
     T *current_y = y + current_y_offset;
     if (x_stride == 1 && kernel == 1) {
@@ -115,10 +115,10 @@ void Unpooling<T>::unpooling_backward_recursive(Variable *outp,
   const int x_stride = outp->strides()[dim];
   const int y_stride = inp->strides()[dim];
   const int kernel =
-      (dim < (ndim - kdim)) ? 1 : this->kernel_[dim - (ndim - kdim)];
+      (static_cast<unsigned>(dim) < (ndim - kdim)) ? 1 : this->kernel_[dim - (ndim - kdim)];
   const int size = inp->shape()[dim];
 
-  if (dim == inp->shape().size() - 1) {
+  if (static_cast<unsigned>(dim) == inp->shape().size() - 1) {
     T *current_dx = dx + current_x_offset;
     const T *current_dy = dy + current_y_offset;
     const T *end_dy = current_dy + size * y_stride;

--- a/src/nbla/function/generic/vat_noise.cpp
+++ b/src/nbla/function/generic/vat_noise.cpp
@@ -32,7 +32,8 @@ void VATNoise<T>::setup_impl(const Variables &inputs,
   NBLA_CHECK(0 < base_axis_, error_code::value,
              "base_axis_ must be grater than 0. base_axis: %d.", base_axis_);
 
-  NBLA_CHECK(base_axis_ < inputs[0]->shape().size(), error_code::value,
+  auto base_axis = static_cast<Shape_t::size_type>(base_axis_);
+  NBLA_CHECK(base_axis < inputs[0]->shape().size(), error_code::value,
              "base_axis must be less than ndim of inputs[0]. "
              "base_axis: %d >= ndim of inputs[0]: %d.",
              base_axis_, inputs[0]->shape().size());

--- a/src/nbla/function/generic/where.cpp
+++ b/src/nbla/function/generic/where.cpp
@@ -31,7 +31,7 @@ void Where<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   NBLA_CHECK(cshape.size() <= tshape.size(), error_code::value,
              "Rank of condition must be less than or equal to that of x_true "
              "or x_false.");
-  for (int d = 0; d < cshape.size(); d++) {
+  for (Shape_t::size_type d = 0; d < cshape.size(); d++) {
     NBLA_CHECK(cshape[d] == tshape[d], error_code::value,
                "The first dimensions of x_true and x_false must be the same as "
                "the shape of condition.");
@@ -49,8 +49,8 @@ void Where<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   size_t csize = inputs[0]->size();
   size_t xsize = inputs[1]->size();
   size_t inner_size = xsize / csize;
-  for (int s = 0; s < xsize; s++) {
-    const int c = s / inner_size;
+  for (auto s = decltype(xsize){0}; s < xsize; s++) {
+    auto c = s / inner_size;
     y[s] = condition[c] ? x_true[s] : x_false[s];
   }
 }
@@ -78,7 +78,7 @@ void Where<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   size_t xsize = inputs[1]->size();
   size_t inner_size = xsize / csize;
 
-  for (int s = 0; s < xsize; s++) {
+  for (auto s = decltype(xsize){0}; s < xsize; s++) {
     const bool cond = condition[s / inner_size];
     if (g_x_true) {
       g_x_true[s] = (accum[1] ? g_x_true[s] : (T)0) + (cond ? g_y[s] : (T)0);

--- a/src/nbla/function/utils/base_pooling.cpp
+++ b/src/nbla/function/utils/base_pooling.cpp
@@ -38,7 +38,7 @@ get_pooling_output_shape(const vector<int> &inshape, const vector<int> &kernel,
   size_t end_spatial_axis = first_spatial_axis + kernel.size();
 
   vector<int> shape(kernel.size());
-  for (int i = 0; i < kernel.size(); i++) {
+  for (unsigned int i = 0; i < kernel.size(); i++) {
     int w_i = static_cast<int>(inshape[i + first_spatial_axis]);
     int k_i = kernel[i];
     int s_i = stride[i];
@@ -47,7 +47,7 @@ get_pooling_output_shape(const vector<int> &inshape, const vector<int> &kernel,
   }
 
   vector<int> outshape(inshape.size());
-  for (int i = 0; i < inshape.size(); i++) {
+  for (unsigned int i = 0; i < inshape.size(); i++) {
     if ((i < first_spatial_axis) || (i >= end_spatial_axis)) {
       outshape[i] = static_cast<int>(inshape[i]);
     } else {

--- a/src/nbla/imperative.cpp
+++ b/src/nbla/imperative.cpp
@@ -24,11 +24,12 @@ using std::make_shared;
 vector<NdArrayPtr> execute(FunctionPtr func, const vector<NdArrayPtr> &inputs,
                            int n_outputs, vector<NdArrayPtr> outputs) {
   // Check inplace outputs size.
-  NBLA_CHECK(outputs.size() <= n_outputs, error_code::value,
+  NBLA_CHECK(outputs.size() <= static_cast<unsigned>(n_outputs),
+             error_code::value,
              "Num of in-place arrays must not be greater than n_outputs. "
              "In-place arrays: %d <= n_outputs: %d",
              outputs.size(), n_outputs);
-  if (outputs.size() != n_outputs) {
+  if (outputs.size() != static_cast<unsigned>(n_outputs)) {
     outputs.resize(n_outputs, nullptr);
   }
 
@@ -40,7 +41,7 @@ vector<NdArrayPtr> execute(FunctionPtr func, const vector<NdArrayPtr> &inputs,
   // Function inputs and outputs must be Variables.
   vector<VariablePtr> vinputs(inputs.size());
   vector<VariablePtr> voutputs(outputs.size());
-  for (int i = 0; i < inputs.size(); ++i) {
+  for (unsigned int i = 0; i < inputs.size(); ++i) {
     vinputs[i] = make_shared<Variable>(inputs[i]);
   }
   for (int i = 0; i < n_outputs; ++i) {
@@ -53,7 +54,7 @@ vector<NdArrayPtr> execute(FunctionPtr func, const vector<NdArrayPtr> &inputs,
   func->setup(finputs, foutputs);
 
   // Set inplace buffer to function output buffer if size matches.
-  for (int i = 0; i < outputs.size(); ++i) {
+  for (unsigned int i = 0; i < outputs.size(); ++i) {
     if (!outputs[i]) {
       outputs[i] = foutputs[i]->data();
     }

--- a/src/nbla/parametric_functions.cpp
+++ b/src/nbla/parametric_functions.cpp
@@ -355,7 +355,7 @@ vector<CgVariablePtr> affine(Context &ctx, CgVariablePtr x, int base_axis,
 
   Shape_t shape_x = x->variable()->shape();
   long int n_in = 1;
-  for (int i = base_axis; i < shape_x.size(); i++)
+  for (unsigned int i = base_axis; i < shape_x.size(); i++)
     n_in *= shape_x[i];
 
   if (w_init == nullptr) {
@@ -551,7 +551,7 @@ batch_normalization(Context &ctx, CgVariablePtr x, const vector<int> &axes,
 
   NBLA_CHECK(axes.size() == 1, error_code::value, "Size of axes should be 1");
   Shape_t shape_stat = x->variable()->shape();
-  for (int i = 0; i < shape_stat.size(); i++)
+  for (int i = 0; static_cast<unsigned>(i) < shape_stat.size(); i++)
     if (i != axes[0])
       shape_stat[i] = 1;
 

--- a/src/nbla/solver.cpp
+++ b/src/nbla/solver.cpp
@@ -89,7 +89,7 @@ void Solver::setup() {
   // classes.
   int array_class_index =
       0; // Default array is 0-th array_class in allowed_array_classes().
-  for (int i = 0; i < this->allowed_array_classes().size(); ++i) {
+  for (unsigned int i = 0; i < this->allowed_array_classes().size(); ++i) {
     if (ctx_.array_class == this->allowed_array_classes()[i]) {
       array_class_index = i;
     }

--- a/src/nbla/utils/dlpack_utils.cpp
+++ b/src/nbla/utils/dlpack_utils.cpp
@@ -59,11 +59,11 @@ Shape_t get_shape_with_contiguous_memory(DLManagedTensor *dlp) {
   const auto shape = dlp->dl_tensor.shape;
   const auto strides = dlp->dl_tensor.strides;
   Shape_t ret_shape(ndim);
-  size_t contig_stride = 1;
+  Size_t contig_stride = 1;
 
   for (int i = ndim - 1; i >= 0; i--) {
     NBLA_CHECK(strides[i] == contig_stride, error_code::value,
-               "The array elements must be contiguous in memery for NNabla. "
+               "The array elements must be contiguous in memory for NNabla. "
                "Check strides in DLPack DLTensor.");
     contig_stride *= shape[i];
     ret_shape[i] = shape[i];


### PR DESCRIPTION
This PR fixes a segmentation fault caused by evaluating an uninitialized variable and re-enables the compiler warning on use of uninitialized variables. Additionally the PR enables the compiler warning for signed-unsigned comparison and corrects the implementation for a number of such comparisons.