### PR TITLE
fix format for random_shift.

### DIFF
--- a/include/nbla/function/random_shift.hpp
+++ b/include/nbla/function/random_shift.hpp
@@ -71,7 +71,7 @@ public:
               int seed)
       : BaseFunction(ctx, shifts, border_mode, constant_value, base_axis, seed),
         shifts_(shifts), border_mode_(border_mode), base_axis_(base_axis),
-        constant_value_(constant_value),  seed_(seed) {}
+        constant_value_(constant_value), seed_(seed) {}
   virtual ~RandomShift() {}
   virtual shared_ptr<Function> copy() const {
     return create_RandomShift(ctx_, shifts_, border_mode_, constant_value_,


### PR DESCRIPTION
Remove extra space to preserve python formatting.