### PR TITLE
Optimize normalization functions implementation

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -251,3 +251,9 @@
   BatchLogdet_Empty: 319
 26:
   RandomShift_iIifii: 320
+27:
+  GroupNormalization_iiiIfBB: 321
+  InstanceNormalization_iiIfBB: 322
+  LayerNormalization_iIfBB: 323
+  TensorNormalization_iIfBB: 324
+  WeightStandardization_if: 325

--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -257,3 +257,5 @@
   LayerNormalization_iIfBB: 323
   TensorNormalization_iIfBB: 324
   WeightStandardization_if: 325
+28:
+  BatchNormalization_iIffBBB: 326

--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -115,13 +115,28 @@ FusedBatchNormalization:
 BatchNormalization:
   float: [float]
   half: [Half]      
+GroupNormalization:
+  float: [float]
+  half: [Half]      
+InstanceNormalization:
+  float: [float]
+  half: [Half]      
+LayerNormalization:
+  float: [float]
+  half: [Half]      
 NormNormalization:
   float: [float]
   half: [Half]
 SyncBatchNormalization:
   float: [float]
   half: [Half]
+TensorNormalization:
+  float: [float]
+  half: [Half]
 WeightNormalization:
+  float: [float]
+  half: [Half]
+WeightStandardization:
   float: [float]
   half: [Half]
 MeanSubtraction:

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -1550,6 +1550,189 @@ Normalization:
     function_ids:
       iIffB: 22
     c_runtime: support
+  GroupNormalization:
+    snake_name: group_normalization
+    doc: |2
+
+      Applies Group Normalization over an input tensor, which is defined as:
+
+      .. math::
+        \begin{eqnarray}
+          \mu^g &=& \frac{1}{H} \sum_{i=1}^{H} x_i^g \\
+          \sigma^g &=& \sqrt{\frac{1}{H} \sum_{i=1}^{H} \left(x_i^g - \mu^g\right)^2 + \epsilon} \\
+          y &=& \frac{x - \mu^g}{\sigma^g} \gamma + \beta
+        \end{eqnarray}
+
+      where :math:`x` and :math:`y` are input and output variable,
+      :math:`\mu^g` and :math:`\sigma^g` are the mean and std of each group which contains `num_channels / num_groups` channels,
+      and :math:`\gamma` and :math:`\beta` are adaptive gains and biases.
+
+      The input channels, specified by :attr:`channel_axis`, are separated into :attr:`num_groups` groups,
+      and the mean and std are calculated over the each group.
+      For example, if the input shape is [B, C, H, W] (= channel_axis=1, batch_axis=0),
+      an input variable is once reshaped to [B, num_groups, C / num_groups, H, W]
+      and standardize by its mean and std whose shapes are [B, num_groups, 1, 1, 1].
+      Finally, an output variable is reshaped again to the original input shape (= [B, C, H, W] in the case above).
+
+      References:
+
+          * `Yuxin Wu, Kaiming He, Group Normalization.
+            <https://arxiv.org/abs/1803.08494>`_
+    inputs:
+      x:
+        doc: N-D array of input.
+      beta:
+        doc: N-D array of beta which is learned.
+        optional: true
+      gamma:
+        doc: N-D array of gamma which is learned.
+        optional: true
+    arguments:
+      num_groups:
+        doc: A number of groups. The channel dim of 'x' must be integer multiple of
+          `num_groups`.
+        type: int64
+        default: 1
+      channel_axis:
+        doc: Channel axis.
+        type: int64
+        default: 1
+      batch_axis:
+        doc: Axes mean and variance are taken.
+        type: repeated int64
+        default: (0,)
+      eps:
+        doc: Tiny value to avoid zero division by std.
+        type: float
+        default: 1e-05
+      no_scale:
+        doc: If `True`, the scale term is omitted.
+        type: bool
+        default: 'False'
+      no_bias:
+        doc: If `True`, the bias term is omitted.
+        type: bool
+        default: 'False'
+    outputs:
+      y:
+        doc: N-D array
+    c_runtime: not support
+    function_ids:
+      iiiIfBB: 321
+  InstanceNormalization:
+    snake_name: instance_normalization
+    doc: |2
+
+      Applies Instance Normalization over an input tensor, which is defined as
+
+      .. math::
+        \begin{eqnarray}
+          \mu^i &=& \frac{1}{H} \sum_{i=1}^{H} x_i^i \\
+          \sigma^i &=& \sqrt{\frac{1}{H} \sum_{i=1}^{H} \left(x_i^i - \mu^i\right)^2 + \epsilon} \\
+          y &=& \frac{x - \mu^i}{\sigma^i} \gamma + \beta
+        \end{eqnarray}
+
+      where :math:`x` and :math:`y` are input and output variable,
+      :math:`\mu^i` and :math:`\sigma^i` are the mean and std of each instance which is separately calculated for each batch and channel,
+      and :math:`\gamma` and :math:`\beta` are adaptive gains and biases.
+
+      If the input shape is [B, C, H, W] (= channel_axis=1, batch_axis=0), the shape of calculated mean and std are [B, C, 1, 1]
+
+      References:
+
+          * `Dmitry Ulyanov, Andrea Vedaldi, Victor Lempitsky, Instance Normalization: The Missing Ingredient for Fast Stylization.
+            <https://arxiv.org/abs/1607.08022>`_
+    inputs:
+      x:
+        doc: N-D array of input.
+      beta:
+        doc: N-D array of beta which is learned.
+        optional: true
+      gamma:
+        doc: N-D array of gamma which is learned.
+        optional: true
+    arguments:
+      channel_axis:
+        doc: Channel axis.
+        type: int64
+        default: 1
+      batch_axis:
+        doc: Axes mean and variance are taken.
+        type: repeated int64
+        default: (0,)
+      eps:
+        doc: Tiny value to avoid zero division by std.
+        type: float
+        default: 1e-05
+      no_scale:
+        doc: If `True`, the scale term is omitted.
+        type: bool
+        default: 'False'
+      no_bias:
+        doc: If `True`, the bias term is omitted.
+        type: bool
+        default: 'False'
+    outputs:
+      y:
+        doc: N-D array
+    c_runtime: not support
+    function_ids:
+      iiIfBB: 322
+  LayerNormalization:
+    snake_name: layer_normalization
+    doc: |2
+
+      Applies Layer Normalization over an input tensor, which is defined as
+
+      .. math::
+        \begin{eqnarray}
+          \mu^l &=& \frac{1}{H} \sum_{i=1}^{H} x_i^l \\
+          \sigma^l &=& \sqrt{\frac{1}{H} \sum_{i=1}^{H} \left(x_i^l - \mu^l\right)^2 + \epsilon} \\
+          y &=& \frac{x - \mu^l}{\sigma^l} \gamma + \beta
+        \end{eqnarray}
+
+      where :math:`x` and :math:`y` are input and output variable,
+      :math:`\mu^l` and :math:`\sigma^l` are the mean and std of each layer which is separately calculated for each batch,
+      and :math:`\beta` and :math:`\gamma` are adaptive biases and gains.
+
+      If the input shape is [B, C, H, W] (= batch_axis=0), the shape of calculated mean and std are [B, 1, 1, 1]
+
+      References:
+
+          * `Jimmy Lei Ba, Jamie Ryan Kiros, Geoffrey E. Hinton, Layer Normalization.
+            <https://arxiv.org/abs/1607.06450>`_
+    inputs:
+      x:
+        doc: N-D array of input.
+      beta:
+        doc: N-D array of beta which is learned.
+        optional: true
+      gamma:
+        doc: N-D array of gamma which is learned.
+        optional: true
+    arguments:
+      batch_axis:
+        doc: Axes mean and variance are taken.
+        type: repeated int64
+        default: (0,)
+      eps:
+        doc: Tiny value to avoid zero division by std.
+        type: float
+        default: 1e-05
+      no_scale:
+        doc: If `True`, the scale term is omitted.
+        type: bool
+        default: 'False'
+      no_bias:
+        doc: If `True`, the bias term is omitted.
+        type: bool
+        default: 'False'
+    outputs:
+      y:
+        doc: N-D array
+    c_runtime: not support
+    function_ids:
+      iIfBB: 323
   NormNormalization:
     snake_name: norm_normalization
     doc: |2
@@ -1644,6 +1827,47 @@ Normalization:
     c_runtime: not support
     function_ids:
       CiiIffB: 263
+  TensorNormalization:
+    snake_name: tensor_normalization
+    doc: |2
+
+      General tensor normalization.
+      Input variable `x` is normalized by mean and std calculated by `x` itself.
+      Mean and variance are calculated along `axes`.
+      For example, if the input shape is (B, C, H, W) and axes is [0, 1],
+      the shape of calculated mean and std are (B, C, 1 ,1).
+    inputs:
+      x:
+        doc: N-D array of input.
+      beta:
+        doc: N-D array of beta which is learned.
+        optional: true
+      gamma:
+        doc: N-D array of gamma which is learned.
+        optional: true
+    arguments:
+      axes:
+        doc: Axes mean and variance are taken.
+        type: repeated int64
+        default: (1,)
+      eps:
+        doc: Tiny value to avoid zero division by std.
+        type: float
+        default: 1e-05
+      no_scale:
+        doc: If `True`, the scale term is omitted.
+        type: bool
+        default: 'False'
+      no_bias:
+        doc: If `True`, the bias term is omitted.
+        type: bool
+        default: 'False'
+    outputs:
+      y:
+        doc: N-D array
+    c_runtime: support
+    function_ids:
+      iIfBB: 324
   WeightNormalization:
     snake_name: weight_normalization
     doc: |2
@@ -1679,6 +1903,44 @@ Normalization:
     c_runtime: not support
     function_ids:
       if: 304
+  WeightStandardization:
+    snake_name: weight_standardization
+    doc: |2
+
+      Applies Weight Standardization over an input weight, which is defined as
+
+      .. math::
+        \begin{eqnarray}
+          \mu_{W_i} &=& \frac{1}{I} \sum_{j=1}^{I} W_{ij} \\
+          \sigma_{W_i} &=& \sqrt{\frac{1}{I} \sum_{i=1}^{I} \left(W_{ij} - \mu_{W_{i}}\right)^2 + \epsilon} \\
+          \hat{W_{ij}} &=& \frac{W_{ij} - \mu_{W_i}}{\sigma_{W_i}} \\
+          y &=& \hat{W} \ast x
+        \end{eqnarray}
+
+      References:
+
+        * `Siyuan Qiao, Huiyu Wang, Chenxi Liu, Wei Shen, Alan Yuille, Weight Standardization
+          <https://arxiv.org/pdf/1903.10520v1.pdf>`_
+          
+    inputs:
+      w:
+        doc: N-D array of learnable weights.
+    arguments:
+      channel_axis:
+        doc: An axis for output channel. Default value is 0 which assumes the weights
+          of convolution.
+        type: int64
+        default: 0
+      eps:
+        doc: Tiny value to avoid zero division by std.
+        type: float
+        default: 1e-05
+    outputs:
+      y:
+        doc: N-D array
+    c_runtime: not support
+    function_ids:
+      if: 325
   MeanSubtraction:
     snake_name: mean_subtraction
     doc: |2

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -1521,12 +1521,16 @@ Normalization:
         doc: N-D array of input.
       beta:
         doc: N-D array of beta which is learned.
+        optional: true
       gamma:
         doc: N-D array of gamma which is learned.
+        optional: true
       mean:
         doc: N-D array of running mean (modified during forward execution).
+        optional: true
       variance:
         doc: N-D array of running variance (modified during forward execution).
+        optional: true
     arguments:
       axes:
         doc: Axes mean and variance are taken.
@@ -1544,11 +1548,20 @@ Normalization:
         doc: Use mini-batch statistics rather than running ones.
         type: bool
         default: 'True'
+      no_scale:
+        doc: If `True`, the scale term is omitted.
+        type: bool
+        default: 'False'
+      no_bias:
+        doc: If `True`, the bias term is omitted.
+        type: bool
+        default: 'False'
     outputs:
       y:
         doc: N-D array
     function_ids:
       iIffB: 22
+      iIffBBB: 326
     c_runtime: support
   GroupNormalization:
     snake_name: group_normalization

--- a/examples/cpp/cpp_graph/main.cpp
+++ b/examples/cpp/cpp_graph/main.cpp
@@ -29,11 +29,11 @@ int main() {
   Context ctx; // ("cpu", "CpuArray", "0", "default");
   auto affine1 = make_shared<CgFunction>(create_Affine(ctx, 1));
   auto bn1 = make_shared<CgFunction>(
-      create_BatchNormalization(ctx, {1}, 0, 0.0, false));
+      create_BatchNormalization(ctx, {1}, 0, 0.0, false, false, false));
   auto relu1 = make_shared<CgFunction>(create_ReLU(ctx, true));
   auto affine2 = make_shared<CgFunction>(create_Affine(ctx, 1));
   auto bn2 = make_shared<CgFunction>(
-      create_BatchNormalization(ctx, {1}, 0, 0.0, false));
+      create_BatchNormalization(ctx, {1}, 0, 0.0, false, false, false));
   auto relu2 = make_shared<CgFunction>(create_ReLU(ctx, true));
   auto affine3 = make_shared<CgFunction>(create_Affine(ctx, 1));
 

--- a/include/nbla/function/group_normalization.hpp
+++ b/include/nbla/function/group_normalization.hpp
@@ -47,7 +47,7 @@ protected:
   bool output_stat_;
   Shape_t instn_x_shape_, gn_x_shape_;
   shared_ptr<Function> f_instance_norm_;
