### PR TITLE
add error message when parameter is illegal

### DIFF
--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -155,7 +155,23 @@ cdef class NdArray:
         a.data = nparr
         return a
 
-    def __init__(self, shape=tuple()):
+    def __init__(self, *args, **kwargs):
+        arg_n = len(args)
+        err_msg = "Input argument should be a tuple or a tuple-like dimension define."
+        if arg_n == 0:
+            shape=tuple()
+        elif arg_n == 1:
+            if type(args[0]) == int:
+                shape = (args[0], )
+            elif type(args[0]) in [tuple, list]:
+                shape = tuple(args[0])
+            else:
+                raise ValueError(err_msg)
+        elif arg_n > 1:
+            if all([type(x) == int for x in args]):
+                shape = tuple(args)
+            else:
+                raise ValueError(err_msg)
         cdef int i
         cdef Shape_t cshape
         cdef int size = len(shape)


### PR DESCRIPTION
This PR gave user more friendly information and interface for creating NdArray, the following will be supported:
`a=nn.NdArray(3)
a=nn.NdArray(4,5,6)
a=nn.NdArray([3,4,5])
a=nn.NdArray()`
But it reported an error message for illegal cases, for example:
`a=nn.NdArray(3,2.2)`
