### PR TITLE
Add stop_exhausted option for data_iterator

### DIFF
--- a/python/src/nnabla/utils/data_iterator.py
+++ b/python/src/nnabla/utils/data_iterator.py
@@ -46,12 +46,19 @@ class DataIterator(object):
         batch_size (int): Size of data unit.
         rng (None or :obj:`numpy.random.RandomState`): Numpy random number
             generator.
+        use_thread (bool): If ``use_thread`` is set to True, iterator will use another
+            thread to fetch data. If ``use_thread`` is set to False, iterator will use
+            current thread to fetch data.
         epoch_begin_callbacks (list of functions): An item is a function
             which takes an epoch index as a argument. These are called
             at the beginning of an epoch.
         epoch_end_callbacks (list of functions): An item is a function
             which takes an epoch index as a argument. These are called
             at the end of an epoch.
+        stop_exhausted (bool): If ``stop_exhausted`` is set to False, iterator will be reset
+            so that iteration can be continued. If ``stop_exhausted`` is set to True, iterator
+            will raise StopIteration to stop the loop.
+
 
     '''
 
@@ -61,10 +68,12 @@ class DataIterator(object):
                  rng=None,
                  use_thread=True,
                  epoch_begin_callbacks=[],
-                 epoch_end_callbacks=[]):
+                 epoch_end_callbacks=[],
+                 stop_exhausted=False):
         logger.info('Using DataIterator')
         if rng is None:
             rng = numpy.random.RandomState(313)
+        self._stop_exhausted = stop_exhausted
         self._rng = rng
         self._shape = None       # Only use with padding
         self._data_position = 0  # Only use with padding
@@ -182,14 +191,18 @@ class DataIterator(object):
     def _next(self):
         data = [[] for x in self._variables]
 
-        for b in range(self._batch_size):
+        if self._data_source.position + self._batch_size > self._size:
+            if self._stop_exhausted:
+                self._current_data = None
+                return
 
+        for b in range(self._batch_size):
             d = self._data_source.next()
             if d is None:
                 self._current_data = None
                 return
 
-            if self._data_source.position >= self._size:
+            if self._data_source.position >= self._size and not self._stop_exhausted:
                 self._reset()
 
             for i, v in enumerate(self._variables):
@@ -215,16 +228,21 @@ class DataIterator(object):
             self._next_thread.join()
 
             if self._current_data is None:
+                if self._stop_exhausted and self._data_source.position + self._batch_size >= self._size:
+                    raise StopIteration
                 logger.log(99, 'next() got None retrying.')
                 self._next_thread = threading.Thread(target=self._next)
                 self._next_thread.start()
                 self._next_thread.join()
+
             self._current_epoch, data = self._current_data
             # Start next thread.
             self._next_thread = threading.Thread(target=self._next)
             self._next_thread.start()
         else:
             self._next()
+            if self._current_data is None:
+                raise StopIteration
             self._current_epoch, data = self._current_data
 
         return data
@@ -359,11 +377,13 @@ class DataIterator(object):
 def data_iterator(data_source,
                   batch_size,
                   rng=None,
+                  use_thread=True,
                   with_memory_cache=True,
                   with_file_cache=False,
                   cache_dir=None,
                   epoch_begin_callbacks=[],
-                  epoch_end_callbacks=[]):
+                  epoch_end_callbacks=[],
+                  stop_exhausted=False):
     '''data_iterator
     Helper method to use :py:class:`DataSource <nnabla.utils.data_source.DataSource>`.
 
