### PR TITLE
L2-Norm initialization for weight normalization

### DIFF
--- a/doc/python/api/parametric_function.rst
+++ b/doc/python/api/parametric_function.rst
@@ -149,6 +149,10 @@ listed below.
 .. autoclass:: OrthogonalInitializer
     :show-inheritance:
 
+.. autoclass:: WeightNormalizationScaleInitializer
+    :show-inheritance:
+
+
 .. autofunction:: calc_normal_std_he_forward
 .. autofunction:: calc_normal_std_he_backward
 .. autofunction:: calc_normal_std_glorot

--- a/python/src/nnabla/initializer.py
+++ b/python/src/nnabla/initializer.py
@@ -267,6 +267,32 @@ class OrthogonalInitializer(BaseInitializer):
         return random_float_type(q.reshape(shape) * self.gain)
 
 
+class WeightNormalizationScaleInitializer(BaseInitializer):
+
+    r"""Compute the L2-norm for each weight kernel.
+
+    This initializer is specific to the weight normalization scale to keep the same magnitude of the originally initialized weights even after the applicaiton of the weight normalization at only initialization.
+
+    Args:
+        w (:obj:`Variable`): Weight the weight normalization is applied.
+        dim (:obj:`int`): Output dimension of the weight normalization.
+        eps (:obj:`float`): Eplision of the weight normalization.
+    """
+
+    def __init__(self, w, dim=0, eps=1e-12):
+        self.w = w.get_unlinked_variable()
+        self.dim = dim
+        self.eps = eps
+
+    def __repr__(self):
+        return '{}({})'.format(self.__class__.__name__)
+
+    def __call__(self, shape):
+        axis = tuple([a for a in range(len(self.w.shape)) if a != self.dim])
+        w_norm_data = np.sqrt(np.sum(self.w.d ** 2, axis=axis) + self.eps)
+        return random_float_type(w_norm_data)
+
+
 def calc_normal_std_he_forward(inmaps, outmaps, kernel=(1, 1)):
     r"""Calculates the standard deviation proposed by He et al.
 

--- a/python/test/test_initializer.py
+++ b/python/test/test_initializer.py
@@ -15,7 +15,7 @@
 import pytest
 import numpy as np
 
-
+import nnabla as nn
 import nnabla.initializer as I
 
 
@@ -28,6 +28,28 @@ def orthogonal_test(x):
     else:
         target = np.matmul(flattened, flattened.T)
         return np.allclose(target, np.eye(rows), atol=1e-6)
+
+
+@pytest.mark.parametrize('shape, dim', [((2, 3), 1),
+                                        ((2, 3, 4, 5), 0),
+                                        ((2, 3, 4, 5), 3),
+                                        ])
+@pytest.mark.parametrize('eps', [1e-12])
+def test_weight_normalization_initializaer(shape, dim, eps):
+    rng = np.random.RandomState(313)
+
+    # Same w returns same results
+    w = nn.Variable.from_numpy_array(rng.randn(*shape))
+    initializer = I.WeightNormalizationScaleInitializer(w, dim, eps)
+    ret0 = initializer(w.shape)
+    ret1 = initializer(w.shape)
+    np.testing.assert_allclose(ret0, ret1)
+
+    # Different w return different results
+    w = nn.Variable.from_numpy_array(rng.randn(*shape))
+    initializer = I.WeightNormalizationScaleInitializer(w, dim, eps)
+    ret1 = initializer(w.shape)
+    assert np.any(ret0 != ret1)
 
 
 @pytest.mark.parametrize('rng', [None, np.random.RandomState(313)])

--- a/python/test/test_parametric_functions.py
+++ b/python/test/test_parametric_functions.py
@@ -1600,10 +1600,10 @@ def test_pf_transformer_decode_execution(g_rng, tgt_len, batch_size, embed_dim, 
 def test_pf_weight_norm_execution(g_rng, func):
     # python implementation
     def ref_weight_normalization(v, g, dim, eps=1e-12):
-        axis = tuple([i for i in range(len(v.shape)) if i != dim])
-        v_norm = np.sqrt(np.sum(v ** 2, axis=axis, keepdims=True) + eps)
-
-        return g * v / v_norm
+        # Use the same w in the initialization time.
+        # Since unless we use the same magnitude of weights,
+        # glorot/he initialization does not work as expected.
+        return v
 
     dim = {"conv": 0, "affine": 1}[func]
 

--- a/python/test/test_parametric_functions.py
+++ b/python/test/test_parametric_functions.py
@@ -1611,7 +1611,7 @@ def test_pf_weight_norm_execution(g_rng, func):
 
     x = nn.Variable.from_numpy_array(g_rng.randn(2, 4, 5, 5))
     if func == "conv":
-        # assume channle first
+        # assume channel first
         y = PF.convolution(x, 8, (3, 3), apply_w=wn_clbk)
     elif func == "affine":
         y = PF.affine(x, 8, apply_w=wn_clbk)


### PR DESCRIPTION
Two changes:
- PF.weight_normalization takes the initializer for the scale parameter
- Change the initial value of the scale of the weight normalization to L2-Norm of the initialized weights, such that the initial magnitude of the weights is kept, and the glorot/he initialization works as expected.