### PR TITLE
limit h5py version to 3.1.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 Cython
 boto3
-h5py
+h5py==3.1.0
 imageio
 numpy==1.19.5
 pillow

--- a/python/setup.py
+++ b/python/setup.py
@@ -31,7 +31,7 @@ install_requires = setup_requires + [
     'boto3',
     'configparser',
     'contextlib2',
-    'h5py',
+    'h5py==3.1.0',
     'protobuf>=3.6',
     'pyyaml',
     'requests',


### PR DESCRIPTION
On some environment, build was failed because latest h5py no longer supports python3.6.
So, fixed h5py to v3.1.0.