@@ -384,6 +404,10 @@ def data_iterator(data_source,
         batch_size (int): Batch size.
         rng (None or :obj:`numpy.random.RandomState`): Numpy random number
             generator.
+        use_thread (bool): 
+            If ``use_thread`` is set to True, iterator will use another thread to 
+            fetch data. If ``use_thread`` is set to False, iterator will use
+            current thread to fetch data.
         with_memory_cache (bool):
             If ``True``, use :py:class:`.data_source.DataSourceWithMemoryCache`
             to wrap ``data_source``. It is a good idea to set this as true unless
@@ -407,6 +431,9 @@ def data_iterator(data_source,
         epoch_end_callbacks (list of functions): An item is a function
             which takes an epoch index as an argument. These are called
             at the end of an epoch.
+        stop_exhausted (bool): If ``stop_exhausted`` is set to False, iterator will be reset
+            so that iteration can be continued. If ``stop_exhausted`` is set to True, iterator
+            will raise StopIteration to stop the loop.
 
     Returns:
         :py:class:`DataIterator <nnabla.utils.data_iterator.DataIterator>`:
@@ -423,16 +450,20 @@ def data_iterator(data_source,
                                            rng=rng)
         return DataIterator(ds,
                             batch_size,
+                            use_thread=use_thread,
                             epoch_begin_callbacks=epoch_begin_callbacks,
-                            epoch_end_callbacks=epoch_end_callbacks)
+                            epoch_end_callbacks=epoch_end_callbacks,
+                            stop_exhausted=stop_exhausted)
     else:
         if with_memory_cache:
             data_source = DataSourceWithMemoryCache(data_source,
                                                     shuffle=data_source.shuffle,
                                                     rng=rng)
         return DataIterator(data_source, batch_size,
+                            use_thread=use_thread,
                             epoch_begin_callbacks=epoch_begin_callbacks,
-                            epoch_end_callbacks=epoch_end_callbacks)
+                            epoch_end_callbacks=epoch_end_callbacks,
+                            stop_exhausted=stop_exhausted)
 
 
 def data_iterator_simple(load_func,
@@ -440,11 +471,13 @@ def data_iterator_simple(load_func,
                          batch_size,
                          shuffle=False,
                          rng=None,
+                         use_thread=True,
                          with_memory_cache=True,
                          with_file_cache=True,
                          cache_dir=None,
                          epoch_begin_callbacks=[],
-                         epoch_end_callbacks=[]):
+                         epoch_end_callbacks=[],
+                         stop_exhausted=False):
     """A generator that ``yield`` s minibatch data as a tuple, as defined in ``load_func`` .
     It can unlimitedly yield minibatches at your request, queried from the provided data.
 
@@ -461,6 +494,10 @@ def data_iterator_simple(load_func,
              Default value is False. 
         rng (None or :obj:`numpy.random.RandomState`): Numpy random number
             generator.
+        use_thread (bool): 
+            If ``use_thread`` is set to True, iterator will use another thread to 
+            fetch data. If ``use_thread`` is set to False, iterator will use
+            current thread to fetch data.
         with_memory_cache (bool):
             If ``True``, use :py:class:`.data_source.DataSourceWithMemoryCache`
             to wrap ``data_source``. It is a good idea to set this as true unless
@@ -484,6 +521,9 @@ def data_iterator_simple(load_func,
         epoch_end_callbacks (list of functions): An item is a function
             which takes an epoch index as an argument. These are called
             at the end of an epoch.
+        stop_exhausted (bool): If ``stop_exhausted`` is set to False, iterator will be reset
+            so that iteration can be continued. If ``stop_exhausted`` is set to True, iterator
+            will raise StopIteration to stop the loop.
 
 
     Returns:
@@ -515,24 +555,28 @@ def data_iterator_simple(load_func,
                                           num_examples,
                                           shuffle=shuffle,
                                           rng=rng),
+                         use_thread=use_thread,
                          batch_size=batch_size,
                          with_memory_cache=with_memory_cache,
                          with_file_cache=with_file_cache,
                          cache_dir=cache_dir,
                          epoch_begin_callbacks=epoch_begin_callbacks,
-                         epoch_end_callbacks=epoch_end_callbacks)
+                         epoch_end_callbacks=epoch_end_callbacks,
+                         stop_exhausted=stop_exhausted)
 
 
 def data_iterator_csv_dataset(uri,
                               batch_size,
                               shuffle=False,
                               rng=None,
+                              use_thread=True,
                               normalize=True,
                               with_memory_cache=True,
                               with_file_cache=True,
                               cache_dir=None,
                               epoch_begin_callbacks=[],
-                              epoch_end_callbacks=[]):
+                              epoch_end_callbacks=[],
+                              stop_exhausted=False):
     '''data_iterator_csv_dataset
     Get data directly from a dataset provided as a CSV file.
 
@@ -552,6 +596,10 @@ def data_iterator_csv_dataset(uri,
              Default value is False. 
         rng (None or :obj:`numpy.random.RandomState`): Numpy random number
             generator.
+        use_thread (bool): 
+            If ``use_thread`` is set to True, iterator will use another thread to 
+            fetch data. If ``use_thread`` is set to False, iterator will use
+            current thread to fetch data.
         normalize (bool): If True, each sample in the data gets normalized by a factor of 255. 
             Default is True.
         with_memory_cache (bool):
@@ -577,6 +625,9 @@ def data_iterator_csv_dataset(uri,
         epoch_end_callbacks (list of functions): An item is a function
             which takes an epoch index as an argument. These are called
             at the end of an epoch.
+        stop_exhausted (bool): If ``stop_exhausted`` is set to False, iterator will be reset
+            so that iteration can be continued. If ``stop_exhausted`` is set to True, iterator
+            will raise StopIteration to stop the loop.
 
 
     Returns:
@@ -589,22 +640,26 @@ def data_iterator_csv_dataset(uri,
                        normalize=normalize)
 
     return data_iterator(ds,
+                         use_thread=use_thread,
                          batch_size=batch_size,
                          with_memory_cache=with_memory_cache,
                          with_file_cache=with_file_cache,
                          cache_dir=cache_dir,
                          epoch_begin_callbacks=epoch_begin_callbacks,
-                         epoch_end_callbacks=epoch_end_callbacks)
+                         epoch_end_callbacks=epoch_end_callbacks,
+                         stop_exhausted=stop_exhausted)
 
 
 def data_iterator_cache(uri,
                         batch_size,
                         shuffle=False,
                         rng=None,
+                        use_thread=True,
                         normalize=True,
                         with_memory_cache=True,
                         epoch_begin_callbacks=[],
-                        epoch_end_callbacks=[]):
+                        epoch_end_callbacks=[],
+                        stop_exhausted=False):
     '''data_iterator_cache
     Get data from the cache directory.
 
@@ -624,6 +679,10 @@ def data_iterator_cache(uri,
              Default value is False. 
         rng (None or :obj:`numpy.random.RandomState`): Numpy random number
             generator.
+        use_thread (bool): 
+            If ``use_thread`` is set to True, iterator will use another thread to 
+            fetch data. If ``use_thread`` is set to False, iterator will use
+            current thread to fetch data.
         normalize (bool): If True, each sample in the data gets normalized by a factor of 255. 
             Default is True.
         with_memory_cache (bool):
@@ -637,6 +696,9 @@ def data_iterator_cache(uri,
         epoch_end_callbacks (list of functions): An item is a function
             which takes an epoch index as an argument. These are called
             at the end of an epoch.
+        stop_exhausted (bool): If ``stop_exhausted`` is set to False, iterator will be reset
+            so that iteration can be continued. If ``stop_exhausted`` is set to True, iterator
+            will raise StopIteration to stop the loop.
 
 
     Returns:
@@ -649,21 +711,25 @@ def data_iterator_cache(uri,
                          normalize=normalize)
 
     return data_iterator(ds,
+                         use_thread=use_thread,
                          batch_size=batch_size,
                          with_memory_cache=with_memory_cache,
                          epoch_begin_callbacks=epoch_begin_callbacks,
-                         epoch_end_callbacks=epoch_end_callbacks)
+                         epoch_end_callbacks=epoch_end_callbacks,
+                         stop_exhausted=stop_exhausted)
 
 
 def data_iterator_concat_datasets(data_source_list,
                                   batch_size,
                                   shuffle=False,
                                   rng=None,
+                                  use_thread=True,
                                   with_memory_cache=True,
                                   with_file_cache=False,
                                   cache_dir=None,
                                   epoch_begin_callbacks=[],
-                                  epoch_end_callbacks=[]):
+                                  epoch_end_callbacks=[],
+                                  stop_exhausted=False):
     '''data_iterator_concat_datasets
     Get data from multiple datasets.
 
@@ -681,6 +747,10 @@ def data_iterator_concat_datasets(data_source_list,
              Default value is False. 
         rng (None or :obj:`numpy.random.RandomState`): Numpy random number
             generator.
+        use_thread (bool): 
+            If ``use_thread`` is set to True, iterator will use another thread to 
+            fetch data. If ``use_thread`` is set to False, iterator will use
+            current thread to fetch data.
         with_memory_cache (bool):
             If ``True``, use :py:class:`.data_source.DataSourceWithMemoryCache`
             to wrap ``data_source``. It is a good idea to set this as true unless
@@ -704,6 +774,9 @@ def data_iterator_concat_datasets(data_source_list,
         epoch_end_callbacks (list of functions): An item is a function
             which takes an epoch index as an argument. These are called
             at the end of an epoch.
+        stop_exhausted (bool): If ``stop_exhausted`` is set to False, iterator will be reset
+            so that iteration can be continued. If ``stop_exhausted`` is set to True, iterator
+            will raise StopIteration to stop the loop.
 
 
     Returns:
@@ -714,8 +787,10 @@ def data_iterator_concat_datasets(data_source_list,
                           shuffle=shuffle,
                           rng=rng)
     return data_iterator(ds,
+                         use_thread=use_thread,
                          batch_size=batch_size,
                          with_memory_cache=with_memory_cache,
                          with_file_cache=with_file_cache,
                          epoch_begin_callbacks=epoch_begin_callbacks,
-                         epoch_end_callbacks=epoch_end_callbacks)
+                         epoch_end_callbacks=epoch_end_callbacks,
+                         stop_exhausted=stop_exhausted)


### PR DESCRIPTION
Our implementation reset the data source if position is exceed, but user requests to add StopIteration.
So, we add stop_exhausted option to data_iterator to allow user iterate all samples only once for each.