### PR TITLE
fix comment error in .bat

### DIFF
--- a/build-tools/msvc/tools/python_env_cleanup.bat
+++ b/build-tools/msvc/tools/python_env_cleanup.bat
@@ -38,5 +38,5 @@ IF [%ENVNAME%] == [%CONDAENV%] (
    RMDIR /s /q %ENVDIR%
 )
 
-# Ignore error.
+REM Ignore error.
 EXIT /b 0


### PR DESCRIPTION
# cannot be used as comment in .bat file.
But it is not a fatal error.