-  shared_ptr<Function> f_mul2_, f_add2_;
+  shared_ptr<Function> f_mul2_, f_add2_, f_sub2_;
 
 public:
   GroupNormalization(const Context &ctx, int num_groups, int channel_axis,

--- a/include/nbla/function/group_normalization.hpp
+++ b/include/nbla/function/group_normalization.hpp
@@ -1,0 +1,92 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_GROUP_NORMALIZATION_HPP
+#define NBLA_FUNCTION_GROUP_NORMALIZATION_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(GroupNormalization, int, int, const vector<int> &,
+                              float, bool, bool);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class GroupNormalization
+    : public BaseFunction<int, int, const vector<int> &, float, bool, bool> {
+protected:
+  int num_groups_;
+  int channel_axis_;
+  const vector<int> batch_axis_;
+  float eps_;
+  bool no_scale_, no_bias_;
+
+  int beta_idx_, gamma_idx_;
+  bool output_stat_;
+  Shape_t instn_x_shape_, gn_x_shape_;
+  shared_ptr<Function> f_instance_norm_;
+  shared_ptr<Function> f_mul2_, f_add2_;
+
+public:
+  GroupNormalization(const Context &ctx, int num_groups, int channel_axis,
+                     const vector<int> &batch_axis, float eps, bool no_scale,
+                     bool no_bias)
+      : BaseFunction(ctx, num_groups, channel_axis, batch_axis, eps, no_scale,
+                     no_bias),
+        num_groups_(num_groups), channel_axis_(channel_axis),
+        batch_axis_(batch_axis), eps_(eps), no_scale_(no_scale),
+        no_bias_(no_bias) {}
+  virtual ~GroupNormalization() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_GroupNormalization(ctx_, num_groups_, channel_axis_,
+                                     batch_axis_, eps_, no_scale_, no_bias_);
+  }
+  virtual int min_inputs() { return 1; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "GroupNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const {
+    // Gradient computation always requires output mean and var.
+    return o > 0;
+  }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/function/instance_normalization.hpp
+++ b/include/nbla/function/instance_normalization.hpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_INSTANCE_NORMALIZATION_HPP
+#define NBLA_FUNCTION_INSTANCE_NORMALIZATION_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(InstanceNormalization, int, const vector<int> &,
+                              float, bool, bool);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class InstanceNormalization
+    : public BaseFunction<int, const vector<int> &, float, bool, bool> {
+protected:
+  int channel_axis_;
+  const vector<int> batch_axis_;
+  float eps_;
+  bool no_scale_, no_bias_;
+
+  int beta_idx_, gamma_idx_;
+  bool need_beta_broadcast_, need_gamma_broadcast_;
+  shared_ptr<Function> f_broadcast_beta_, f_broadcast_gamma_;
+  shared_ptr<Function> f_tensor_norm_;
+
+public:
+  InstanceNormalization(const Context &ctx, int channel_axis,
+                        const vector<int> &batch_axis, float eps, bool no_scale,
+                        bool no_bias)
+      : BaseFunction(ctx, channel_axis, batch_axis, eps, no_scale, no_bias),
+        channel_axis_(channel_axis), batch_axis_(batch_axis), eps_(eps),
+        no_scale_(no_scale), no_bias_(no_bias) {}
+  virtual ~InstanceNormalization() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_InstanceNormalization(ctx_, channel_axis_, batch_axis_, eps_,
+                                        no_scale_, no_bias_);
+  }
+  virtual int min_inputs() { return 1; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "InstanceNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const {
+    // Gradient computation always requires output mean and var.
+    return o > 0;
+  }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/function/layer_normalization.hpp
+++ b/include/nbla/function/layer_normalization.hpp
@@ -47,6 +47,7 @@ protected:
   shared_ptr<Function> f_tensor_norm_;
   shared_ptr<Function> f_mul2_;
   shared_ptr<Function> f_add2_;
+  shared_ptr<Function> f_sub2_;
 
 public:
   LayerNormalization(const Context &ctx, const vector<int> &batch_axis,

--- a/include/nbla/function/layer_normalization.hpp
+++ b/include/nbla/function/layer_normalization.hpp
@@ -1,0 +1,88 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_LAYER_NORMALIZATION_HPP
+#define NBLA_FUNCTION_LAYER_NORMALIZATION_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(LayerNormalization, const vector<int> &, float,
+                              bool, bool);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class LayerNormalization
+    : public BaseFunction<const vector<int> &, float, bool, bool> {
+protected:
+  const vector<int> batch_axis_;
+  float eps_;
+  bool no_scale_, no_bias_;
+
+  int beta_idx_, gamma_idx_;
+  bool output_stat_;
+  Shape_t tn_shape_;
+  shared_ptr<Function> f_tensor_norm_;
+  shared_ptr<Function> f_mul2_;
+  shared_ptr<Function> f_add2_;
+
+public:
+  LayerNormalization(const Context &ctx, const vector<int> &batch_axis,
+                     float eps, bool no_scale, bool no_bias)
+      : BaseFunction(ctx, batch_axis, eps, no_scale, no_bias),
+        batch_axis_(batch_axis), eps_(eps), no_scale_(no_scale),
+        no_bias_(no_bias) {}
+  virtual ~LayerNormalization() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_LayerNormalization(ctx_, batch_axis_, eps_, no_scale_,
+                                     no_bias_);
+  }
+  virtual int min_inputs() { return 1; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "LayerNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const {
+    // Gradient computation always requires output mean and var.
+    return o > 0;
+  }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/function/sync_batch_normalization.hpp
+++ b/include/nbla/function/sync_batch_normalization.hpp
@@ -82,7 +82,8 @@ public:
                          const std::shared_ptr<Communicator> &comm,
                          const std::string &group, const vector<int> axes,
                          float decay_rate, float eps, bool batch_stat)
