### PR TITLE
fix nnpload no variable name problem

### DIFF
--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -46,6 +46,9 @@ class NnpNetwork(object):
         proto_network = proto_network.expand_loop_control()
         self.proto_network = proto_network.promote(callback)
         self.proto_network(batch_size=batch_size)
+        for k, v in itertools.chain(
+                self.proto_network.variables.items(), self.proto_network.parameters.items()):
+            v.variable_instance.name = k
         self._inputs = {
             i: self.proto_network.variables[i].variable_instance
             for i in self.proto_network.inputs

--- a/python/test/core/test_nnp_graph.py
+++ b/python/test/core/test_nnp_graph.py
@@ -57,7 +57,7 @@ def nnp_check(nnp, side, callback=None):
         for k in sorted(network.variables.keys()):
             print('variables', side, k, '{}, {}'.format(
                 network.variables[k].shape, network.variables[k].d.shape))
-            yield (k, network.variables[k])
+            yield (k, network.variables[k], network.variables[k].name)
 
         for k in sorted(network.inputs.keys()):
             print('inputs', side, k, '{}, {}'.format(
@@ -77,9 +77,10 @@ def compare_nn_variable_metadata(ref_v, v):
 
 
 def compare_nn_variable_with_name(ref_v, v):
-    ref_v_name, ref_var = ref_v
-    v_name, var = v
+    ref_v_name, ref_var, ref_v_dot_name = ref_v
+    v_name, var, v_dot_name = v
     assert ref_v_name == v_name
+    assert v_dot_name == ref_v_dot_name
     assert ref_var.d.shape == var.d.shape
     assert ref_var.need_grad == var.need_grad
     if ref_v_name[-2:] in ['/b', '/W']:


### PR DESCRIPTION
This commit tends to fix the problem of no variable name. When a network returns from NnpLoader(), in previous implementation, the name of variable is properly set, but in refactor-ed version, this variable name is not properly set. This fix can resolve this problem, although it looks a bit ugle.