### PR TITLE
fix nnp refactor memory problem

### DIFF
--- a/python/src/nnabla/utils/cli/train.py
+++ b/python/src/nnabla/utils/cli/train.py
@@ -322,7 +322,7 @@ def _evaluate(args, config, monitoring_report, best_error, epoch, scheduler):
 
             with scheduler:
                 # Forward recursive
-                m.target.forward(clear_no_need_grad=True)
+                m.target.forward(clear_no_need_grad=True, clear_buffer=True)
 
         # Sum error at the end of dataset
         error_sum = 0.0


### PR DESCRIPTION
This commit is to fix memory issue after nnp refactor.  `clear_buffer=True` is necessary for evaluation forward. If this option is not set, cuda memory usage becomes big especially when start to evalution step, and program might crash for 'no memory' when exit.
