### PR TITLE
 No grad context and converter

### DIFF
--- a/doc/python/api/computation_graph.rst
+++ b/doc/python/api/computation_graph.rst
@@ -10,3 +10,5 @@ Computation Graph
 .. automodule:: nnabla
 
 .. autofunction:: forward_all
+
+.. autofunction:: no_grad

--- a/python/src/nnabla/__init__.py
+++ b/python/src/nnabla/__init__.py
@@ -33,7 +33,8 @@ from ._nd_array import NdArray
 from .parameter import (
     get_current_parameter_scope,
     parameter_scope, get_parameters, clear_parameters,
-    load_parameters, save_parameters)
+    load_parameters, save_parameters,
+    no_grad)
 from .context import (
     context_scope, set_default_context, get_current_context)
 from .auto_forward import auto_forward, set_auto_forward, get_auto_forward

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -851,6 +851,27 @@ cdef class Variable:
             (< Variable > var).varp.set_need_grad(self.varp.need_grad_state())
         return var
 
+    def no_grad(self):
+        """No gradients for the whole network.
+
+        This method is like :obj:`nnabla.no_grad` but can be used for the static network only, and useful for 
+        the case where the network is loaded from NNP format.
+        
+        Example:
+
+            .. code-block:: python
+
+                x = nn.Variable.from_numpy_array([2, 3])
+                y = <Network>(x).no_grad()
+        """
+
+        import nnabla.experimental.graph_converters as GC
+        modifiers = [GC.NoGradModifier()]
+        gc = GC.GraphConverter(modifiers)
+        out = gc.convert(self)
+        return out
+        
+
     @property
     def persistent(self):
         """

--- a/python/src/nnabla/experimental/graph_converters/__init__.py
+++ b/python/src/nnabla/experimental/graph_converters/__init__.py
@@ -26,3 +26,4 @@ from .remove_function import RemoveFunctionModifier
 from .batch_norm_batchstat import BatchNormBatchStatModifier
 from .test_mode import TestModeModifier
 from .identity import IdentityModifier
+from .no_grad import NoGradModifier

--- a/python/src/nnabla/experimental/graph_converters/no_grad.py
+++ b/python/src/nnabla/experimental/graph_converters/no_grad.py
@@ -1,0 +1,61 @@
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nnabla as nn
+import nnabla.functions as F
+import numpy as np
+
+from nnabla.parameter import get_parameter_or_create
+from nnabla.initializer import ConstantInitializer
+
+from .graph_converter import FunctionModifier
+
+
+class NoGradModifier(FunctionModifier):
+    """
+    All functions are replaced to the same `new` function.
+
+    Args:
+        inputs (:obj: `dict`): Input variable mapping from the original input to another input. Default is the empty dictionary, so the new graph shares the original inputs.
+
+    Examples:
+
+    .. code-block:: python
+
+       pred = Model(...)
+       x = nn.Variable(...)
+
+       import nnabla.experimental.graph_converters as GC
+
+       modifiers = [GC.NoGradModifier()]
+       gc = GC.GraphConverter(modifiers)
+       pred = gc.convert(pred)
+    """
+
+    def __init__(self):
+        super(NoGradModifier, self).__init__()
+
+    def modify(self, f, inputs):
+        params = [v.data for v in nn.get_parameters(grad_only=False).values()]
+        inputs_ = []
+        for inp in inputs:
+            if inp.data not in params:
+                inputs_.append(inp)
+            else:
+                inp = inp.get_unlinked_variable(need_grad=False)
+                inputs_.append(inp)
+
+        o = self._call_function(
+            f.info.type_name, inputs_, f.info.args)
+        return o

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -299,7 +299,14 @@ cdef class Function:
                 return self._proto_call(inputs, n_outputs, outputs)
             elif any([isinstance(inp, NdArray) for inp in inputs]):
                 return self._imperative_call(inputs, n_outputs, outputs)
-        return self._cg_call(inputs, n_outputs, outputs, auto_forward)
+        out = self._cg_call(inputs, n_outputs, outputs, auto_forward)
+
+        import nnabla
+        if not auto_forward or not nnabla.parameter.current_no_grad:
+            return out
+
+        return out.get_unlinked_variable(need_grad=False) if not isinstance(out, (tuple, list)) else \
+          tuple([o.get_unlinked_variable(need_grad=False) for o in out])
 
     @property
     def args(self):

--- a/python/test/utils/test_graph_converters/graph_converter_test_utils.py
+++ b/python/test/utils/test_graph_converters/graph_converter_test_utils.py
@@ -64,11 +64,11 @@ def structure_tester(v_ref, v_act):
         assert f_ref.name == f_act.name
 
 
-def value_tester(v_ref, v_act, rtol=1e-04, atol=1e-05):
+def value_tester(v_ref, v_act, rtol=1e-04, atol=1e-05, clear_no_need_grad=False):
     from nbla_test_utils import ArrayDiffStats
 
-    v_ref.forward()
-    v_act.forward()
+    v_ref.forward(clear_no_need_grad)
+    v_act.forward(clear_no_need_grad)
     print(ArrayDiffStats(v_ref.d, v_act.d))
     assert_allclose(v_ref.d, v_act.d, rtol=rtol, atol=atol)
 

--- a/python/test/utils/test_graph_converters/test_no_grad.py
+++ b/python/test/utils/test_graph_converters/test_no_grad.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+
+from .ref_graphs.resnets import small_cf_resnet
+from .ref_graphs.lenets import lenet
+
+
+@pytest.mark.parametrize('seed', [313])
+@pytest.mark.parametrize('graph', [lenet, small_cf_resnet])
+def test_no_grad(seed, graph):
+    from .graph_converter_test_utils import structure_tester, value_tester
+
+    nn.clear_parameters()
+
+    # Random number
+    np.random.seed(seed)
+    rng = np.random.RandomState(seed)
+
+    # Graph
+    x_data = rng.randn(4, 3, 32, 32)
+    x0 = nn.Variable.from_numpy_array(x_data)\
+        .apply(need_grad=False) \
+        .apply(persistent=True)
+    y0 = graph(x0)
+    y1 = y0.no_grad()
+
+    # Test
+    def assert_need_grad_flase(f):
+        for inp in f.inputs:
+            assert inp.need_grad == False, "need_grad must be false"
+        for out in f.outputs:
+            assert out.need_grad == False, "need_grad must be false"
+    y1.visit(assert_need_grad_flase)
+    structure_tester(y0, y1)
+    value_tester(y0, y1, clear_no_need_grad=True)


### PR DESCRIPTION
This feature is useful for example when an output of a pre-trained network is used for an input to another network, where the first pre-trained network does not need to be fine-tuned, but the other network is optimized.

```python
with nn.no_grad():
    output0 = <Network0>(<input0>)

output1 = <Network1>(<input1>, output0)
loss = <Loss>(output1, <ground_truth>)
loss.forward(clear_no_need_grad=True)
```

This context also works in the dynamic mode.

```python
with nn.auto_forward(), nn.no_grad():
    output0 = <Network0>(<input0>)
```

The static graph alreay constructed can also be converted like

```python

x = nn.Variable.from_numpy_array([2, 3])
y = <Network>(x).no_grad()
```

This is useful for the loaded network from NNP file.