-      : BatchNormalization<T>(ctx, axes, decay_rate, eps, batch_stat),
+      : BatchNormalization<T>(ctx, axes, decay_rate, eps, batch_stat,
+                              false /* no_scale */, false /* no_bias */),
         comm_(comm), group_(group) {}
   virtual ~SyncBatchNormalization() {}
   virtual shared_ptr<Function> copy() const override {

--- a/include/nbla/function/tensor_normalization.hpp
+++ b/include/nbla/function/tensor_normalization.hpp
@@ -1,0 +1,177 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_TENSOR_NORMALIZATION_HPP
+#define NBLA_FUNCTION_TENSOR_NORMALIZATION_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+#include <nbla/function/batch_normalization.hpp>
+#include <nbla/function/reshape.hpp>
+#include <nbla/function/transpose.hpp>
+#include <nbla/imperative.hpp>
+
+#include <numeric>
+
+namespace nbla {
+
+class BatchNormalizationInOutAdapter {
+  vector<int> transpose_axes_, inv_transpose_axes_;
+  Shape_t transposed_shape_, bn_input_shape_;
+  shared_ptr<Function> pre_op_transpose_, post_op_transpose_;
+
+public:
+  BatchNormalizationInOutAdapter(const Context &ctx, int ndim,
+                                 const Shape_t &in_shape,
+                                 const vector<int> &axes) {
+    // inner_axes = sort(axes)
+    auto inner_axes = axes;
+    std::sort(inner_axes.begin(), inner_axes.end());
+
+    // outer_axes = sort(range(ndim) / inner_axes)
+    vector<int> outer_axes, range_ndim(ndim);
+    std::iota(range_ndim.begin(), range_ndim.end(), 0);
+    std::set_difference(range_ndim.begin(), range_ndim.end(),
+                        inner_axes.begin(), inner_axes.end(),
+                        std::inserter(outer_axes, outer_axes.begin()));
+    std::sort(outer_axes.begin(), outer_axes.end());
+
+    // transpose_axes = outer_axes + inner_axes
+    transpose_axes_.reserve(outer_axes.size() + inner_axes.size());
+    transpose_axes_.insert(transpose_axes_.end(), outer_axes.begin(),
+                           outer_axes.end());
+    transpose_axes_.insert(transpose_axes_.end(), inner_axes.begin(),
+                           inner_axes.end());
+
+    // tranposed_shape
+    for (int i = 0; i < ndim; i++) {
+      transposed_shape_.push_back(in_shape[transpose_axes_[i]]);
+    }
+
+    // bn_input_shape
+    int64_t reduced_inner_size = 1;
+    for (int i = outer_axes.size(); i < transposed_shape_.size(); i++) {
+      reduced_inner_size *= transposed_shape_[i];
+    }
+    for (int i = 0; i < outer_axes.size(); i++) {
+      bn_input_shape_.push_back(transposed_shape_[i]);
+    }
+    bn_input_shape_.push_back(reduced_inner_size);
+
+    // inv_transpose_axes = argsort(transpose_axes)
+    vector<pair<int, int>> transpose_axes_with_index;
+    for (int i = 0; i < ndim; i++) {
+      transpose_axes_with_index.push_back({transpose_axes_[i], i});
+    }
+    std::sort(transpose_axes_with_index.begin(),
+              transpose_axes_with_index.end());
+    for (int i = 0; i < ndim; i++) {
+      inv_transpose_axes_.push_back(transpose_axes_with_index[i].second);
+    }
+
+    // functions
+    pre_op_transpose_ = create_Transpose(ctx, transpose_axes_);
+    post_op_transpose_ = create_Transpose(ctx, inv_transpose_axes_);
+  }
+
+  // batch_norm inputs adapter
+  void pre_op(Variable *x, Variable *y) {
+    nbla::execute(pre_op_transpose_, {x}, {y});
+    y->reshape(bn_input_shape_, false);
+  }
+
+  void pre_op_backward(Variable *x, Variable *y, bool propagate_down,
+                       bool accum) {
+    y->reshape(transposed_shape_, false);
+    nbla::backward(pre_op_transpose_, {x}, {y}, {propagate_down}, {accum});
+  }
+
+  // batch_norm outputs adapter
+  void post_op(Variable *x, Variable *y) {
+    x->reshape(transposed_shape_, false);
+    nbla::execute(post_op_transpose_, {x}, {y});
+  }
+
+  void post_op_backward(Variable *x, Variable *y, bool propagate_down,
+                        bool accum) {
+    nbla::backward(post_op_transpose_, {x}, {y}, {propagate_down}, {accum});
+    x->reshape(bn_input_shape_, false);
+  }
+};
+
+NBLA_REGISTER_FUNCTION_HEADER(TensorNormalization, const vector<int> &, float,
+                              bool, bool);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class TensorNormalization
+    : public BaseFunction<const vector<int> &, float, bool, bool> {
+protected:
+  const vector<int> axes_;
+  float eps_;
+  bool no_scale_, no_bias_;
+
+  int beta_idx_, gamma_idx_;
+  bool output_stat_;
+  Shape_t bn_param_shape_;
+  std::unique_ptr<BatchNormalizationInOutAdapter> bn_in_adapter_,
+      bn_param_adapter_;
+  shared_ptr<Function> f_batch_norm_;
+
+public:
+  TensorNormalization(const Context &ctx, const vector<int> &axes, float eps,
+                      bool no_scale, bool no_bias)
+      : BaseFunction(ctx, axes, eps, no_scale, no_bias), axes_(axes), eps_(eps),
+        no_scale_(no_scale), no_bias_(no_bias) {}
+  virtual ~TensorNormalization() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_TensorNormalization(ctx_, axes_, eps_, no_scale_, no_bias_);
+  }
+  virtual int min_inputs() { return 1; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "TensorNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const {
+    // Gradient computation always requires output mean and var.
+    return o > 0;
+  }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/include/nbla/function/tensor_normalization.hpp
+++ b/include/nbla/function/tensor_normalization.hpp
@@ -63,10 +63,10 @@ public:
 
     // bn_shape
     int64_t reduced_inner_size = 1;
-    for (int i = outer_axes.size(); i < transposed_shape_.size(); i++) {
+    for (size_t i = outer_axes.size(); i < transposed_shape_.size(); i++) {
       reduced_inner_size *= transposed_shape_[i];
     }
-    for (int i = 0; i < outer_axes.size(); i++) {
+    for (size_t i = 0; i < outer_axes.size(); i++) {
       bn_shape.push_back(transposed_shape_[i]);
     }
     bn_shape.push_back(reduced_inner_size);

--- a/include/nbla/function/tensor_normalization.hpp
+++ b/include/nbla/function/tensor_normalization.hpp
@@ -70,6 +70,10 @@ public:
       bn_input_shape_.push_back(transposed_shape_[i]);
     }
     bn_input_shape_.push_back(reduced_inner_size);
+    // ndim of batch_norm input x muse be greater than or equal to 2.
+    if (bn_input_shape_.size() == 1) {
+      bn_input_shape_ = {1, bn_input_shape_[0]};
+    }
 
     // inv_transpose_axes = argsort(transpose_axes)
     vector<pair<int, int>> transpose_axes_with_index;

--- a/include/nbla/function/weight_standardization.hpp
+++ b/include/nbla/function/weight_standardization.hpp
@@ -1,0 +1,76 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_WEIGHT_STANDARDIZATION_HPP
+#define NBLA_FUNCTION_WEIGHT_STANDARDIZATION_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(WeightStandardization, int, float);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T>
+class WeightStandardization : public BaseFunction<int, float> {
+protected:
+  int channel_axis_;
+  float eps_;
+
+  Shape_t tn_shape_;
+  shared_ptr<Function> f_tensor_norm_;
+
+public:
+  WeightStandardization(const Context &ctx, int channel_axis, float eps)
+      : BaseFunction(ctx, channel_axis, eps), channel_axis_(channel_axis),
+        eps_(eps) {}
+  virtual ~WeightStandardization() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_WeightStandardization(ctx_, channel_axis_, eps_);
+  }
+  virtual int min_inputs() { return 1; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "WeightStandardization"; }
+  virtual bool grad_depends_output_data(int i, int o) const {
+    // Gradient computation always requires output mean and var.
+    return o > 0;
+  }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+};
+}
+#endif

--- a/python/src/nnabla/backward_function/group_normalization.py
+++ b/python/src/nnabla/backward_function/group_normalization.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class GroupNormalizationBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'GroupNormalizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of GroupNormalizationBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/instance_normalization.py
+++ b/python/src/nnabla/backward_function/instance_normalization.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class InstanceNormalizationBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'InstanceNormalizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of InstanceNormalizationBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/layer_normalization.py
+++ b/python/src/nnabla/backward_function/layer_normalization.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class LayerNormalizationBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'LayerNormalizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of LayerNormalizationBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/tensor_normalization.py
+++ b/python/src/nnabla/backward_function/tensor_normalization.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class TensorNormalizationBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'TensorNormalizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of TensorNormalizationBackward class is not implemented.")

--- a/python/src/nnabla/backward_function/weight_standardization.py
+++ b/python/src/nnabla/backward_function/weight_standardization.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from .backward_function import BackwardFunction
+
+
+class WeightStandardizationBackward(BackwardFunction):
+
+    @property
+    def name(self):
+        return 'WeightStandardizationBackward'
+
+    def _create_forward_inputs_and_outputs(self, inputs, outputs):
+        msg = ("Implement this function correctly \n"
+               "if the backward function takes the output(s) of the forward function.\n"
+               "See the SigmoidBackward in that case.\n"
+               "Delete this error message after implementing.")
+        raise Exception(msg)
+
+        # Inputs on the forward graph
+        inputs_fwd = []
+        for i in range(self._num_inputs_fwd):
+            need_grad = self.forward_func.inputs[i].need_grad
+            v = nn.Variable(inputs[i].shape, need_grad=need_grad)
+            v.data = inputs[i].data
+            v.grad = outputs[i].data
+            inputs_fwd += [v]
+        # Outputs on the forward graph
+        outputs_fwd = []
+        for i in range(self._num_outputs_fwd):
+            inp = inputs[self._num_inputs_fwd + i]
+            v = nn.Variable(inp.shape)
+            v.grad = inp.data
+            outputs_fwd += [v]
+        return inputs_fwd, outputs_fwd
+
+    def backward_impl(self, inputs, outputs, prop_down, accum):
+        # inputs: [inputs_fwd_graph] + [inputs_bwd_graph] or
+        # [inputs_fwd_graph] + [outputs_fwd_graph] + [inputs_bwd_graph]
+
+        raise NotImplementedError(
+            "The backward method of WeightStandardizationBackward class is not implemented.")

--- a/python/src/nnabla/experimental/graph_converters/batch_norm_batchstat.py
+++ b/python/src/nnabla/experimental/graph_converters/batch_norm_batchstat.py
@@ -54,6 +54,12 @@ class BatchNormBatchStatModifier(FunctionModifier):
     def connect(self, fname, inputs, args):
         fct = self._fct_set[fname]
         args['batch_stat'] = False
+
+        if 'no_scale' in args:
+            del args['no_scale']
+        if 'no_bias' in args:
+            del args['no_bias']
+
         h = fct(*inputs, **args)
         return h
 

--- a/python/src/nnabla/experimental/graph_converters/channel_first.py
+++ b/python/src/nnabla/experimental/graph_converters/channel_first.py
@@ -88,6 +88,10 @@ class ChannelFirstModifier(FunctionModifier):
             mean = inputs[3]
             var = inputs[4]
             args['axes'] = [1]
+            if 'no_scale' in args:
+                del args['no_scale']
+            if 'no_bias' in args:
+                del args['no_bias']
             scope = self.get_parameter_scope(beta)
             with nn.parameter_scope(scope):
                 beta_d = beta.d.copy().transpose(0, 3, 1, 2)

--- a/python/src/nnabla/experimental/graph_converters/channel_last.py
+++ b/python/src/nnabla/experimental/graph_converters/channel_last.py
@@ -88,6 +88,10 @@ class ChannelLastModifier(FunctionModifier):
             mean = inputs[3]
             var = inputs[4]
             args['axes'] = [len(x.shape) - 1]
+            if 'no_scale' in args:
+                del args['no_scale']
+            if 'no_bias' in args:
+                del args['no_bias']
             scope = self.get_parameter_scope(beta)
             with nn.parameter_scope(scope):
                 beta_d = beta.d.copy().transpose(0, 2, 3, 1)

--- a/python/test/function/test_group_normalization.py
+++ b/python/test/function/test_group_normalization.py
@@ -102,9 +102,5 @@ def test_group_normalization_forward_backward(ctx, func_name, seed, num_groups, 
     x, beta, gamma = create_inputs(
         rng, x_shape, channel_axis, no_scale, no_bias)
 
-    # 'need_grad' of beta and gamma must be same in batch_norm
-    param_backward = not no_bias or not no_scale
-    backward = [True, param_backward, param_backward]
-
     function_tester(rng, F.group_normalization, ref_group_normalization, [x, beta, gamma], [num_groups, channel_axis, batch_axis, eps, output_stat], ctx=ctx,
-                    func_name=func_name, dstep=1e-2, atol_b=4e-2, atol_accum=1e-5, backward=backward, disable_half_test=True)
+                    func_name=func_name, dstep=1e-2, atol_b=4e-2, atol_accum=1e-5, backward=[True, not no_bias, not no_scale], disable_half_test=True)

--- a/python/test/function/test_instance_normalization.py
+++ b/python/test/function/test_instance_normalization.py
@@ -88,9 +88,5 @@ def test_instance_normalization_forward_backward(ctx, func_name, seed, x_shape, 
     x, beta, gamma = create_inputs(
         rng, x_shape, batch_axis, channel_axis, no_scale, no_bias)
 
-    # 'need_grad' of beta and gamma must be same in batch_norm
-    param_backward = not no_bias or not no_scale
-    backward = [True, param_backward, param_backward]
-
     function_tester(rng, F.instance_normalization, ref_instance_normalization, [x, beta, gamma], [channel_axis, batch_axis, eps, output_stat], ctx=ctx,
-                    func_name=func_name, dstep=1e-2, atol_b=1e-2, backward=backward, disable_half_test=True)
+                    func_name=func_name, dstep=1e-2, atol_b=1e-2, backward=[True, not no_bias, not no_scale], disable_half_test=True)

--- a/python/test/function/test_layer_normalization.py
+++ b/python/test/function/test_layer_normalization.py
@@ -86,9 +86,5 @@ def test_layer_normalization_forward_backward(ctx, func_name, seed, x_shape, bat
     rng = np.random.RandomState(seed)
     x, beta, gamma = create_inputs(rng, x_shape, batch_axis, no_scale, no_bias)
 
-    # 'need_grad' of beta and gamma must be same in batch_norm
-    param_backward = not no_bias or not no_scale
-    backward = [True, param_backward, param_backward]
-
     function_tester(rng, F.layer_normalization, ref_layer_normalization, [x, beta, gamma], [batch_axis, eps, output_stat], ctx=ctx,
-                    func_name=func_name, dstep=1e-2, atol_b=1e-2, backward=backward, disable_half_test=True)
+                    func_name=func_name, dstep=1e-2, atol_b=1e-2, backward=[True, not no_bias, not no_scale], disable_half_test=True)

--- a/python/test/function/test_layer_normalization.py
+++ b/python/test/function/test_layer_normalization.py
@@ -2,9 +2,11 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
-from nnabla.testing import assert_allclose
+from nbla_test_utils import list_context
 
 from nnabla.normalization_functions import _force_list, _get_axes_excluding
+
+ctxs = list_context('LayerNormalization')
 
 
 def ref_layer_normalization(x, beta, gamma, batch_axis, eps, output_stat):
@@ -17,12 +19,32 @@ def ref_layer_normalization(x, beta, gamma, batch_axis, eps, output_stat):
 
     norm = (x - x_mean) / (x_var + eps) ** 0.5
 
+    if gamma is not None:
+        norm *= gamma
+
+    if beta is not None:
+        norm += beta
+
     if output_stat:
-        return norm * gamma + beta, x_mean, x_var
+        return norm, x_mean, x_var
 
-    return norm * gamma + beta
+    return norm
 
 
+def create_inputs(rng, x_shape, batch_axis, no_scale, no_bias):
+    x = rng.randn(*x_shape).astype(np.float32)
+
+    stat_shape = list(x_shape)
+    for baxis in _force_list(batch_axis):
+        stat_shape[baxis] = 1
+
+    beta = None if no_bias else rng.randn(*stat_shape).astype(np.float32)
+    gamma = None if no_scale else rng.randn(*stat_shape).astype(np.float32)
+
+    return x, beta, gamma
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("x_shape , batch_axis", [((4, 3, 8, 8), 0),
                                                   ((4, 16, 16, 8), 0),
@@ -31,39 +53,42 @@ def ref_layer_normalization(x, beta, gamma, batch_axis, eps, output_stat):
                                                   # time-series (T, B, C) or (B, T, C)
                                                   ((10, 4, 16), [0, 1])
                                                   ])
+@pytest.mark.parametrize("eps", [1e-05])
 @pytest.mark.parametrize("output_stat", [False, True])
-def test_layer_normalization_forward_backward(seed, x_shape, batch_axis, output_stat):
+@pytest.mark.parametrize("no_scale", [False, True])
+@pytest.mark.parametrize("no_bias", [False, True])
+def test_layer_normalization_forward(ctx, func_name, seed, x_shape, batch_axis, eps, output_stat, no_scale, no_bias):
+    from nbla_test_utils import function_tester
+
     rng = np.random.RandomState(seed)
-    input = rng.randn(*x_shape).astype(np.float32)
+    x, beta, gamma = create_inputs(rng, x_shape, batch_axis, no_scale, no_bias)
 
-    stat_shape = list(x_shape)
-    for baxis in _force_list(batch_axis):
-        stat_shape[baxis] = 1
+    function_tester(rng, F.layer_normalization, ref_layer_normalization, [x, beta, gamma], [batch_axis, eps, output_stat], ctx=ctx,
+                    func_name=func_name, dstep=1e-2, atol_b=1e-2, backward=[False, False, False], disable_half_test=True)
 
-    beta = rng.randn(*stat_shape).astype(np.float32)
-    gamma = rng.randn(*stat_shape).astype(np.float32)
-    eps = 1e-05
 
-    x = nn.Variable.from_numpy_array(input)
-    v_beta = nn.Variable.from_numpy_array(beta)
-    v_gamma = nn.Variable.from_numpy_array(gamma)
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("x_shape , batch_axis", [((2, 3, 4, 4), 0),
+                                                  ((2, 4, 4, 3), 0),
+                                                  ((16, 1), 0),
+                                                  ((2, 4, 3), 0),
+                                                  # time-series (T, B, C) or (B, T, C)
+                                                  ((3, 2, 5), [0, 1])
+                                                  ])
+@pytest.mark.parametrize("eps", [1e-05])
+@pytest.mark.parametrize("output_stat", [False, True])
+@pytest.mark.parametrize("no_scale", [False, True])
+@pytest.mark.parametrize("no_bias", [False, True])
+def test_layer_normalization_forward_backward(ctx, func_name, seed, x_shape, batch_axis, eps, output_stat, no_scale, no_bias):
+    from nbla_test_utils import function_tester
 
-    output = F.layer_normalization(
-        x, v_beta, v_gamma, batch_axis, eps, output_stat)
-    ref = ref_layer_normalization(
-        input, beta, gamma, batch_axis, eps, output_stat)
+    rng = np.random.RandomState(seed)
+    x, beta, gamma = create_inputs(rng, x_shape, batch_axis, no_scale, no_bias)
 
-    if output_stat:
-        tmp = F.sink(*output)
-        tmp.forward()
-        tmp.backward()
+    # 'need_grad' of beta and gamma must be same in batch_norm
+    param_backward = not no_bias or not no_scale
+    backward = [True, param_backward, param_backward]
 
-        for o, r in zip(output, ref):
-            assert o.shape == r.shape
-            assert_allclose(o.d, r, atol=1e-2, rtol=1e-5)
-
-    else:
-        output.forward()
-        output.backward()
-
-        assert_allclose(output.d, ref, atol=1e-2, rtol=1e-5)
+    function_tester(rng, F.layer_normalization, ref_layer_normalization, [x, beta, gamma], [batch_axis, eps, output_stat], ctx=ctx,
+                    func_name=func_name, dstep=1e-2, atol_b=1e-2, backward=backward, disable_half_test=True)

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -129,6 +129,7 @@ def compute_analytical_and_numerical_grad(f, inputs, outputs, inputs0,
         vinputs = []
         for i, i0 in zip(inputs, inputs0):
             if i is None:  # Optional argument
+                backups.append(None)
                 continue
             vinputs += [i]
             if i0 is not None:  # Not need backward

--- a/python/test/test_parametric_functions.py
+++ b/python/test/test_parametric_functions.py
@@ -517,7 +517,8 @@ def check_normalization_params(f_name, p_shape, gamma_ref, beta_ref, no_scale, n
 @pytest.mark.parametrize('output_stat', [False, True])
 @pytest.mark.parametrize("fix_parameters", [False, True])
 @pytest.mark.parametrize('param_init', [None, True])
-@pytest.mark.parametrize('no_scale, no_bias', [(False, False), (True, True)])
+@pytest.mark.parametrize('no_scale', [False, True])
+@pytest.mark.parametrize('no_bias', [False, True])
 def test_pf_layer_normalization(g_rng, inshape, batch_axis, output_stat, fix_parameters, param_init, no_scale, no_bias):
     from nnabla.normalization_functions import _force_list, _get_axes_excluding, _apply_affine
 
@@ -600,7 +601,8 @@ def test_pf_layer_normalization(g_rng, inshape, batch_axis, output_stat, fix_par
 @pytest.mark.parametrize('output_stat', [False, True])
 @pytest.mark.parametrize("fix_parameters", [False, True])
 @pytest.mark.parametrize('param_init', [None, True])
-@pytest.mark.parametrize('no_scale, no_bias', [(False, False), (True, True)])
+@pytest.mark.parametrize('no_scale', [False, True])
+@pytest.mark.parametrize('no_bias', [False, True])
 def test_pf_instance_normalization(g_rng, inshape, batch_axis, channel_axis, output_stat,
                                    fix_parameters, param_init, no_scale, no_bias):
     from nnabla.normalization_functions import _force_list, _get_axes_excluding, _apply_affine
@@ -686,7 +688,8 @@ def test_pf_instance_normalization(g_rng, inshape, batch_axis, channel_axis, out
 @pytest.mark.parametrize('output_stat', [False, True])
 @pytest.mark.parametrize("fix_parameters", [False, True])
 @pytest.mark.parametrize('param_init', [None, True])
-@pytest.mark.parametrize('no_scale, no_bias', [(False, False), (True, True)])
+@pytest.mark.parametrize('no_scale', [False, True])
+@pytest.mark.parametrize('no_bias', [False, True])
 def test_pf_group_normalization(g_rng, num_groups, inshape, batch_axis, channel_axis, output_stat,
                                 fix_parameters, param_init, no_scale, no_bias):
     from nnabla.normalization_functions import _force_list, _get_axes_excluding, _apply_affine

--- a/src/nbla/function/generic/batch_normalization.cpp
+++ b/src/nbla/function/generic/batch_normalization.cpp
@@ -23,7 +23,7 @@
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_SOURCE(BatchNormalization, const vector<int> &, float,
-                              float, bool);
+                              float, bool, bool, bool);
 
 template <typename T>
 void BatchNormalization<T>::setup_impl(const Variables &inputs,
@@ -31,6 +31,30 @@ void BatchNormalization<T>::setup_impl(const Variables &inputs,
   // Check axes
   NBLA_CHECK(axes_.size() == 1, error_code::not_implemented,
              "Specifying axis more than one is not supported so far.")
+
+  // Check num of inputs and outputs.
+  size_t ninputs = inputs.size();
+  size_t noutputs = outputs.size();
+  size_t ninputs_expect = 3;
+  if (!no_scale_)
+    ninputs_expect++;
+  if (!no_bias_)
+    ninputs_expect++;
+  NBLA_CHECK(ninputs == ninputs_expect, error_code::value,
+             "Number of inputs must be 3, 4 or 5.");
+  if (!batch_stat_) {
+    NBLA_CHECK(
+        noutputs == 1, error_code::value,
+        "If batch_stat_ is false, it cannot output batch mean and variance.");
+  }
+  NBLA_CHECK(noutputs == 1 || noutputs == 3, error_code::value,
+             "Number of outputs must be 1 or 3.");
+
+  // calculate parameter index
+  b_idx_ = no_bias_ ? -1 : 1;
+  g_idx_ = no_scale_ ? -1 : no_bias_ ? 1 : 2;
+  m_idx_ = ninputs - 2; // mean
+  v_idx_ = ninputs - 1; // variance
 
   // Check and parse shapes
   Shape_t shape_i = inputs[0]->shape();
@@ -43,53 +67,47 @@ void BatchNormalization<T>::setup_impl(const Variables &inputs,
   size02_ = size0_ * size2_;
   NBLA_CHECK(size0_ * size1_ * size2_ == size, error_code::unclassified,
              "An error occurred during setup BatchNormalization function.");
-  // Verify mean, var, beta and gamma dims.
-  Shape_t shape_b = inputs[1]->shape();
-  Shape_t shape_g = inputs[2]->shape();
-  Shape_t shape_m = inputs[3]->shape();
-  Shape_t shape_v = inputs[4]->shape();
+
   // Verify mean, var, beta and gamma shapes.
   Shape_t shape_check(shape_i.size(), 1);
   shape_check[axes_[0]] = shape_i[axes_[0]];
-  NBLA_CHECK(shape_check == shape_b, error_code::value,
-             "Shape of beta(inputs[1]) does not match. "
-             "beta: (%s) != expected: (%s).",
-             string_join(shape_b, string(", ")).c_str(),
-             string_join(shape_check, string(", ")).c_str());
-  NBLA_CHECK(shape_check == shape_g, error_code::value,
-             "Shape of gamma(inputs[2]) does not match. "
-             "gamma: (%s) != expected: (%s).",
-             string_join(shape_g, string(", ")).c_str(),
-             string_join(shape_check, string(", ")).c_str());
+  if (!no_bias_) {
+    Shape_t shape_b = inputs[b_idx_]->shape();
+    NBLA_CHECK(shape_check == shape_b, error_code::value,
+               "Shape of beta(inputs[%d]) does not match. "
+               "beta: (%s) != expected: (%s).",
+               b_idx_, string_join(shape_b, string(", ")).c_str(),
+               string_join(shape_check, string(", ")).c_str());
+  }
+  if (!no_scale_) {
+    Shape_t shape_g = inputs[g_idx_]->shape();
+    NBLA_CHECK(shape_check == shape_g, error_code::value,
+               "Shape of gamma(inputs[%d]) does not match. "
+               "gamma: (%s) != expected: (%s).",
+               g_idx_, string_join(shape_g, string(", ")).c_str(),
+               string_join(shape_check, string(", ")).c_str());
+  }
+  Shape_t shape_m = inputs[m_idx_]->shape();
+  Shape_t shape_v = inputs[v_idx_]->shape();
   NBLA_CHECK(shape_check == shape_m, error_code::value,
-             "Shape of mean(inputs[3]) does not match. "
+             "Shape of mean(inputs[%d]) does not match. "
              "mean: (%s) != expected: (%s).",
-             string_join(shape_m, string(", ")).c_str(),
+             m_idx_, string_join(shape_m, string(", ")).c_str(),
              string_join(shape_check, string(", ")).c_str());
   NBLA_CHECK(shape_check == shape_v, error_code::value,
-             "Shape of var(inputs[4]) does not match. "
+             "Shape of var(inputs[%d]) does not match. "
              "var: (%s) != expected: (%s).",
-             string_join(shape_v, string(", ")).c_str(),
+             v_idx_, string_join(shape_v, string(", ")).c_str(),
              string_join(shape_check, string(", ")).c_str());
-
-  // Check num of inputs and outputs.
-  size_t noutputs = outputs.size();
-  if (!batch_stat_) {
-    NBLA_CHECK(
-        noutputs == 1, error_code::value,
-        "If batch_stat_ is false, it cannot output batch mean and variance.");
-  }
-  NBLA_CHECK(noutputs == 1 || noutputs == 3, error_code::value,
-             "Number of outputs must be 1 or 3.");
 
   // Reshape outputs and/or temporary buffers.
   outputs[0]->reshape(shape_i, true);
   if (noutputs == 3) {
-    outputs[1]->reshape(shape_b, true); // batch mean
-    outputs[2]->reshape(shape_g, true); // batch var
+    outputs[1]->reshape(shape_m, true); // batch mean
+    outputs[2]->reshape(shape_v, true); // batch var
   } else {
-    mean_.reshape(shape_b, true); // batch mean
-    var_.reshape(shape_g, true);  // batch var
+    mean_.reshape(shape_m, true); // batch mean
+    var_.reshape(shape_v, true);  // batch var
   }
 
   // Instantiate functions used for the backward in test mode (batch_stat_ =
@@ -132,8 +150,12 @@ void BatchNormalization<T>::forward_impl_batch(const Variables &inputs,
   }
   // Inputs
   const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
-  const T *beta = inputs[1]->get_data_pointer<T>(this->ctx_);
-  const T *gamma = inputs[2]->get_data_pointer<T>(this->ctx_);
+  const T *beta =
+      no_bias_ ? nullptr
+               : inputs[b_idx_]->template get_data_pointer<T>(this->ctx_);
+  const T *gamma =
+      no_scale_ ? nullptr
+                : inputs[g_idx_]->template get_data_pointer<T>(this->ctx_);
   // Output
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   T *m =
@@ -141,8 +163,10 @@ void BatchNormalization<T>::forward_impl_batch(const Variables &inputs,
   T *v =
       batch_var->cast_data_and_get_pointer<T>(this->ctx_, true); // batch varf
   // Inputs/Outputs
-  T *rm = inputs[3]->cast_data_and_get_pointer<T>(this->ctx_); // running mean
-  T *rv = inputs[4]->cast_data_and_get_pointer<T>(this->ctx_); // running var
+  T *rm = inputs[m_idx_]->template cast_data_and_get_pointer<T>(
+      this->ctx_); // running mean
+  T *rv = inputs[v_idx_]->template cast_data_and_get_pointer<T>(
+      this->ctx_); // running var
 
   // Main loop
   for (int i1 = 0; i1 < size1_; ++i1) {
@@ -173,7 +197,9 @@ void BatchNormalization<T>::forward_impl_batch(const Variables &inputs,
       const int i2 = i02 % size2_;
       const int i = i0 * size12_ + i1 * size2_ + i2;
       const T stdvar = std::sqrt(v[i1] + (T)eps_);
-      y[i] = (x[i] - m[i1]) * gamma[i1] / stdvar + beta[i1];
+      const auto scale = gamma ? gamma[i1] : (T)1;
+      const auto bias = beta ? beta[i1] : (T)0;
+      y[i] = (x[i] - m[i1]) * scale / stdvar + bias;
     }
   }
 }
@@ -183,10 +209,16 @@ void BatchNormalization<T>::forward_impl_global(const Variables &inputs,
                                                 const Variables &outputs) {
   // Inputs
   const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
-  const T *beta = inputs[1]->get_data_pointer<T>(this->ctx_);
-  const T *gamma = inputs[2]->get_data_pointer<T>(this->ctx_);
-  const T *rm = inputs[3]->get_data_pointer<T>(this->ctx_); // running mean
-  const T *rv = inputs[4]->get_data_pointer<T>(this->ctx_); // running var
+  const T *beta =
+      no_bias_ ? nullptr
+               : inputs[b_idx_]->template get_data_pointer<T>(this->ctx_);
+  const T *gamma =
+      no_scale_ ? nullptr
+                : inputs[g_idx_]->template get_data_pointer<T>(this->ctx_);
+  const T *rm =
+      inputs[m_idx_]->template get_data_pointer<T>(this->ctx_); // running mean
+  const T *rv =
+      inputs[v_idx_]->template get_data_pointer<T>(this->ctx_); // running var
   // Output
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
 
@@ -201,7 +233,9 @@ void BatchNormalization<T>::forward_impl_global(const Variables &inputs,
       const int i = i0 * size12_ + i1 * size2_ + i2;
       const T mean = rm[i1];
       const T stdvar = std::sqrt(rv[i1] + (T)eps_);
-      y[i] = (x[i] - mean) * gamma[i1] / stdvar + beta[i1];
+      const auto scale = gamma ? gamma[i1] : (T)1;
+      const auto bias = beta ? beta[i1] : (T)0;
+      y[i] = (x[i] - mean) * scale / stdvar + bias;
     }
   }
 }
@@ -225,6 +259,12 @@ void BatchNormalization<T>::backward_impl_batch(
   if (!(propagate_down[0] || propagate_down[1] || propagate_down[2])) {
     return;
   }
+
+  const bool pd_beta =
+      !no_bias_ && propagate_down[b_idx_]; // propagate_down beta
+  const bool pd_gamma =
+      !no_scale_ && propagate_down[g_idx_]; // propagate_down gamma
+
   // Check whether it outputs batch mean/var.
   Variable *batch_mean = &mean_;
   Variable *batch_var = &var_;
@@ -242,7 +282,9 @@ void BatchNormalization<T>::backward_impl_batch(
   // Gradient wrt. x.
   if (propagate_down[0]) {
     T *dx = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
-    const T *g = inputs[2]->get_data_pointer<T>(this->ctx_);
+    const T *g = no_scale_
+                     ? nullptr
+                     : inputs[g_idx_]->template get_data_pointer<T>(this->ctx_);
     const T *dm = nullptr;
     const T *dv = nullptr;
     if (outputs.size() == 3) {
@@ -258,7 +300,8 @@ void BatchNormalization<T>::backward_impl_batch(
         const int i0 = i02 / size2_;
         const int i2 = i02 % size2_;
         const int i = i0 * size12_ + i1 * size2_ + i2;
-        const T dxh = dy[i] * g[i1]; // Grad of x hat.
+        const auto scale = g ? g[i1] : (T)1;
+        const T dxh = dy[i] * scale; // Grad of x hat.
         const T cx = x[i] - m[i1];   // x - mean
         dvar += dxh * cx;
         dmean += dxh;
@@ -275,7 +318,8 @@ void BatchNormalization<T>::backward_impl_batch(
         const int i0 = i02 / size2_;
         const int i2 = i02 % size2_;
         const int i = i0 * size12_ + i1 * size2_ + i2;
-        const T grad = dy[i] * g[i1] / std::sqrt(v[i1] + (T)eps_) +
+        const auto scale = g ? g[i1] : (T)1;
+        const T grad = dy[i] * scale / std::sqrt(v[i1] + (T)eps_) +
                        dvar * 2 * (x[i] - m[i1]) / (size02_) +
                        dmean / (size02_);
         if (accum[0])
@@ -286,23 +330,33 @@ void BatchNormalization<T>::backward_impl_batch(
     }
   }
 
-  if (propagate_down[1] || propagate_down[2]) { // beta and gamma
-    NBLA_CHECK(propagate_down[1] && propagate_down[2], error_code::value,
-               "'need_grad' of beta and gamma must be the same.");
-    T *db = inputs[1]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[1]);
-    T *dg = inputs[2]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[2]);
+  if (pd_beta || pd_gamma) { // beta and gamma
+    T *db = pd_beta
+                ? inputs[b_idx_]->template cast_grad_and_get_pointer<T>(
+                      this->ctx_, !accum[b_idx_])
+                : nullptr;
+    T *dg = pd_gamma
+                ? inputs[g_idx_]->template cast_grad_and_get_pointer<T>(
+                      this->ctx_, !accum[g_idx_])
+                : nullptr;
+    const bool b_accum = pd_beta ? accum[b_idx_] : false;
+    const bool g_accum = pd_gamma ? accum[g_idx_] : false;
     for (int i1 = 0; i1 < size1_; ++i1) {
-      T dbv = accum[1] ? db[i1] : (T)0;
-      T dgv = accum[2] ? dg[i1] : (T)0;
+      T dbv = b_accum ? db[i1] : (T)0;
+      T dgv = g_accum ? dg[i1] : (T)0;
       for (int i02 = 0; i02 < size02_; ++i02) {
         const int i0 = i02 / size2_;
         const int i2 = i02 % size2_;
         const int i = i0 * size12_ + i1 * size2_ + i2;
-        dbv += dy[i];
-        dgv += dy[i] * (x[i] - m[i1]) / std::sqrt(v[i1] + (T)eps_);
+        if (db)
+          dbv += dy[i];
+        if (dg)
+          dgv += dy[i] * (x[i] - m[i1]) / std::sqrt(v[i1] + (T)eps_);
       }
-      db[i1] = dbv;
-      dg[i1] = dgv;
+      if (db)
+        db[i1] = dbv;
+      if (dg)
+        dg[i1] = dgv;
     }
   }
 }
@@ -314,37 +368,43 @@ void BatchNormalization<T>::backward_impl_global(
   if (!(propagate_down[0] || propagate_down[1] || propagate_down[2])) {
     return;
   }
+  const bool pd_beta =
+      !no_bias_ && propagate_down[b_idx_]; // propagate_down beta
+  const bool pd_gamma =
+      !no_scale_ && propagate_down[g_idx_]; // propagate_down gamma
 
   // Common inputs wrt. gradient.
   auto x = inputs[0];
-  auto beta = inputs[1];
-  auto gamma = inputs[2];
-  auto rmean = inputs[3];
-  auto rvar = inputs[4];
+  auto beta = no_bias_ ? nullptr : inputs[b_idx_];
+  auto gamma = no_scale_ ? nullptr : inputs[g_idx_];
+  auto rmean = inputs[m_idx_];
+  auto rvar = inputs[v_idx_];
   auto y = outputs[0];
 
   // Running std
   shared_ptr<Variable> rstd_inv_sptr;
   shared_ptr<Variable> g_y_sptr;
-  if (propagate_down[0] || propagate_down[2]) { // x or gamma
-    // running std
-    rstd_inv_sptr = make_shared<Variable>(rvar->shape());
-    auto rstd_inv = rstd_inv_sptr.get();
-    execute(identity_, Variables{rvar}, Variables{rstd_inv});
-    execute(add_epsilon_, Variables{rstd_inv}, Variables{rstd_inv});
-    execute(square_root_, Variables{rstd_inv}, Variables{rstd_inv});
-    // g_y variable
-    g_y_sptr = make_shared<Variable>(y->shape());
-    g_y_sptr->set_data(y->grad());
-  }
+  // running std
+  rstd_inv_sptr = make_shared<Variable>(rvar->shape());
+  auto rstd_inv = rstd_inv_sptr.get();
+  execute(identity_, Variables{rvar}, Variables{rstd_inv});
+  execute(add_epsilon_, Variables{rstd_inv}, Variables{rstd_inv});
+  execute(square_root_, Variables{rstd_inv}, Variables{rstd_inv});
+  // g_y variable
+  g_y_sptr = make_shared<Variable>(y->shape());
+  g_y_sptr->set_data(y->grad());
 
   // Gradient wrt. x.
   if (propagate_down[0]) {
     // gamma / rstd
-    auto iv_sptr = make_shared<Variable>(beta->shape());
+    const auto param_shape = rmean->shape();
+    shared_ptr<Variable> iv_sptr = make_shared<Variable>(param_shape);
     auto rstd_inv = rstd_inv_sptr.get();
-    auto iv = iv_sptr.get();
-    execute(mul2_, Variables{gamma, rstd_inv}, Variables{iv});
+    auto iv = rstd_inv;
+    if (!no_scale_) {
+      iv = iv_sptr.get();
+      execute(mul2_, Variables{gamma, rstd_inv}, Variables{iv});
+    }
     // g_y * gamma / rstd
     auto g_x_tmp_sptr = make_shared<Variable>(x->shape());
     auto g_y = g_y_sptr.get();
@@ -363,46 +423,48 @@ void BatchNormalization<T>::backward_impl_global(
   }
 
   // Gradient wrt. beta and gamma.
-  if (propagate_down[1] || propagate_down[2]) { // beta and gamma
-    NBLA_CHECK(propagate_down[1] && propagate_down[2], error_code::value,
-               "'need_grad' of beta and gamma must be the same.");
+  if (pd_beta || pd_gamma) { // beta and gamma
 
     auto g_y = g_y_sptr.get();
 
     // 1. beta
-    auto g_beta_tmp_sptr = make_shared<Variable>(beta->shape());
-    auto g_beta_tmp = g_beta_tmp_sptr.get();
-    execute(sum_, Variables{g_y}, Variables{g_beta_tmp});
-    auto g_beta_sptr = make_shared<Variable>(beta->shape());
-    g_beta_sptr->set_data(beta->grad());
-    auto g_beta = g_beta_sptr.get();
-    if (accum[1]) {
-      execute(add2_, Variables{g_beta, g_beta_tmp}, Variables{g_beta});
-    } else {
-      execute(identity_, Variables{g_beta_tmp}, Variables{g_beta});
+    if (pd_beta) {
+      auto g_beta_tmp_sptr = make_shared<Variable>(beta->shape());
+      auto g_beta_tmp = g_beta_tmp_sptr.get();
+      execute(sum_, Variables{g_y}, Variables{g_beta_tmp});
+      auto g_beta_sptr = make_shared<Variable>(beta->shape());
+      g_beta_sptr->set_data(beta->grad());
+      auto g_beta = g_beta_sptr.get();
+      if (accum[b_idx_]) {
+        execute(add2_, Variables{g_beta, g_beta_tmp}, Variables{g_beta});
+      } else {
+        execute(identity_, Variables{g_beta_tmp}, Variables{g_beta});
+      }
     }
 
     // 2. gamma
-    // (x - rmean) / rstd
-    auto iv_sptr = make_shared<Variable>(x->shape());
-    auto iv = iv_sptr.get();
-    execute(sub2_, Variables{x, rmean}, Variables{iv});
-    auto rstd_inv = rstd_inv_sptr.get();
-    execute(mul2_, Variables{iv, rstd_inv}, Variables{iv});
-    // g_y * (x - rmean) / rstd
-    mul2_ = create_Mul2(this->ctx_, false);
-    execute(mul2_, Variables{g_y, iv}, Variables{iv});
-    // reduction
-    auto g_gamma_tmp_sptr = make_shared<Variable>(gamma->shape());
-    auto g_gamma_tmp = g_gamma_tmp_sptr.get();
-    execute(sum_, Variables{iv}, Variables{g_gamma_tmp});
-    auto g_gamma_sptr = make_shared<Variable>(gamma->shape());
-    g_gamma_sptr->set_data(gamma->grad());
-    auto g_gamma = g_gamma_sptr.get();
-    if (accum[2]) {
-      execute(add2_, Variables{g_gamma, g_gamma_tmp}, Variables{g_gamma});
-    } else {
-      execute(identity_, Variables{g_gamma_tmp}, Variables{g_gamma});
+    if (pd_gamma) {
+      // (x - rmean) / rstd
+      auto iv_sptr = make_shared<Variable>(x->shape());
+      auto iv = iv_sptr.get();
+      execute(sub2_, Variables{x, rmean}, Variables{iv});
+      auto rstd_inv = rstd_inv_sptr.get();
+      execute(mul2_, Variables{iv, rstd_inv}, Variables{iv});
+      // g_y * (x - rmean) / rstd
+      mul2_ = create_Mul2(this->ctx_, false);
+      execute(mul2_, Variables{g_y, iv}, Variables{iv});
+      // reduction
+      auto g_gamma_tmp_sptr = make_shared<Variable>(gamma->shape());
+      auto g_gamma_tmp = g_gamma_tmp_sptr.get();
+      execute(sum_, Variables{iv}, Variables{g_gamma_tmp});
+      auto g_gamma_sptr = make_shared<Variable>(gamma->shape());
+      g_gamma_sptr->set_data(gamma->grad());
+      auto g_gamma = g_gamma_sptr.get();
+      if (accum[g_idx_]) {
+        execute(add2_, Variables{g_gamma, g_gamma_tmp}, Variables{g_gamma});
+      } else {
+        execute(identity_, Variables{g_gamma_tmp}, Variables{g_gamma});
+      }
     }
   }
 }

--- a/src/nbla/function/generic/fused_batch_normalization.cpp
+++ b/src/nbla/function/generic/fused_batch_normalization.cpp
@@ -53,7 +53,8 @@ void FusedBatchNormalization<T>::setup_impl(const Variables &inputs,
              "Currently \"relu\" is only supported as a nonlinearity.");
   Variables inputs_bn(inputs.begin(), inputs.begin() + 5);
   bn_ = create_BatchNormalization(this->ctx_, axes_, decay_rate_, eps_,
-                                  batch_stat_);
+                                  batch_stat_, false /* no_scale */,
+                                  false /* no_bias */);
   bn_->setup(inputs_bn, outputs);
 }
 

--- a/src/nbla/function/generic/fused_convolution.cpp
+++ b/src/nbla/function/generic/fused_convolution.cpp
@@ -174,7 +174,8 @@ void FusedConvolution<T>::setup_impl(const Variables &inputs,
     vector<int> axes{channel_last_ ? (int)(inputs[0]->ndim() - 1) : base_axis_};
     last_out = functions::batch_normalization(
         ctx_, last_out, cg_beta, cg_gamma, cg_mean, cg_variance, axes,
-        decay_rate_, eps_, batch_stat_)[0];
+        decay_rate_, eps_, batch_stat_, false /* no_scale */,
+        false /* no_bias */)[0];
   }
 
   // ----------------------------------------------------------------

--- a/src/nbla/function/generic/group_normalization.cpp
+++ b/src/nbla/function/generic/group_normalization.cpp
@@ -1,0 +1,214 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/group_normalization.hpp>
+#include <nbla/variable.hpp>
+
+#include <nbla/function/add2.hpp>
+#include <nbla/function/instance_normalization.hpp>
+#include <nbla/function/mul2.hpp>
+#include <nbla/imperative.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(GroupNormalization, int, int, const vector<int> &,
+                              float, bool, bool);
+
+template <typename T>
+void GroupNormalization<T>::setup_impl(const Variables &inputs,
+                                       const Variables &outputs) {
+  const auto n_inputs = inputs.size();
+  const auto n_outputs = outputs.size();
+  beta_idx_ = no_bias_ ? -1 : 1;
+  gamma_idx_ = no_scale_ ? -1 : no_bias_ ? 1 : 2;
+
+  gn_x_shape_ = inputs[0]->shape();
+  const auto ndim = gn_x_shape_.size();
+  output_stat_ = n_outputs == 3;
+
+  // check inputs size
+  int n_inputs_expect = 1;
+  if (!no_scale_)
+    n_inputs_expect++;
+  if (!no_bias_)
+    n_inputs_expect++;
+  NBLA_CHECK(n_inputs == n_inputs_expect, error_code::value,
+             "Number of inputs must be 1, 2 or 3.");
+
+  // check chennel_axis
+  NBLA_CHECK(0 <= channel_axis_ && channel_axis_ < ndim, error_code::value,
+             "channel_axis must be in the range of [0, ndim). channel_axis : "
+             "%d, ndim: {}.",
+             channel_axis_, ndim);
+
+  const auto cdim = gn_x_shape_[channel_axis_];
+  NBLA_CHECK(cdim % num_groups_ == 0, error_code::value,
+             "Channel dim (%d) must be integer multiple of num_groups (%d).",
+             cdim, num_groups_);
+
+  // check param shapes
+  auto gn_param_shape = Shape_t(ndim, 1);
+  gn_param_shape[channel_axis_] = gn_x_shape_[channel_axis_];
+  const auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  const auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+  if (beta) {
+    const auto beta_shape = beta->shape();
+    NBLA_CHECK(gn_param_shape == beta_shape, error_code::value,
+               "Shape of beta(inputs[1]) does not match. "
+               "beta: (%s) != expected: (%s).",
+               string_join(beta_shape, string(", ")).c_str(),
+               string_join(gn_param_shape, string(", ")).c_str());
+  }
+  if (gamma) {
+    const auto gamma_shape = gamma->shape();
+    NBLA_CHECK(gn_param_shape == gamma_shape, error_code::value,
+               "Shape of gamma(inputs[1]) does not match. "
+               "gamma: (%s) != expected: (%s).",
+               string_join(gamma_shape, string(", ")).c_str(),
+               string_join(gn_param_shape, string(", ")).c_str());
+  }
+
+  // calculate instance_norm input shape
+  instn_x_shape_.clear();
+  for (int i = 0; i < channel_axis_; i++) {
+    instn_x_shape_.push_back(gn_x_shape_[i]);
+  }
+  instn_x_shape_.push_back(num_groups_);
+  instn_x_shape_.push_back(cdim / num_groups_);
+  if (channel_axis_ < ndim - 1) {
+    for (int i = channel_axis_ + 1; i < ndim; i++) {
+      instn_x_shape_.push_back(gn_x_shape_[i]);
+    }
+  }
+
+  // calculate instance_norm param shape
+  Shape_t adapt_shape(instn_x_shape_.size(), 1);
+  for (auto a : batch_axis_) {
+    adapt_shape[a] = instn_x_shape_[a];
+  }
+  adapt_shape[channel_axis_] = instn_x_shape_[channel_axis_];
+
+  // reshape outputs
+  outputs[0]->reshape(gn_x_shape_, true);
+  if (n_outputs == 3) {
+    outputs[1]->reshape(adapt_shape, true); // batch mean
+    outputs[2]->reshape(adapt_shape, true); // batch var
+  }
+
+  // functions
+  f_instance_norm_ =
+      create_InstanceNormalization(ctx_, channel_axis_, batch_axis_, eps_,
+                                   true /* no_scale */, true /* no_bias */);
+  if (!no_scale_)
+    f_mul2_ = create_Mul2(ctx_, false);
+  if (!no_bias_)
+    f_add2_ = create_Add2(ctx_, false);
+}
+
+template <typename T>
+void GroupNormalization<T>::forward_impl(const Variables &inputs,
+                                         const Variables &outputs) {
+  auto x = inputs[0];
+  auto y = outputs[0];
+
+  // variables for affine
+  auto bias = no_bias_ ? nullptr : inputs[beta_idx_];
+  auto scale = no_scale_ ? nullptr : inputs[gamma_idx_];
+
+  // instance norm
+  x->reshape(instn_x_shape_, false);
+  y->reshape(instn_x_shape_, false);
+
+  nbla::execute(f_instance_norm_, Variables{x}, outputs);
+
+  x->reshape(gn_x_shape_, false); // restore input shape
+  y->reshape(gn_x_shape_, false);
+
+  // apply affine
+  if (scale) {
+    nbla::execute(f_mul2_, Variables{y, scale}, Variables{y});
+  }
+  if (bias) {
+    nbla::execute(f_add2_, Variables{y, bias}, Variables{y});
+  }
+}
+
+template <typename T>
+void GroupNormalization<T>::backward_impl(const Variables &inputs,
+                                          const Variables &outputs,
+                                          const vector<bool> &propagate_down,
+                                          const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+
+  // group_norm variables
+  auto x = inputs[0];
+
+  // instance_norm variables
+  Variable out_instn_y_buf;
+  Variable *out_instn_y = no_scale_ && no_bias_ ? outputs[0] : &out_instn_y_buf;
+  const auto instn_inputs = Variables{x};
+  const auto instn_outputs =
+      output_stat_ ? Variables{out_instn_y, outputs[1], outputs[2]}
+                   : Variables{out_instn_y};
+
+  // variables for affine
+  Variable out_mul2;
+  auto bias = no_bias_ ? nullptr : inputs[beta_idx_];
+  auto scale = no_scale_ ? nullptr : inputs[gamma_idx_];
+  const auto mul2_inputs = Variables{out_instn_y, scale};
+  const auto mul2_outputs = bias ? Variables{&out_mul2} : Variables{outputs[0]};
+  const auto add2_inputs =
+      scale ? Variables{&out_mul2, bias} : Variables{out_instn_y, bias};
+  const auto add2_outputs = Variables{outputs[0]};
+
+  // forward (instance_norm -> affine)
+
+  x->reshape(instn_x_shape_, false);
+  nbla::execute(f_instance_norm_, instn_inputs, instn_outputs);
+  out_instn_y->reshape(gn_x_shape_, false);
+
+  if (scale) {
+    nbla::execute(f_mul2_, mul2_inputs, mul2_outputs);
+  }
+  if (bias) {
+    nbla::execute(f_add2_, add2_inputs, add2_outputs);
+  }
+
+  // backward (affine -> instance_norm)
+
+  if (bias) {
+    nbla::backward(f_add2_, add2_inputs, add2_outputs,
+                   {true, propagate_down[beta_idx_]},
+                   {false, accum[beta_idx_]});
+  }
+  if (scale) {
+    nbla::backward(f_mul2_, mul2_inputs, mul2_outputs,
+                   {true, propagate_down[gamma_idx_]},
+                   {false, accum[gamma_idx_]});
+  }
+
+  if (propagate_down[0]) {
+    out_instn_y->reshape(instn_x_shape_, false);
+    nbla::backward(f_instance_norm_, instn_inputs, instn_outputs, {true},
+                   {accum[0]});
+    out_instn_y->reshape(gn_x_shape_, false);
+  }
+  x->reshape(gn_x_shape_, false); // restore input shape
+}
+}

--- a/src/nbla/function/generic/group_normalization.cpp
+++ b/src/nbla/function/generic/group_normalization.cpp
@@ -37,11 +37,11 @@ void GroupNormalization<T>::setup_impl(const Variables &inputs,
   gamma_idx_ = no_scale_ ? -1 : no_bias_ ? 1 : 2;
 
   gn_x_shape_ = inputs[0]->shape();
-  const auto ndim = gn_x_shape_.size();
+  const int ndim = gn_x_shape_.size();
   output_stat_ = n_outputs == 3;
 
   // check inputs size
-  int n_inputs_expect = 1;
+  size_t n_inputs_expect = 1;
   if (!no_scale_)
     n_inputs_expect++;
   if (!no_bias_)

--- a/src/nbla/function/generic/group_normalization.cpp
+++ b/src/nbla/function/generic/group_normalization.cpp
@@ -208,9 +208,10 @@ void GroupNormalization<T>::backward_impl(const Variables &inputs,
     if (scale) {
       nbla::execute(f_mul2_, mul2_inputs, mul2_outputs);
     }
-    if (bias) {
-      nbla::execute(f_add2_, add2_inputs, add2_outputs);
-    }
+    // add2 is skipped since its output is already in data region of outputs[0]
+    // if (bias) {
+    //   nbla::execute(f_add2_, add2_inputs, add2_outputs);
+    // }
   } else { // no_scale == true
     if (bias) {
       // instance_norm outputs are restored by group_norm output - bias

--- a/src/nbla/function/generic/instance_normalization.cpp
+++ b/src/nbla/function/generic/instance_normalization.cpp
@@ -1,0 +1,218 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/instance_normalization.hpp>
+#include <nbla/variable.hpp>
+
+#include <nbla/function/broadcast.hpp>
+#include <nbla/function/tensor_normalization.hpp>
+#include <nbla/imperative.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(InstanceNormalization, int, const vector<int> &,
+                              float, bool, bool);
+
+template <typename T>
+void InstanceNormalization<T>::setup_impl(const Variables &inputs,
+                                          const Variables &outputs) {
+  const int n_inputs = inputs.size();
+  const auto x_shape = inputs[0]->shape();
+  const int ndim = x_shape.size();
+  beta_idx_ = no_bias_ ? -1 : 1;
+  gamma_idx_ = no_scale_ ? -1 : no_bias_ ? 1 : 2;
+
+  // check inputs size
+  int n_inputs_expect = 1;
+  if (!no_scale_)
+    n_inputs_expect++;
+  if (!no_bias_)
+    n_inputs_expect++;
+  NBLA_CHECK(n_inputs == n_inputs_expect, error_code::value,
+             "Number of inputs must be 1, 2 or 3.");
+
+  // check chennel_axis
+  NBLA_CHECK(0 <= channel_axis_ && channel_axis_ < ndim, error_code::value,
+             "channel_axis must be in the range of [0, ndim). channel_axis : "
+             "%d, ndim: {}.",
+             channel_axis_, ndim);
+  // check batch_axis
+  for (int i = 0; i < batch_axis_.size(); i++) {
+    const auto ba = batch_axis_[i];
+    NBLA_CHECK(0 <= ba && ba < ndim, error_code::value,
+               "each element of batch_axis must be in the range of [0, ndim). "
+               "batch_axis[%d] : %d, ndim: {}.",
+               i, ba, ndim);
+  }
+
+  // check whether broadcast is needed or not.
+  // Unlike layer_norm and group_norm, only instance_norm can use bn scale bias
+  // & scale adaptation by broadcasting channel axis to channel * batch axis.
+  // (like [1, C, 1, 1] -> [N, C, 1, 1])
+  vector<int> adapt_shape(ndim, 1);
+  for (auto ba : batch_axis_) {
+    adapt_shape[ba] = x_shape[ba];
+  }
+  adapt_shape[channel_axis_] = x_shape[channel_axis_];
+
+  // check param shapes
+  const auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  const auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+  // beta
+  need_beta_broadcast_ = false;
+  if (beta) {
+    const auto beta_shape = beta->shape();
+    for (int i = 0; i < beta_shape.size(); i++) {
+      if (beta_shape[i] != adapt_shape[i]) {
+        need_beta_broadcast_ = true;
+        NBLA_CHECK(beta_shape[channel_axis_] == adapt_shape[channel_axis_],
+                   error_code::value,
+                   "channel size of beta: %d != channel size of x (%d).",
+                   beta_shape[channel_axis_], adapt_shape[channel_axis_]);
+        break;
+      }
+    }
+  }
+  // gamma
+  need_gamma_broadcast_ = false;
+  if (gamma) {
+    const auto gamma_shape = gamma->shape();
+    for (int i = 0; i < gamma_shape.size(); i++) {
+      if (gamma_shape[i] != adapt_shape[i]) {
+        need_gamma_broadcast_ = true;
+        NBLA_CHECK(gamma_shape[channel_axis_] == adapt_shape[channel_axis_],
+                   error_code::value,
+                   "channel size of gamma: %d != channel size of x (%d).",
+                   gamma_shape[channel_axis_], adapt_shape[channel_axis_]);
+        break;
+      }
+    }
+  }
+
+  // reshape outputs
+  outputs[0]->reshape(x_shape, true);
+  Shape_t out_param_shape;
+  for (int i = 0; i < ndim; i++) {
+    out_param_shape.push_back(adapt_shape[i]);
+  }
+  if (outputs.size() == 3) {
+    outputs[1]->reshape(out_param_shape, true); // batch mean
+    outputs[2]->reshape(out_param_shape, true); // batch var
+  }
+
+  // functions
+  if (need_beta_broadcast_) {
+    f_broadcast_beta_ = create_Broadcast(ctx_, adapt_shape);
+  }
+  if (need_gamma_broadcast_) {
+    f_broadcast_gamma_ = create_Broadcast(ctx_, adapt_shape);
+  }
+  auto tn_axes = batch_axis_;
+  tn_axes.push_back(channel_axis_);
+  f_tensor_norm_ =
+      create_TensorNormalization(ctx_, tn_axes, eps_, no_scale_, no_bias_);
+}
+
+template <typename T>
+void InstanceNormalization<T>::forward_impl(const Variables &inputs,
+                                            const Variables &outputs) {
+  auto x = inputs[0];
+  const auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  const auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+
+  // tensor_norm variables
+  Variable beta_bc, gamma_bc;
+  Variable *tn_beta = beta;
+  Variable *tn_gamma = gamma;
+
+  // broadcast
+  if (beta && need_beta_broadcast_) {
+    nbla::execute(f_broadcast_beta_, Variables{beta}, Variables{&beta_bc});
+    tn_beta = &beta_bc;
+  }
+  if (gamma && need_gamma_broadcast_) {
+    nbla::execute(f_broadcast_gamma_, Variables{gamma}, Variables{&gamma_bc});
+    tn_gamma = &gamma_bc;
+  }
+
+  // tensor_norm
+  auto tn_inputs = Variables{x};
+  if (beta)
+    tn_inputs.push_back(tn_beta);
+  if (gamma)
+    tn_inputs.push_back(tn_gamma);
+  nbla::execute(f_tensor_norm_, tn_inputs, outputs);
+}
+
+template <typename T>
+void InstanceNormalization<T>::backward_impl(const Variables &inputs,
+                                             const Variables &outputs,
+                                             const vector<bool> &propagate_down,
+                                             const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+
+  auto x = inputs[0];
+  const auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  const auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+
+  // tensor_norm variables
+  Variable beta_bc, gamma_bc;
+  Variable *tn_beta = beta;
+  Variable *tn_gamma = gamma;
+
+  // forward (broadcast -> tensor_norm)
+
+  // broadcast
+  if (beta && need_beta_broadcast_) {
+    nbla::execute(f_broadcast_beta_, Variables{beta}, Variables{&beta_bc});
+    tn_beta = &beta_bc;
+  }
+  if (gamma && need_gamma_broadcast_) {
+    nbla::execute(f_broadcast_gamma_, Variables{gamma}, Variables{&gamma_bc});
+    tn_gamma = &gamma_bc;
+  }
+
+  auto tn_inputs = Variables{x};
+  if (beta)
+    tn_inputs.push_back(tn_beta);
+  if (gamma)
+    tn_inputs.push_back(tn_gamma);
+
+  nbla::execute(f_tensor_norm_, tn_inputs, outputs);
+
+  // backward (tensor_norm -> broadcast)
+
+  vector<bool> tn_accum = {accum[0]};
+  if (beta)
+    tn_accum.push_back(accum[beta_idx_] && !need_beta_broadcast_);
+  if (gamma)
+    tn_accum.push_back(accum[gamma_idx_] && !need_gamma_broadcast_);
+
+  nbla::backward(f_tensor_norm_, tn_inputs, outputs, propagate_down, tn_accum);
+
+  if (beta && need_beta_broadcast_ && propagate_down[beta_idx_]) {
+    nbla::backward(f_broadcast_beta_, Variables{beta}, Variables{&beta_bc},
+                   {true}, {accum[beta_idx_]});
+  }
+  if (gamma && need_gamma_broadcast_ && propagate_down[gamma_idx_]) {
+    nbla::backward(f_broadcast_gamma_, Variables{gamma}, Variables{&gamma_bc},
+                   {true}, {accum[gamma_idx_]});
+  }
+}
+}

--- a/src/nbla/function/generic/instance_normalization.cpp
+++ b/src/nbla/function/generic/instance_normalization.cpp
@@ -50,7 +50,7 @@ void InstanceNormalization<T>::setup_impl(const Variables &inputs,
              "%d, ndim: {}.",
              channel_axis_, ndim);
   // check batch_axis
-  for (int i = 0; i < batch_axis_.size(); i++) {
+  for (size_t i = 0; i < batch_axis_.size(); i++) {
     const auto ba = batch_axis_[i];
     NBLA_CHECK(0 <= ba && ba < ndim, error_code::value,
                "each element of batch_axis must be in the range of [0, ndim). "
@@ -75,7 +75,7 @@ void InstanceNormalization<T>::setup_impl(const Variables &inputs,
   need_beta_broadcast_ = false;
   if (beta) {
     const auto beta_shape = beta->shape();
-    for (int i = 0; i < beta_shape.size(); i++) {
+    for (size_t i = 0; i < beta_shape.size(); i++) {
       if (beta_shape[i] != adapt_shape[i]) {
         need_beta_broadcast_ = true;
         NBLA_CHECK(beta_shape[channel_axis_] == adapt_shape[channel_axis_],
@@ -90,7 +90,7 @@ void InstanceNormalization<T>::setup_impl(const Variables &inputs,
   need_gamma_broadcast_ = false;
   if (gamma) {
     const auto gamma_shape = gamma->shape();
-    for (int i = 0; i < gamma_shape.size(); i++) {
+    for (size_t i = 0; i < gamma_shape.size(); i++) {
       if (gamma_shape[i] != adapt_shape[i]) {
         need_gamma_broadcast_ = true;
         NBLA_CHECK(gamma_shape[channel_axis_] == adapt_shape[channel_axis_],

--- a/src/nbla/function/generic/layer_normalization.cpp
+++ b/src/nbla/function/generic/layer_normalization.cpp
@@ -168,9 +168,10 @@ void LayerNormalization<T>::backward_impl(const Variables &inputs,
     if (scale) {
       nbla::execute(f_mul2_, mul2_inputs, mul2_outputs);
     }
-    if (bias) {
-      nbla::execute(f_add2_, add2_inputs, add2_outputs);
-    }
+    // add2 is skipped since its output is already in data region of outputs[0]
+    // if (bias) {
+    //   nbla::execute(f_add2_, add2_inputs, add2_outputs);
+    // }
   } else { // no_scale == true
     if (bias) {
       // tensor_norm outputs are restored by layer_norm output - bias

--- a/src/nbla/function/generic/layer_normalization.cpp
+++ b/src/nbla/function/generic/layer_normalization.cpp
@@ -36,7 +36,7 @@ void LayerNormalization<T>::setup_impl(const Variables &inputs,
 
   output_stat_ = n_outputs == 3;
   const auto x_shape = inputs[0]->shape();
-  const auto ndim = x_shape.size();
+  const int ndim = x_shape.size();
   beta_idx_ = no_bias_ ? -1 : 1;
   gamma_idx_ = no_scale_ ? -1 : no_bias_ ? 1 : 2;
   auto tn_axes = batch_axis_;
@@ -55,7 +55,7 @@ void LayerNormalization<T>::setup_impl(const Variables &inputs,
              "Number of inputs must be 1, 2 or 3.");
 
   // check batch_axis
-  for (int i = 0; i < batch_axis_.size(); i++) {
+  for (size_t i = 0; i < batch_axis_.size(); i++) {
     const auto ba = batch_axis_[i];
     NBLA_CHECK(0 <= ba && ba < ndim, error_code::value,
                "each element of batch_axis must be in the range of [0, ndim). "

--- a/src/nbla/function/generic/layer_normalization.cpp
+++ b/src/nbla/function/generic/layer_normalization.cpp
@@ -1,0 +1,184 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/layer_normalization.hpp>
+#include <nbla/variable.hpp>
+
+#include <nbla/function/add2.hpp>
+#include <nbla/function/mul2.hpp>
+#include <nbla/function/tensor_normalization.hpp>
+#include <nbla/imperative.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(LayerNormalization, const vector<int> &, float,
+                              bool, bool);
+
+template <typename T>
+void LayerNormalization<T>::setup_impl(const Variables &inputs,
+                                       const Variables &outputs) {
+  const int n_inputs = inputs.size();
+  const int n_outputs = outputs.size();
+
+  output_stat_ = n_outputs == 3;
+  const auto x_shape = inputs[0]->shape();
+  const auto ndim = x_shape.size();
+  beta_idx_ = no_bias_ ? -1 : 1;
+  gamma_idx_ = no_scale_ ? -1 : no_bias_ ? 1 : 2;
+  auto tn_axes = batch_axis_;
+  auto tn_param_shape = x_shape;
+  for (auto a : tn_axes) {
+    tn_param_shape[a] = 1;
+  }
+
+  // check inputs size
+  int n_inputs_expect = 1;
+  if (!no_scale_)
+    n_inputs_expect++;
+  if (!no_bias_)
+    n_inputs_expect++;
+  NBLA_CHECK(n_inputs == n_inputs_expect, error_code::value,
+             "Number of inputs must be 1, 2 or 3.");
+
+  // check batch_axis
+  for (int i = 0; i < batch_axis_.size(); i++) {
+    const auto ba = batch_axis_[i];
+    NBLA_CHECK(0 <= ba && ba < ndim, error_code::value,
+               "each element of batch_axis must be in the range of [0, ndim). "
+               "batch_axis[%d] : %d, ndim: {}.",
+               i, ba, ndim);
+  }
+
+  // check param shapes
+  const auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  const auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+  if (beta) {
+    const auto beta_shape = beta->shape();
+    NBLA_CHECK(tn_param_shape == beta_shape, error_code::value,
+               "Shape of beta(inputs[1]) does not match. "
+               "beta: (%s) != expected: (%s).",
+               string_join(beta_shape, string(", ")).c_str(),
+               string_join(tn_param_shape, string(", ")).c_str());
+  }
+  if (gamma) {
+    const auto gamma_shape = gamma->shape();
+    NBLA_CHECK(tn_param_shape == gamma_shape, error_code::value,
+               "Shape of gamma(inputs[1]) does not match. "
+               "gamma: (%s) != expected: (%s).",
+               string_join(gamma_shape, string(", ")).c_str(),
+               string_join(tn_param_shape, string(", ")).c_str());
+  }
+
+  // calculate the shape of beta and gamma for tensor norm
+  tn_shape_ = Shape_t(ndim, 1);
+  for (auto a : tn_axes) {
+    tn_shape_[a] = x_shape[a];
+  }
+
+  // reshape outputs
+  outputs[0]->reshape(x_shape, true);
+  if (output_stat_) {
+    outputs[1]->reshape(tn_shape_, true); // batch mean
+    outputs[2]->reshape(tn_shape_, true); // batch var
+  }
+
+  // functions
+  f_tensor_norm_ = create_TensorNormalization(
+      ctx_, tn_axes, eps_, true /* no_scale */, true /* no_bias */);
+  if (!no_scale_)
+    f_mul2_ = create_Mul2(ctx_, false);
+  if (!no_bias_)
+    f_add2_ = create_Add2(ctx_, false);
+}
+
+template <typename T>
+void LayerNormalization<T>::forward_impl(const Variables &inputs,
+                                         const Variables &outputs) {
+  // variables for affine
+  auto bias = no_bias_ ? nullptr : inputs[beta_idx_];
+  auto scale = no_scale_ ? nullptr : inputs[gamma_idx_];
+
+  // tensor norm
+  const auto tn_inputs = Variables{inputs[0]}; // no beta and gamma
+  nbla::execute(f_tensor_norm_, tn_inputs, outputs);
+
+  // apply affine
+  auto y = outputs[0];
+  if (scale) {
+    nbla::execute(f_mul2_, Variables{y, scale}, Variables{y});
+  }
+  if (bias) {
+    nbla::execute(f_add2_, Variables{y, bias}, Variables{y});
+  }
+}
+
+template <typename T>
+void LayerNormalization<T>::backward_impl(const Variables &inputs,
+                                          const Variables &outputs,
+                                          const vector<bool> &propagate_down,
+                                          const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+
+  // tensor norm variables
+  Variable out_tn_y_buf;
+  Variable *out_tn_y = no_scale_ && no_bias_ ? outputs[0] : &out_tn_y_buf;
+  const auto tn_inputs = Variables{inputs[0]}; // no beta and gamma
+  const auto tn_outputs = output_stat_
+                              ? Variables{out_tn_y, outputs[1], outputs[2]}
+                              : Variables{out_tn_y};
+
+  // variables for affine
+  Variable out_mul2;
+  auto bias = no_bias_ ? nullptr : inputs[beta_idx_];
+  auto scale = no_scale_ ? nullptr : inputs[gamma_idx_];
+  const auto mul2_inputs = Variables{out_tn_y, scale};
+  const auto mul2_outputs = bias ? Variables{&out_mul2} : Variables{outputs[0]};
+  const auto add2_inputs =
+      scale ? Variables{&out_mul2, bias} : Variables{out_tn_y, bias};
+  const auto add2_outputs = Variables{outputs[0]};
+
+  // forward (tensor_norm -> affine)
+
+  nbla::execute(f_tensor_norm_, tn_inputs, tn_outputs);
+
+  if (scale) {
+    nbla::execute(f_mul2_, mul2_inputs, mul2_outputs);
+  }
+  if (bias) {
+    nbla::execute(f_add2_, add2_inputs, add2_outputs);
+  }
+
+  // backward (affine -> tensor_norm)
+
+  if (bias) {
+    nbla::backward(f_add2_, add2_inputs, add2_outputs,
+                   {true, propagate_down[beta_idx_]},
+                   {false, accum[beta_idx_]});
+  }
+  if (scale) {
+    nbla::backward(f_mul2_, mul2_inputs, mul2_outputs,
+                   {true, propagate_down[gamma_idx_]},
+                   {false, accum[gamma_idx_]});
+  }
+
+  if (propagate_down[0]) {
+    nbla::backward(f_tensor_norm_, tn_inputs, tn_outputs, {true}, {accum[0]});
+  }
+}
+}

--- a/src/nbla/function/generic/tensor_normalization.cpp
+++ b/src/nbla/function/generic/tensor_normalization.cpp
@@ -35,7 +35,7 @@ void TensorNormalization<T>::setup_impl(const Variables &inputs,
   }
 
   // check inputs size
-  int n_inputs_expect = 1;
+  size_t n_inputs_expect = 1;
   if (!no_scale_)
     n_inputs_expect++;
   if (!no_bias_)

--- a/src/nbla/function/generic/tensor_normalization.cpp
+++ b/src/nbla/function/generic/tensor_normalization.cpp
@@ -1,0 +1,217 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/tensor_normalization.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(TensorNormalization, const vector<int> &, float,
+                              bool, bool);
+
+template <typename T>
+void TensorNormalization<T>::setup_impl(const Variables &inputs,
+                                        const Variables &outputs) {
+  const auto x_shape = inputs[0]->shape();
+  const auto ndim = x_shape.size();
+  beta_idx_ = no_bias_ ? -1 : 1;
+  gamma_idx_ = no_scale_ ? -1 : no_bias_ ? 1 : 2;
+  bn_param_shape_ = Shape_t(ndim, 1);
+  for (auto a : axes_) {
+    bn_param_shape_[a] = x_shape[a];
+  }
+
+  // check inputs size
+  int n_inputs_expect = 1;
+  if (!no_scale_)
+    n_inputs_expect++;
+  if (!no_bias_)
+    n_inputs_expect++;
+  NBLA_CHECK(inputs.size() == n_inputs_expect, error_code::value,
+             "Number of inputs must be 1, 2 or 3.");
+
+  // check param shapes
+  const auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  const auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+  if (beta) {
+    const auto beta_shape = beta->shape();
+    NBLA_CHECK(bn_param_shape_ == beta_shape, error_code::value,
+               "Shape of beta(inputs[%d]) does not match. "
+               "beta: (%s) != expected: (%s).",
+               beta_idx_, string_join(beta_shape, string(", ")).c_str(),
+               string_join(bn_param_shape_, string(", ")).c_str());
+  }
+  if (gamma) {
+    const auto gamma_shape = gamma->shape();
+    NBLA_CHECK(bn_param_shape_ == gamma_shape, error_code::value,
+               "Shape of gamma(inputs[%d]) does not match. "
+               "gamma: (%s) != expected: (%s).",
+               gamma_idx_, string_join(gamma_shape, string(", ")).c_str(),
+               string_join(bn_param_shape_, string(", ")).c_str());
+  }
+
+  output_stat_ = outputs.size() == 3;
+
+  // reshape outputs
+  outputs[0]->reshape(x_shape, true);
+  if (output_stat_) {
+    outputs[1]->reshape(bn_param_shape_, true); // batch mean
+    outputs[2]->reshape(bn_param_shape_, true); // batch var
+  }
+
+  // batch_norm adapter
+  bn_in_adapter_.reset(
+      new BatchNormalizationInOutAdapter(ctx_, ndim, x_shape, axes_));
+  bn_param_adapter_.reset(
+      new BatchNormalizationInOutAdapter(ctx_, ndim, bn_param_shape_, axes_));
+
+  // function
+  const vector<int> bn_axes = {static_cast<int>(ndim - axes_.size())};
+  f_batch_norm_ = create_BatchNormalization(ctx_, bn_axes, 0. /* decay_rate */,
+                                            eps_, true /* batch_stat */);
+}
+
+template <typename T>
+void TensorNormalization<T>::forward_impl(const Variables &inputs,
+                                          const Variables &outputs) {
+  // tensor norm variables
+  auto x = inputs[0];
+  auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+
+  // batch norm variables
+  Variable bn_x, bn_beta, bn_gamma, bn_in_mean, bn_in_variance;
+  Variable bn_y, bn_out_mean, bn_out_variance;
+  Variable dummy_beta,
+      dummy_gamma;                // dummy used when beta and gamma are optional
+  Variable mean(bn_param_shape_); // dummy
+  Variable variance(bn_param_shape_); // dummy
+  if (!beta) {
+    dummy_beta.reshape(bn_param_shape_, true);
+    dummy_beta.data()->zero();
+    beta = &dummy_beta;
+  }
+  if (!gamma) {
+    dummy_gamma.reshape(bn_param_shape_, true);
+    dummy_gamma.data()->fill(1.);
+    gamma = &dummy_gamma;
+  }
+
+  const auto bn_inputs =
+      Variables{&bn_x, &bn_beta, &bn_gamma, &bn_in_mean, &bn_in_variance};
+  const auto bn_outputs = output_stat_
+                              ? Variables{&bn_y, &bn_out_mean, &bn_out_variance}
+                              : Variables{&bn_y};
+
+  bn_in_adapter_->pre_op(x, &bn_x);
+  bn_param_adapter_->pre_op(beta, &bn_beta);
+  bn_param_adapter_->pre_op(gamma, &bn_gamma);
+  bn_param_adapter_->pre_op(&mean, &bn_in_mean);
+  bn_param_adapter_->pre_op(&variance, &bn_in_variance);
+
+  nbla::execute(f_batch_norm_, bn_inputs, bn_outputs);
+
+  bn_in_adapter_->post_op(&bn_y, outputs[0]);
+  if (output_stat_) {
+    bn_param_adapter_->post_op(&bn_out_mean, outputs[1]);
+    bn_param_adapter_->post_op(&bn_out_variance, outputs[2]);
+  }
+}
+
+template <typename T>
+void TensorNormalization<T>::backward_impl(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &propagate_down,
+                                           const vector<bool> &accum) {
+  if (!(propagate_down[0] || (inputs.size() > 1 && propagate_down[1]) ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+
+  // tensor norm variables
+  const auto x = inputs[0];
+  auto beta = no_bias_ ? nullptr : inputs[beta_idx_];
+  auto gamma = no_scale_ ? nullptr : inputs[gamma_idx_];
+
+  // batch norm variables
+  Variable bn_x, bn_beta, bn_gamma, bn_in_mean, bn_in_variance;
+  Variable bn_y, bn_out_mean, bn_out_variance;
+  Variable dummy_beta,
+      dummy_gamma;                // dummy used when beta and gamma is optional
+  Variable mean(bn_param_shape_); // dummy
+  Variable variance(bn_param_shape_); // dummy
+  if (!beta) {
+    dummy_beta.reshape(bn_param_shape_, true);
+    dummy_beta.data()->zero();
+    beta = &dummy_beta;
+  }
+  if (!gamma) {
+    dummy_gamma.reshape(bn_param_shape_, true);
+    dummy_gamma.data()->fill(1.);
+    gamma = &dummy_gamma;
+  }
+
+  // synonyms
+  const auto bn_inputs =
+      Variables{&bn_x, &bn_beta, &bn_gamma, &bn_in_mean, &bn_in_variance};
+  const auto bn_outputs = output_stat_
+                              ? Variables{&bn_y, &bn_out_mean, &bn_out_variance}
+                              : Variables{&bn_y};
+  const auto pd = propagate_down;
+  const bool pd_beta = no_bias_ ? false : pd[beta_idx_];
+  const bool pd_gamma = no_scale_ ? false : pd[gamma_idx_];
+  const bool pd_param = pd_beta || pd_gamma;
+  // propagate_down of beta and gamma must be same in batch_norm
+  vector<bool> bn_pd = {pd[0], pd_param, pd_param, false, false};
+  const vector<bool> bn_accum(5, false);
+
+  // forward (in_adapter -> batch_norm -> out_adapter)
+
+  bn_in_adapter_->pre_op(x, &bn_x);
+  bn_param_adapter_->pre_op(beta, &bn_beta);
+  bn_param_adapter_->pre_op(gamma, &bn_gamma);
+  bn_param_adapter_->pre_op(&mean, &bn_in_mean);
+  bn_param_adapter_->pre_op(&variance, &bn_in_variance);
+
+  nbla::execute(f_batch_norm_, bn_inputs, bn_outputs);
+
+  bn_in_adapter_->post_op(&bn_y, outputs[0]);
+  if (output_stat_) {
+    bn_param_adapter_->post_op(&bn_out_mean, outputs[1]);
+    bn_param_adapter_->post_op(&bn_out_variance, outputs[2]);
+  }
+
+  // backward (out_adapter -> batch_norm -> in_adapter)
+
+  bn_in_adapter_->post_op_backward(&bn_y, outputs[0], true, false);
+  if (output_stat_) {
+    bn_param_adapter_->post_op_backward(&bn_out_mean, outputs[1], true, false);
+    bn_param_adapter_->post_op_backward(&bn_out_variance, outputs[2], true,
+                                        false);
+  }
+
+  nbla::backward(f_batch_norm_, bn_inputs, bn_outputs, bn_pd, bn_accum);
+
+  bn_in_adapter_->pre_op_backward(x, &bn_x, pd[0], accum[0]);
+  if (pd_beta) {
+    bn_param_adapter_->pre_op_backward(beta, &bn_beta, true, accum[beta_idx_]);
+  }
+  if (pd_gamma) {
+    bn_param_adapter_->pre_op_backward(gamma, &bn_gamma, true,
+                                       accum[gamma_idx_]);
+  }
+}
+}

--- a/src/nbla/function/generic/weight_standardization.cpp
+++ b/src/nbla/function/generic/weight_standardization.cpp
@@ -28,7 +28,7 @@ template <typename T>
 void WeightStandardization<T>::setup_impl(const Variables &inputs,
                                           const Variables &outputs) {
   const auto w_shape = inputs[0]->shape();
-  const auto ndim = w_shape.size();
+  const int ndim = w_shape.size();
 
   // check chennel_axis
   NBLA_CHECK(0 <= channel_axis_ && channel_axis_ < ndim, error_code::value,

--- a/src/nbla/function/generic/weight_standardization.cpp
+++ b/src/nbla/function/generic/weight_standardization.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/weight_standardization.hpp>
+#include <nbla/variable.hpp>
+
+#include <nbla/function/tensor_normalization.hpp>
+#include <nbla/imperative.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(WeightStandardization, int, float);
+
+template <typename T>
+void WeightStandardization<T>::setup_impl(const Variables &inputs,
+                                          const Variables &outputs) {
+  const auto w_shape = inputs[0]->shape();
+  const auto ndim = w_shape.size();
+
+  // check chennel_axis
+  NBLA_CHECK(0 <= channel_axis_ && channel_axis_ < ndim, error_code::value,
+             "channel_axis must be in the range of [0, ndim). channel_axis : "
+             "%d, ndim: {}.",
+             channel_axis_, ndim);
+
+  // convert channel_axis to axes for tensor_norm
+  const vector<int> tn_axes = {channel_axis_};
+
+  f_tensor_norm_ = create_TensorNormalization(
+      ctx_, tn_axes, eps_, true /* no_scale */, true /* no_bias */);
+  f_tensor_norm_->setup(inputs, outputs);
+}
+
+template <typename T>
+void WeightStandardization<T>::forward_impl(const Variables &inputs,
+                                            const Variables &outputs) {
+  nbla::execute(f_tensor_norm_, inputs, outputs);
+}
+
+template <typename T>
+void WeightStandardization<T>::backward_impl(const Variables &inputs,
+                                             const Variables &outputs,
+                                             const vector<bool> &propagate_down,
+                                             const vector<bool> &accum) {
+  if (!propagate_down[0]) {
+    return;
+  }
+
+  nbla::backward(f_tensor_norm_, inputs, outputs, propagate_down, accum);
+}
+}

--- a/src/nbla/functions.cpp.tmpl
+++ b/src/nbla/functions.cpp.tmpl
@@ -216,8 +216,8 @@ vector<CgVariablePtr> deconvolution(Context &ctx, CgVariablePtr x, CgVariablePtr
   return deconvolution(ctx, x, weight, bias, base_axis, opts.pad(), opts.stride(), opts.dilation(), group, opts.channel_last(), opts.output_padding());
 }
 
-vector<CgVariablePtr> batch_normalization(Context &ctx, CgVariablePtr x, CgVariablePtr beta, CgVariablePtr gamma, CgVariablePtr mean, CgVariablePtr variance, bool batch_stat, BatchNormalizationOpts batch_opts){
-  return batch_normalization(ctx, x, beta, gamma, mean, variance, batch_opts.axes(), batch_opts.decay_rate(), batch_opts.eps(), batch_stat);
+vector<CgVariablePtr> batch_normalization(Context &ctx, CgVariablePtr x, CgVariablePtr beta, CgVariablePtr gamma, CgVariablePtr mean, CgVariablePtr variance, bool batch_stat, bool no_scale, bool no_bias, BatchNormalizationOpts batch_opts){
+  return batch_normalization(ctx, x, beta, gamma, mean, variance, batch_opts.axes(), batch_opts.decay_rate(), batch_opts.eps(), batch_stat, no_scale, no_bias);
 }
 
 vector<CgVariablePtr> max_pooling(Context &ctx, CgVariablePtr x, const vector<int> & kernel, const vector<int> & stride, PoolingOpts pooling_opts){
@@ -260,9 +260,9 @@ CgVariablePtr deconvolution(CgVariablePtr x, CgVariablePtr weight, CgVariablePtr
   return deconvolution(global_ctx, x, weight, bias, base_axis, opts.pad(), opts.stride(), opts.dilation(), group, opts.channel_last(), opts.output_padding())[0];
 }
 
-CgVariablePtr batch_normalization(CgVariablePtr x, CgVariablePtr beta, CgVariablePtr gamma, CgVariablePtr mean, CgVariablePtr variance, bool batch_stat, BatchNormalizationOpts batch_opts){
+CgVariablePtr batch_normalization(CgVariablePtr x, CgVariablePtr beta, CgVariablePtr gamma, CgVariablePtr mean, CgVariablePtr variance, bool batch_stat, bool no_scale, bool no_bias, BatchNormalizationOpts batch_opts){
   auto global_ctx = SingletonManager::get<GlobalContext>()->get_current_context();
-  return batch_normalization(global_ctx, x, beta, gamma, mean, variance, batch_opts.axes(), batch_opts.decay_rate(), batch_opts.eps(), batch_stat)[0];
+  return batch_normalization(global_ctx, x, beta, gamma, mean, variance, batch_opts.axes(), batch_opts.decay_rate(), batch_opts.eps(), batch_stat, no_scale, no_bias)[0];
 }
 
 }

--- a/src/nbla/parametric_functions.cpp
+++ b/src/nbla/parametric_functions.cpp
@@ -572,7 +572,8 @@ batch_normalization(Context &ctx, CgVariablePtr x, const vector<int> &axes,
   bool execute_forward =
       SingletonManager::get<AutoForward>()->get_auto_forward();
   return connect(make_shared<CgFunction>(create_BatchNormalization(
-                     ctx, axes, decay_rate, eps, batch_stat)),
+                     ctx, axes, decay_rate, eps, batch_stat,
+                     false /* no_scale */, false /* no_bias */)),
                  {x, beta, gamma, mean, variance}, 1, {}, execute_forward);
 }
 


### PR DESCRIPTION
We ported the python-based implementation of the following normalization functions to the cpp-side and optimized these in memory and computation tradeoff.

- LayerNormalization
- InstanceNormalization
- GroupNormalization
- WeightStanderdization