### PR TITLE
fix link error for extra NBLA_API

### DIFF
--- a/include/nbla/memory/virtual_caching_allocator.hpp
+++ b/include/nbla/memory/virtual_caching_allocator.hpp
@@ -166,7 +166,7 @@ public:
 };
 
 template <class PhysicalMemoryType, class VirtualMemoryType>
-class NBLA_API VirtualCachingAllocator : public VirtualCachingAllocatorBase {
+class VirtualCachingAllocator : public VirtualCachingAllocatorBase {
   typedef PhysicalMemoryType p_memory_type;
   typedef VirtualMemoryType v_memory_type;
 


### PR DESCRIPTION
Fix link error for VirutalCacheAllocator(). Template should not be prefix-ed with NBLA_API.