### PR TITLE
set h5py version <= 3.1.0

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,6 +1,6 @@
 Cython
 boto3
-h5py==3.1.0
+h5py<=3.1.0
 imageio
 numpy==1.19.5
 pillow

--- a/python/setup.py
+++ b/python/setup.py
@@ -31,7 +31,7 @@ install_requires = setup_requires + [
     'boto3',
     'configparser',
     'contextlib2',
-    'h5py==3.1.0',
+    'h5py<=3.1.0',
     'protobuf>=3.6',
     'pyyaml',
     'requests',


### PR DESCRIPTION
Allow h5py version limitation to 3.1.0 or lower.