### PR TITLE
Limit numpy version to 1.19.5

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -146,7 +146,6 @@ RUN umask 0 \
     && . /opt/miniconda3/bin/activate \
     && conda create -n nnabla-build python=${PYVERNAME} \
     && conda activate nnabla-build \
-    && pip install numpy \
     && pip install -U -r /tmp/deps/setup_requirements.txt \
     && pip install -U -r /tmp/deps/requirements.txt \
     && pip install -U -r /tmp/deps/test_requirements.txt \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ Cython
 boto3
 h5py
 imageio
-numpy
+numpy==1.19.5
 pillow
 protobuf
 pyyaml


### PR DESCRIPTION
When compiling nnabla on numpy >= 1.20.x, the nnabla wheel will not run on numpy <= 1.19.x. In order to maximize the compability of nnabla package, we required compile nnabla on a relative low numpy version, for example, numpy== 1.19.5. In this fix, we tend to limit numpy in build docker to 1.19.5 so that we can build a version can work on numpy 1.19.x.