### PR TITLE
Support forward recomputation in backward propagation

### DIFF
--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -89,9 +89,12 @@ class CgVariable {
   };
   NeedGrad need_grad_{NG_NONE}; ///< Whether the variable requires gradients.
   NeedGrad need_grad_state_{
-      NG_NONE};     ///< Updated during graph construction or forward
-                    /// propagation.
-  VariablePtr var_; /// Variable instance.
+      NG_NONE};           ///< Updated during graph construction or forward
+                          /// propagation.
+  bool recompute_{false}; ///< Whether the data is cleared during forward
+                          /// propagation and recomputation is performed during
+  /// backward propagation.
+  VariablePtr var_;               /// Variable instance.
   CgFunctionPtr parent_{nullptr}; ///< Function created this variable.
   int rank_{0};                   ///< Longest path from root variable.
   ///< Holds weak function references. <https://stackoverflow.com/a/22110715>
@@ -185,6 +188,14 @@ public:
   /** Unset need grad state flag.
    */
   inline void unset_need_grad_state() { need_grad_state_ = NG_NONE; }
+
+  /** Get recompute flag.
+   */
+  inline bool recompute() const { return recompute_; }
+
+  /** Set recompute flag.
+   */
+  inline void set_recompute(bool b) { recompute_ = b; }
 
   /** Get prohibit_clear_data_ flag.
    */

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -343,6 +343,7 @@ public:
   void
   visit_function_recursive(CgFunctionPtr func,
                            unordered_set<CgFunctionPtr> &fclosed,
+                           const bool recomputation,
                            std::function<void(CgFunctionPtr)> forward_callback);
 
   /** Execute callback at functions in backward order in a graph.

--- a/include/nbla/function.hpp
+++ b/include/nbla/function.hpp
@@ -136,8 +136,7 @@ public:
   @sa recompute()
   @sa need_setup_recompute()
   */
-  void setup_recompute(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  void setup_recompute(const Variables &inputs, const Variables &outputs);
 
   /** Reproduce previous forward().
 
@@ -146,8 +145,7 @@ public:
 
   @sa setup_recompute()
   */
-  void recompute(const Variables &inputs, const Variables &outputs,
-                 const vector<bool> &need_recompute);
+  void recompute(const Variables &inputs, const Variables &outputs);
 
   /** Get Context used in this function.
   */
@@ -344,14 +342,10 @@ protected:
   recomputation. (e.g. Save random states for reproduction of forward execution
   during recomputation.)
 
-  @param need_recompute Boolean array that indicates whether recompute is needed
-  for an output corresponding to its index.
-
   @sa setup() arguments.
   */
   virtual void setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute) {
+                                    const Variables &outputs) {
     return;
   };
 
@@ -361,13 +355,10 @@ protected:
 
   - Reproduce the previous forward execution.
 
-  @param need_recompute Boolean array that indicates whether recompute is needed
-  for an output corresponding to its index.
-
   @sa setup() arguments.
   */
-  virtual void recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute) {
+  virtual void recompute_impl(const Variables &inputs,
+                              const Variables &outputs) {
     this->forward_impl(inputs, outputs);
   };
 

--- a/include/nbla/function/batch_normalization.hpp
+++ b/include/nbla/function/batch_normalization.hpp
@@ -133,12 +133,16 @@ protected:
                                    const Variables &outputs);
   NBLA_API virtual void forward_impl(const Variables &inputs,
                                      const Variables &outputs);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
   NBLA_API virtual void backward_impl(const Variables &inputs,
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
   NBLA_API virtual void forward_impl_batch(const Variables &inputs,
-                                           const Variables &outputs);
+                                           const Variables &outputs,
+                                           const bool update_inputs);
   NBLA_API virtual void forward_impl_global(const Variables &inputs,
                                             const Variables &outputs);
   NBLA_API virtual void backward_impl_batch(const Variables &inputs,

--- a/include/nbla/function/batch_normalization.hpp
+++ b/include/nbla/function/batch_normalization.hpp
@@ -134,8 +134,7 @@ protected:
   NBLA_API virtual void forward_impl(const Variables &inputs,
                                      const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   NBLA_API virtual void backward_impl(const Variables &inputs,
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,

--- a/include/nbla/function/dropout.hpp
+++ b/include/nbla/function/dropout.hpp
@@ -90,12 +90,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   void dropout(const Variables &inputs, const Variables &outputs,
                std::mt19937 &rgen);
 };

--- a/include/nbla/function/dropout.hpp
+++ b/include/nbla/function/dropout.hpp
@@ -60,8 +60,8 @@ protected:
   int seed_;
   float scale_; // = 1./(1.-p_)
   Variable mask_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
   std::bernoulli_distribution rdist_;
 
 public:

--- a/include/nbla/function/dropout.hpp
+++ b/include/nbla/function/dropout.hpp
@@ -61,6 +61,7 @@ protected:
   float scale_; // = 1./(1.-p_)
   Variable mask_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
   std::bernoulli_distribution rdist_;
 
 public:
@@ -78,6 +79,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -88,6 +90,14 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
+  void dropout(const Variables &inputs, const Variables &outputs,
+               std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/function_impl.hpp.tmpl
+++ b/include/nbla/function/function_impl.hpp.tmpl
@@ -97,6 +97,10 @@ public:
   // virtual bool prohibit_zero_input_grad() const {
   //   return true;
   // }
+  // TODO: If you implement `setup_recompute_impl`, uncomment the following function definition. See doc in function.hpp
+  // virtual bool need_setup_recompute(int o) const {
+  //   return true;
+  // }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs, const Variables &outputs);
@@ -104,6 +108,13 @@ protected:
   NBLA_API virtual void backward_impl(const Variables &inputs, const Variables &outputs,
 				      const vector<bool> &propagate_down,
 				      const vector<bool> &accum);
+  // TODO: This must be overridden if there are something need to be saved for recomputation. See doc in function.hpp.
+  // NBLA_API virtual void
+  // setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+  //                      const vector<bool> &need_recompute);
+  // NBLA_API virtual void recompute_impl(const Variables &inputs,
+  //                                      const Variables &outputs,
+  //                                      const vector<bool> &need_recompute);
   // TODO: This must be overridden if any of input grad depends on a input data. See doc in function.hpp.
   // virtual bool grad_depends_input_data_impl(int i, int j) const {
   // }

--- a/include/nbla/function/function_impl.hpp.tmpl
+++ b/include/nbla/function/function_impl.hpp.tmpl
@@ -109,12 +109,8 @@ protected:
 				      const vector<bool> &propagate_down,
 				      const vector<bool> &accum);
   // TODO: This must be overridden if there are something need to be saved for recomputation. See doc in function.hpp.
-  // NBLA_API virtual void
-  // setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-  //                      const vector<bool> &need_recompute);
-  // NBLA_API virtual void recompute_impl(const Variables &inputs,
-  //                                      const Variables &outputs,
-  //                                      const vector<bool> &need_recompute);
+  // NBLA_API virtual void setup_recompute_impl(const Variables &inputs, const Variables &outputs);
+  // NBLA_API virtual void recompute_impl(const Variables &inputs, const Variables &outputs);
   // TODO: This must be overridden if any of input grad depends on a input data. See doc in function.hpp.
   // virtual bool grad_depends_input_data_impl(int i, int j) const {
   // }

--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -124,8 +124,7 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (batch_stat_) { // Training mode.
       if (i == 0) {

--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -123,6 +123,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (batch_stat_) { // Training mode.
       if (i == 0) {

--- a/include/nbla/function/fused_convolution.hpp
+++ b/include/nbla/function/fused_convolution.hpp
@@ -106,8 +106,7 @@ protected:
   NBLA_API virtual void forward_impl(const Variables &inputs,
                                      const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   NBLA_API virtual void backward_impl(const Variables &inputs,
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,

--- a/include/nbla/function/fused_convolution.hpp
+++ b/include/nbla/function/fused_convolution.hpp
@@ -105,6 +105,9 @@ protected:
                                    const Variables &outputs);
   NBLA_API virtual void forward_impl(const Variables &inputs,
                                      const Variables &outputs);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
   NBLA_API virtual void backward_impl(const Variables &inputs,
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,

--- a/include/nbla/function/image_augmentation.hpp
+++ b/include/nbla/function/image_augmentation.hpp
@@ -104,6 +104,7 @@ protected:
   int seed_;
 
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   ImageAugmentation(const Context &ctx, const vector<int> &shape,
@@ -136,6 +137,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return vector<string>{"CpuArray"};
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -146,6 +148,14 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
+  void image_augmentation(const Variables &inputs, const Variables &outputs,
+                          std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/image_augmentation.hpp
+++ b/include/nbla/function/image_augmentation.hpp
@@ -103,8 +103,9 @@ protected:
   float noise_;
   int seed_;
 
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
+  std::bernoulli_distribution rdist_;
 
 public:
   ImageAugmentation(const Context &ctx, const vector<int> &shape,

--- a/include/nbla/function/image_augmentation.hpp
+++ b/include/nbla/function/image_augmentation.hpp
@@ -149,12 +149,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   void image_augmentation(const Variables &inputs, const Variables &outputs,
                           std::mt19937 &rgen);
 };

--- a/include/nbla/function/inq_affine.hpp
+++ b/include/nbla/function/inq_affine.hpp
@@ -126,8 +126,7 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (i == 0 && j == 1) {
       return true;

--- a/include/nbla/function/inq_affine.hpp
+++ b/include/nbla/function/inq_affine.hpp
@@ -125,6 +125,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (i == 0 && j == 1) {
       return true;

--- a/include/nbla/function/inq_convolution.hpp
+++ b/include/nbla/function/inq_convolution.hpp
@@ -145,8 +145,7 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (i == 0 && j == 1) {
       return true;

--- a/include/nbla/function/inq_convolution.hpp
+++ b/include/nbla/function/inq_convolution.hpp
@@ -144,6 +144,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (i == 0 && j == 1) {
       return true;

--- a/include/nbla/function/mean_subtraction.hpp
+++ b/include/nbla/function/mean_subtraction.hpp
@@ -112,6 +112,9 @@ protected:
                                              const Variables &outputs,
                                              const vector<bool> &propagate_down,
                                              const vector<bool> &accum);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (update_running_mean_) { // Training mode.
       if (i == 0 && j == 2)

--- a/include/nbla/function/mean_subtraction.hpp
+++ b/include/nbla/function/mean_subtraction.hpp
@@ -113,8 +113,7 @@ protected:
                                              const vector<bool> &propagate_down,
                                              const vector<bool> &accum);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (update_running_mean_) { // Training mode.
       if (i == 0 && j == 2)

--- a/include/nbla/function/rand.hpp
+++ b/include/nbla/function/rand.hpp
@@ -38,6 +38,7 @@ protected:
   const vector<int> shape_;
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   Rand(const Context &ctx, float low, float high, const vector<int> &shape,
@@ -61,6 +62,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -71,6 +73,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/function/rand.hpp
+++ b/include/nbla/function/rand.hpp
@@ -73,12 +73,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/function/rand.hpp
+++ b/include/nbla/function/rand.hpp
@@ -37,8 +37,8 @@ protected:
   float high_;
   const vector<int> shape_;
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   Rand(const Context &ctx, float low, float high, const vector<int> &shape,

--- a/include/nbla/function/rand_beta.hpp
+++ b/include/nbla/function/rand_beta.hpp
@@ -44,6 +44,7 @@ protected:
   const vector<int> shape_;
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   RandBeta(const Context &ctx, float alpha, float beta,
@@ -67,6 +68,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "RandBeta"; }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -77,6 +79,14 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
+  void random_beta(const Variables &inputs, const Variables &outputs,
+                   std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/rand_beta.hpp
+++ b/include/nbla/function/rand_beta.hpp
@@ -79,12 +79,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   void random_beta(const Variables &inputs, const Variables &outputs,
                    std::mt19937 &rgen);
 };

--- a/include/nbla/function/rand_beta.hpp
+++ b/include/nbla/function/rand_beta.hpp
@@ -43,8 +43,8 @@ protected:
   float beta_;
   const vector<int> shape_;
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   RandBeta(const Context &ctx, float alpha, float beta,

--- a/include/nbla/function/rand_binomial.hpp
+++ b/include/nbla/function/rand_binomial.hpp
@@ -44,8 +44,8 @@ protected:
   float p_;
   const vector<int> shape_;
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   RandBinomial(const Context &ctx, int n, float p, const vector<int> &shape,

--- a/include/nbla/function/rand_binomial.hpp
+++ b/include/nbla/function/rand_binomial.hpp
@@ -45,6 +45,7 @@ protected:
   const vector<int> shape_;
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   RandBinomial(const Context &ctx, int n, float p, const vector<int> &shape,
@@ -70,6 +71,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "RandBinomial"; }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -80,6 +82,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/function/rand_binomial.hpp
+++ b/include/nbla/function/rand_binomial.hpp
@@ -82,12 +82,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/function/rand_gamma.hpp
+++ b/include/nbla/function/rand_gamma.hpp
@@ -45,6 +45,7 @@ protected:
   const vector<int> shape_;
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   RandGamma(const Context &ctx, float k, float theta, const vector<int> &shape,
@@ -68,6 +69,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "RandGamma"; }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -78,6 +80,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/function/rand_gamma.hpp
+++ b/include/nbla/function/rand_gamma.hpp
@@ -80,12 +80,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/function/rand_gamma.hpp
+++ b/include/nbla/function/rand_gamma.hpp
@@ -44,8 +44,8 @@ protected:
   float theta_;
   const vector<int> shape_;
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   RandGamma(const Context &ctx, float k, float theta, const vector<int> &shape,

--- a/include/nbla/function/randint.hpp
+++ b/include/nbla/function/randint.hpp
@@ -75,12 +75,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/function/randint.hpp
+++ b/include/nbla/function/randint.hpp
@@ -38,6 +38,7 @@ protected:
   const vector<int> shape_;
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   Randint(const Context &ctx, int low, int high, const vector<int> &shape,
@@ -63,6 +64,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -73,6 +75,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/function/randint.hpp
+++ b/include/nbla/function/randint.hpp
@@ -37,8 +37,8 @@ protected:
   int high_;
   const vector<int> shape_;
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   Randint(const Context &ctx, int low, int high, const vector<int> &shape,

--- a/include/nbla/function/randn.hpp
+++ b/include/nbla/function/randn.hpp
@@ -37,8 +37,8 @@ protected:
   float sigma_;
   const vector<int> shape_;
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   Randn(const Context &ctx, float mu, float sigma, const vector<int> &shape,

--- a/include/nbla/function/randn.hpp
+++ b/include/nbla/function/randn.hpp
@@ -72,12 +72,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 };
 }
 #endif

--- a/include/nbla/function/randn.hpp
+++ b/include/nbla/function/randn.hpp
@@ -38,6 +38,7 @@ protected:
   const vector<int> shape_;
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   Randn(const Context &ctx, float mu, float sigma, const vector<int> &shape,
@@ -60,6 +61,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -70,6 +72,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 };
 }
 #endif

--- a/include/nbla/function/random_choice.hpp
+++ b/include/nbla/function/random_choice.hpp
@@ -96,6 +96,7 @@ protected:
   bool replace_;
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
   Variable idxbuf_;   // stores chosen indices for backward
   Size_t outer_loop_; // product of batch dimensions
   Size_t inner_loop_; // product of shape dimensions
@@ -119,6 +120,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "RandomChoice"; }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -129,6 +131,15 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
+
+  void random_choice(const Variables &inputs, const Variables &outputs,
+                     std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/random_choice.hpp
+++ b/include/nbla/function/random_choice.hpp
@@ -95,8 +95,8 @@ protected:
   const vector<int> shape_;
   bool replace_;
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
   Variable idxbuf_;   // stores chosen indices for backward
   Size_t outer_loop_; // product of batch dimensions
   Size_t inner_loop_; // product of shape dimensions

--- a/include/nbla/function/random_choice.hpp
+++ b/include/nbla/function/random_choice.hpp
@@ -131,12 +131,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 
   void random_choice(const Variables &inputs, const Variables &outputs,
                      std::mt19937 &rgen);

--- a/include/nbla/function/random_crop.hpp
+++ b/include/nbla/function/random_crop.hpp
@@ -55,6 +55,7 @@ protected:
 
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   RandomCrop(const Context &ctx, const vector<int> &shape, int base_axis,
@@ -73,6 +74,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return vector<string>{"CpuArray"};
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -83,6 +85,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 
 private:
   void slice_forward_recursive(const Variable *inp, Variable *outp, const T *x,
@@ -91,6 +99,9 @@ private:
   void slice_backward_recursive(Variable *outp, const Variable *inp, T *dx,
                                 const T *dy, int x_offset, int y_offset,
                                 int dim, int &slice_index);
+
+  void random_crop(const Variables &inputs, const Variables &outputs,
+                   std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/random_crop.hpp
+++ b/include/nbla/function/random_crop.hpp
@@ -85,12 +85,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 
 private:
   void slice_forward_recursive(const Variable *inp, Variable *outp, const T *x,

--- a/include/nbla/function/random_crop.hpp
+++ b/include/nbla/function/random_crop.hpp
@@ -54,8 +54,8 @@ protected:
   vector<vector<int>> step_;
 
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   RandomCrop(const Context &ctx, const vector<int> &shape, int base_axis,

--- a/include/nbla/function/random_erase.hpp
+++ b/include/nbla/function/random_erase.hpp
@@ -75,6 +75,7 @@ protected:
   bool ste_fine_grained_;
 
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
   NdArrayPtr random_coordinates_;
 
@@ -109,6 +110,7 @@ public:
     return inplace_ ? Function::INPLACE : Function::NOT_INPLACE;
   }
   virtual int inplace_data_with(int i) const { return 0; }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -119,6 +121,15 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
+
+  void random_erase(const Variables &inputs, const Variables &outputs,
+                    std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/random_erase.hpp
+++ b/include/nbla/function/random_erase.hpp
@@ -121,12 +121,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 
   void random_erase(const Variables &inputs, const Variables &outputs,
                     std::mt19937 &rgen);

--- a/include/nbla/function/random_erase.hpp
+++ b/include/nbla/function/random_erase.hpp
@@ -74,8 +74,8 @@ protected:
   bool channel_last_;
   bool ste_fine_grained_;
 
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
   NdArrayPtr random_coordinates_;
 

--- a/include/nbla/function/random_flip.hpp
+++ b/include/nbla/function/random_flip.hpp
@@ -55,8 +55,8 @@ protected:
   vector<vector<bool>> flip_;
 
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   RandomFlip(const Context &ctx, const vector<int> &axes, int base_axis,

--- a/include/nbla/function/random_flip.hpp
+++ b/include/nbla/function/random_flip.hpp
@@ -88,12 +88,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 
 private:
   void flip_recursive(const Variable *inp, const T *x, T *y, bool add,

--- a/include/nbla/function/random_flip.hpp
+++ b/include/nbla/function/random_flip.hpp
@@ -56,6 +56,7 @@ protected:
 
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   RandomFlip(const Context &ctx, const vector<int> &axes, int base_axis,
@@ -76,6 +77,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -86,10 +88,18 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 
 private:
   void flip_recursive(const Variable *inp, const T *x, T *y, bool add,
                       int x_offset, int y_offset, int dim, int &flip_index);
+  void random_flip(const Variables &inputs, const Variables &outputs,
+                   std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/random_shift.hpp
+++ b/include/nbla/function/random_shift.hpp
@@ -64,6 +64,7 @@ protected:
 
   int seed_;
   std::mt19937 rgen_;
+  std::shared_ptr<std::mt19937> rgen_for_recompute_;
 
 public:
   RandomShift(const Context &ctx, const vector<int> &shifts,
@@ -85,6 +86,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -95,6 +97,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
 
   vector<vector<int>> prepare_addr_table(const Variables &inputs,
                                          const vector<int> &shifts);
@@ -105,6 +113,8 @@ private:
   void shift_backward_recursive(const Variable *inp, const T *dy, T *dx,
                                 int x_offset, int y_offset, int dim,
                                 int &shift_index);
+  void random_shift(const Variables &inputs, const Variables &outputs,
+                    std::mt19937 &rgen);
 };
 }
 #endif

--- a/include/nbla/function/random_shift.hpp
+++ b/include/nbla/function/random_shift.hpp
@@ -97,12 +97,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
 
   vector<vector<int>> prepare_addr_table(const Variables &inputs,
                                          const vector<int> &shifts);

--- a/include/nbla/function/random_shift.hpp
+++ b/include/nbla/function/random_shift.hpp
@@ -63,8 +63,8 @@ protected:
   vector<vector<vector<int>>> addr_table_;
 
   int seed_;
-  std::mt19937 rgen_;
-  std::shared_ptr<std::mt19937> rgen_for_recompute_;
+  bool save_rng_ = false;
+  std::mt19937 rgen_, rgen_for_recompute_;
 
 public:
   RandomShift(const Context &ctx, const vector<int> &shifts,

--- a/include/nbla/function/spectral_norm.hpp
+++ b/include/nbla/function/spectral_norm.hpp
@@ -100,12 +100,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  NBLA_API virtual void
-  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
-                       const vector<bool> &need_recompute);
+  NBLA_API virtual void setup_recompute_impl(const Variables &inputs,
+                                             const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute);
+                                       const Variables &outputs);
   virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
   virtual bool overwrite_input_data_in_forward_impl(int i) const {
     if (i == 1) {

--- a/include/nbla/function/spectral_norm.hpp
+++ b/include/nbla/function/spectral_norm.hpp
@@ -84,6 +84,7 @@ public:
   }
   virtual string name() { return "SpectralNorm"; }
   virtual bool grad_depends_output_data(int i, int o) const { return i == 0; }
+  virtual bool need_setup_recompute(int o) const { return true; }
 
 protected:
   NBLA_API virtual CgVariablePtr spectral_norm(const Variables &inputs,
@@ -99,6 +100,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  NBLA_API virtual void
+  setup_recompute_impl(const Variables &inputs, const Variables &outputs,
+                       const vector<bool> &need_recompute);
+  NBLA_API virtual void recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute);
   virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
   virtual bool overwrite_input_data_in_forward_impl(int i) const {
     if (i == 1) {

--- a/include/nbla/function/sync_batch_normalization.hpp
+++ b/include/nbla/function/sync_batch_normalization.hpp
@@ -97,7 +97,8 @@ protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
                                    const Variables &outputs) override;
   NBLA_API virtual void forward_impl_batch(const Variables &inputs,
-                                           const Variables &outputs) override;
+                                           const Variables &outputs,
+                                           const bool update_inputs) override;
   NBLA_API virtual void backward_impl_batch(const Variables &inputs,
                                             const Variables &outputs,
                                             const vector<bool> &propagate_down,

--- a/python/src/nnabla/_variable.pxd
+++ b/python/src/nnabla/_variable.pxd
@@ -73,6 +73,8 @@ cdef extern from "nbla/computation_graph/variable.hpp" namespace "nbla":
         cpp_bool need_grad_state_is_set() const
         void set_need_grad_state(cpp_bool b)
         void unset_need_grad_state()
+        cpp_bool recompute() const
+        void set_recompute(cpp_bool b)
         void set_parent(CgFunctionPtr func) except+
         CgFunctionPtr parent()
         VariablePtr variable()

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -348,6 +348,23 @@ cdef class Variable:
     def need_grad(self, b):
         self.varp.set_need_grad(b)
 
+    @property
+    def recompute(self):
+        """
+        Gets or sets a boolean indicating whether its data is cleared during forward propagation and recomputation is performed during backward propagation. 
+
+        Args:
+            b (bool): Whether recomputation is performed during backward propagation.
+
+        Returns:
+           bool: Whether this variable is recomputed during backward propagation.
+        """
+        return self.varp.need_grad_state()
+
+    @recompute.setter
+    def recompute(self, b):
+        self.varp.set_recompute(b)
+
     def rewire_on(self, var):
         '''Rewire a successor graph of this variable on top of ``var``.
 

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -359,7 +359,7 @@ cdef class Variable:
         Returns:
            bool: Whether this variable is recomputed during backward propagation.
         """
-        return self.varp.need_grad_state()
+        return self.varp.recompute()
 
     @recompute.setter
     def recompute(self, b):

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -52,6 +52,7 @@ cdef extern from "nbla/function.hpp" namespace "nbla":
         string name()
         shared_ptr[CFunction] copy() except +
         cpp_bool grad_depends_output_data(int i, int o) except+
+        cpp_bool need_setup_recompute(int o) except+
         int inplace_data(int i) except+
         int inplace_data_with(int i) except+
 

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -40,10 +40,8 @@ cdef extern from "nbla/function.hpp" namespace "nbla":
         void backward(const Variables&, const Variables&,
                       const vector[cpp_bool] &propagate_down,
                       const vector[cpp_bool] &accum) nogil except +
-        void setup_recompute(const Variables&, const Variables&,
-                             const vector[cpp_bool] &need_recompute) nogil except +
-        void recompute(const Variables&, const Variables&,
-                       const vector[cpp_bool] &need_recompute) nogil except +
+        void setup_recompute(const Variables&, const Variables&) nogil except +
+        void recompute(const Variables&, const Variables&) nogil except +
         CContext context() except +
         vector[dtypes] in_types()
         vector[dtypes] out_types()

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -40,6 +40,10 @@ cdef extern from "nbla/function.hpp" namespace "nbla":
         void backward(const Variables&, const Variables&,
                       const vector[cpp_bool] &propagate_down,
                       const vector[cpp_bool] &accum) nogil except +
+        void setup_recompute(const Variables&, const Variables&,
+                             const vector[cpp_bool] &need_recompute) nogil except +
+        void recompute(const Variables&, const Variables&,
+                       const vector[cpp_bool] &need_recompute) nogil except +
         CContext context() except +
         vector[dtypes] in_types()
         vector[dtypes] out_types()

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -112,14 +112,6 @@ cdef vector[cpp_bool] variables_to_prop_down_flags(varlist) except *:
         ret.push_back((<_Variable?>varlist[i]).varp.need_grad_state())
     return ret
 
-cdef vector[cpp_bool] variables_to_need_recompute_flags(varlist) except *:
-    cdef int i
-    cdef int size = len(varlist)
-    cdef vector[cpp_bool] ret
-    for i in range(size):
-        ret.push_back((<_Variable?>varlist[i]).varp.recompute())
-    return ret
-
 cdef tuple vector_to_tuple_nd_array(const vector[NdArrayPtr] &vec):
     cdef int i
     cdef list ret = []
@@ -227,19 +219,15 @@ cdef class Function:
 
     def setup_recompute(self, inputs, outputs):
         cdef int i
-        cdef vector[cpp_bool] need_recompute = variables_to_need_recompute_flags(outputs)
         self.funp.function().get().setup_recompute(
             list_to_vector_variable_p(inputs),
-            list_to_vector_variable_p(outputs),
-            need_recompute)
+            list_to_vector_variable_p(outputs))
 
     def recompute(self, inputs, outputs):
         cdef int i
-        cdef vector[cpp_bool] need_recompute = variables_to_need_recompute_flags(outputs)
         self.funp.function().get().recompute(
             list_to_vector_variable_p(inputs),
-            list_to_vector_variable_p(outputs),
-            need_recompute)
+            list_to_vector_variable_p(outputs))
 
     @property
     def context(self):

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -112,6 +112,14 @@ cdef vector[cpp_bool] variables_to_prop_down_flags(varlist) except *:
         ret.push_back((<_Variable?>varlist[i]).varp.need_grad_state())
     return ret
 
+cdef vector[cpp_bool] variables_to_need_recompute_flags(varlist) except *:
+    cdef int i
+    cdef int size = len(varlist)
+    cdef vector[cpp_bool] ret
+    for i in range(size):
+        ret.push_back((<_Variable?>varlist[i]).varp.recompute())
+    return ret
+
 cdef tuple vector_to_tuple_nd_array(const vector[NdArrayPtr] &vec):
     cdef int i
     cdef list ret = []
@@ -216,6 +224,22 @@ cdef class Function:
             list_to_vector_variable_p(outputs),
 	    prop_down,
             caccum)
+
+    def setup_recompute(self, inputs, outputs):
+        cdef int i
+        cdef vector[cpp_bool] need_recompute = variables_to_need_recompute_flags(outputs)
+        self.funp.function().get().setup_recompute(
+            list_to_vector_variable_p(inputs),
+            list_to_vector_variable_p(outputs),
+            need_recompute)
+
+    def recompute(self, inputs, outputs):
+        cdef int i
+        cdef vector[cpp_bool] need_recompute = variables_to_need_recompute_flags(outputs)
+        self.funp.function().get().recompute(
+            list_to_vector_variable_p(inputs),
+            list_to_vector_variable_p(outputs),
+            need_recompute)
 
     @property
     def context(self):

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -257,6 +257,9 @@ cdef class Function:
     def grad_depends_output_data(self, int i, int o):
         return self.funp.function().get().grad_depends_output_data(i, o)
 
+    def need_setup_recompute(self, int o):
+        return self.funp.function().get().need_setup_recompute(o)
+
     def inplace_data(self, int i):
         return self.funp.function().get().inplace_data(i)
 

--- a/python/test/function/test_assign.py
+++ b/python/test/function/test_assign.py
@@ -20,7 +20,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
-from nbla_test_utils import list_context
+from nbla_test_utils import list_context, recomputation_test
 from nnabla.testing import assert_allclose
 
 ctxs = list_context('Assign')
@@ -63,3 +63,14 @@ def test_assign_forward_backward(seed, ctx, func_name):
     f.backward([dst, src], [assign], accum=[False])
     assert np.all(dst.g == assign.g)
     assert np.all(src.g == np.zeros((2, 3, 4)))
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [314])
+def test_assign_recomputation(seed, ctx, func_name):
+    rng = np.random.RandomState(seed)
+    dst = nn.Variable((2, 3, 4))
+    src = nn.Variable((2, 3, 4))
+
+    recomputation_test(rng=rng, func=F.assign, vinputs=[dst, src],
+                       func_args=[], func_kwargs={}, ctx=ctx)

--- a/python/test/function/test_dropout.py
+++ b/python/test/function/test_dropout.py
@@ -80,3 +80,16 @@ def test_dropout_double_backward(p, seed, ctx, func_name):
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
     backward_function_tester(rng, F.dropout, inputs, func_args=[p, seed], ctx=ctx,
                              skip_backward_check=True)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [-1, 313])
+@pytest.mark.parametrize("p", [0.5])
+def test_dropout_recompute(p, seed, ctx, func_name):
+    from nbla_test_utils import recomputation_test
+
+    rng = np.random.RandomState(0)
+    x = nn.Variable((2, 3, 4))
+    func_args = [p, seed]
+    recomputation_test(rng=rng, func=F.dropout, vinputs=[x],
+                       func_args=func_args, func_kwargs={}, ctx=ctx)

--- a/python/test/function/test_image_augmentation.py
+++ b/python/test/function/test_image_augmentation.py
@@ -34,12 +34,34 @@ def test_image_augmentation_forward(seed, shape, ctx, func_name):
         o = F.image_augmentation(i)
     assert o.d.shape == inputs[0].shape
 
+    func_kargs = {
+        'shape': shape,
+        'pad': (2, 2),
+        'min_scale': 0.8,
+        'max_scale': 1.2,
+        'angle': 0.2,
+        'aspect_ratio': 1.1,
+        'distortion': 0.1,
+        'flip_lr': True,
+        'flip_ud': False,
+        'brightness': 0.1,
+        'brightness_each': True,
+        'contrast': 1.1,
+        'contrast_center': 0.5,
+        'contrast_each': True,
+        'noise': 0.1,
+        'seed': 0}
+
     with nn.context_scope(ctx), nn.auto_forward():
-        o = F.image_augmentation(i, shape=shape, pad=(2, 2),
-                                 min_scale=0.8, max_scale=1.2, angle=0.2,
-                                 aspect_ratio=1.1, distortion=0.1,
-                                 flip_lr=True, flip_ud=False,
-                                 brightness=0.1, brightness_each=True,
-                                 contrast=1.1, contrast_center=0.5, contrast_each=True,
-                                 noise=0.1, seed=0)
+        o = F.image_augmentation(i, **func_kargs)
     assert o.d.shape == (inputs[0].shape[0],) + shape
+
+    # Checking recomputation
+    from nbla_test_utils import recomputation_test
+
+    recomputation_test(rng=rng, func=F.image_augmentation, vinputs=[i],
+                       func_args=[], func_kwargs=func_kargs, ctx=ctx)
+
+    func_kargs['seed'] = -1
+    recomputation_test(rng=rng, func=F.image_augmentation, vinputs=[i],
+                       func_args=[], func_kwargs=func_kargs, ctx=ctx)

--- a/python/test/function/test_inq_convolution.py
+++ b/python/test/function/test_inq_convolution.py
@@ -151,3 +151,47 @@ def test_convolution_2d_forward_backward(inshape, kernel, outmaps, pad, stride,
                                selection_algorithm, seed],
                     atol_f=1e-5, atol_b=1e-2, atol_accum=1e-5, backward=[True, True, False, True], ctx=ctx, func_name=func_name,
                     ref_grad=ref_grad_inq_convolution)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape, kernel, outmaps, pad, stride, dilation, num_bits",
+                         [((2, 2, 10, 10), (3, 2), 4, (3, 0), (1, 2), (2, 1), 3), ])
+@pytest.mark.parametrize("group", [1, 2])
+@pytest.mark.parametrize("with_bias", [True, False])
+@pytest.mark.parametrize("inq_iterations", [(1,)])
+@pytest.mark.parametrize("selection_algorithm", ["largest_abs", "random"])
+@pytest.mark.parametrize("func_seed", [-1, 412])
+def test_convolution_2d_recomputation(inshape, kernel, outmaps, pad, stride,
+                                      dilation, group, with_bias, seed,
+                                      num_bits, inq_iterations,
+                                      selection_algorithm, func_seed, ctx, func_name):
+    from nbla_test_utils import recomputation_test
+    rng = np.random.RandomState(seed)
+    # Input
+    inputs = [rng.randn(*inshape).astype(np.float32)]
+    # Weights
+    inmaps = inshape[-3]
+    kshape = (outmaps,) + (inmaps // group,) + kernel
+    inputs += [rng.randn(*kshape).astype(np.float32)]
+    # Indices
+    inputs += [np.random.randint(2, size=kshape)]
+    # Bias
+    if with_bias:
+        inputs += [rng.randn(outmaps).astype(np.float32)]
+    else:
+        inputs += [None]
+
+    base_axis = len(inshape) - 3
+    func_args = [base_axis, pad, stride, dilation, group, num_bits,
+                 inq_iterations, selection_algorithm, func_seed]
+
+    vinputs = []
+    for i in inputs:
+        if i is None:
+            vinputs.append(None)
+        else:
+            vinputs.append(nn.Variable.from_numpy_array(i))
+
+    recomputation_test(rng=rng, func=F.inq_convolution, vinputs=vinputs,
+                       func_args=func_args, func_kwargs={}, ctx=ctx)

--- a/python/test/function/test_random_choice.py
+++ b/python/test/function/test_random_choice.py
@@ -48,6 +48,23 @@ def test_random_choice_with_replacement(ctx, func_name, seed):
         y = F.random_choice(x, w, shape=(10,), replace=True, seed=seed)
     assert y.shape == (2, 10) and np.all(y.d[0] > 0) and np.all(y.d[1] < 0)
 
+    # Check recomputation
+    from nbla_test_utils import recomputation_test
+
+    x = nn.Variable([100], need_grad=True)
+    x.d = np.random.random(x.size).astype(np.float32)
+    w = nn.Variable([x.size], need_grad=True)
+    w.d = np.random.randint(1, 100, w.size)
+    rng = np.random.RandomState(0)
+
+    vinputs = [x, w]
+    func_kwargs = {'shape': (trials,),
+                   'replace': True,
+                   'seed': seed}
+
+    recomputation_test(rng=rng, func=F.random_choice, vinputs=vinputs,
+                       func_args=[], func_kwargs=func_kwargs, ctx=ctx)
+
     return
     x = nn.Variable((3, 3), need_grad=True)
     w = nn.Variable((3, 3), need_grad=True)
@@ -76,3 +93,18 @@ def test_random_choice_without_replacement(ctx, func_name, seed):
         y.forward()
         r[i] = y.d.copy()
     assert np.all(np.bincount(r.flatten()) == x.size * [repeats])
+
+    # Check recomputation
+    from nbla_test_utils import recomputation_test
+    rng = np.random.RandomState(0)
+
+    x.d = np.random.random(*x.shape).astype(np.float32)
+    w.d = np.random.randint(1, 100, w.size)
+
+    vinputs = [x, w]
+    func_kwargs = {'shape': (w.size,),
+                   'replace': False,
+                   'seed': seed}
+
+    recomputation_test(rng=rng, func=F.random_choice, vinputs=vinputs,
+                       func_args=[], func_kwargs=func_kwargs, ctx=ctx)

--- a/python/test/function/test_random_crop.py
+++ b/python/test/function/test_random_crop.py
@@ -42,7 +42,8 @@ def test_random_crop_forward_backward(seed, inshape, shape, ctx, func_name):
         possible_crop_range = [
             input - output for output, input in zip(shape, inshape)]
         for crop_pos in itertools.product(*map(tuple, map(lambda x: range(*x), [(0, r + 1) for r in possible_crop_range]))):
-            r = inputs[0][crop_pos[0]:crop_pos[0] + shape[0], crop_pos[1]:crop_pos[1] + shape[1], crop_pos[2]:crop_pos[2] + shape[2]]
+            r = inputs[0][crop_pos[0]:crop_pos[0] + shape[0], crop_pos[1]
+                :crop_pos[1] + shape[1], crop_pos[2]:crop_pos[2] + shape[2]]
             assert(o.d.shape == r.shape)
             correl_and_p = pearsonr(o.d.flatten(), r.flatten())
             if correl_and_p[0] > max_correl:
@@ -79,3 +80,18 @@ def test_random_crop_forward_backward(seed, inshape, shape, ctx, func_name):
     o_diff = rng.randn(*o.shape).astype(i.d.dtype)
     o.backward(o_diff)
     assert np.all(i.g == 0)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [-1, 313])
+@pytest.mark.parametrize("inshape", [(8, 8, 8)])
+@pytest.mark.parametrize("shape", [None, (4, 4, 4,)])
+def test_random_crop_recomputation(seed, inshape, shape, ctx, func_name):
+    from nbla_test_utils import recomputation_test
+    rng = np.random.RandomState(0)
+    vinputs = [nn.Variable(inshape)]
+
+    base_axis = 0
+    func_args = [shape, base_axis, seed]
+    recomputation_test(rng=rng, func=F.random_crop, vinputs=vinputs,
+                       func_args=func_args, func_kwargs={}, ctx=ctx)

--- a/python/test/function/test_random_flip.py
+++ b/python/test/function/test_random_flip.py
@@ -69,3 +69,19 @@ def test_random_flip_forward_backward(seed, axes, ctx, func_name):
     i.need_grad = False
     o.backward(o_grad)
     assert np.all(i.g == 0)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("axes", [None, (1,), (2,)])
+@pytest.mark.parametrize("func_seed", [412, -1])
+def test_random_flip_recomputation(seed, axes, func_seed, ctx, func_name):
+    from nbla_test_utils import recomputation_test
+
+    rng = np.random.RandomState(seed)
+    vinputs = [nn.Variable((5, 4, 3))]
+
+    base_axis = 2
+    func_args = [axes, base_axis, func_seed]
+    recomputation_test(rng=rng, func=F.random_flip, vinputs=vinputs,
+                       func_args=func_args, func_kwargs={}, ctx=ctx)

--- a/python/test/function/test_random_functions.py
+++ b/python/test/function/test_random_functions.py
@@ -16,7 +16,7 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
-from nbla_test_utils import list_context
+from nbla_test_utils import list_context, recomputation_test
 import platform
 
 ctxs_rand = list_context('Rand')
@@ -42,6 +42,11 @@ def test_rand_forward(seed, ctx, func_name, low, high, shape):
     assert np.all(o.d <= high)
     assert np.all(o.d >= low)
 
+    # Checking recomputation
+    func_args = [low, high, shape, seed]
+    recomputation_test(rng=None, func=F.rand, vinputs=[],
+                       func_args=func_args, func_kwargs={}, ctx=ctx)
+
 
 @pytest.mark.parametrize("ctx, func_name", ctxs_randint)
 @pytest.mark.parametrize("low, high", [(100, 50000), (-5, 100), (101, 102)])
@@ -57,6 +62,11 @@ def test_randint_forward(seed, ctx, func_name, low, high, shape):
     # but use <= high because std::uniform_random contains a bug.
     assert np.all(o.d <= high)
     assert np.all(o.d >= low)
+
+    # Checking recomputation
+    func_args = [low, high, shape, seed]
+    recomputation_test(rng=None, func=F.randint, vinputs=[],
+                       func_args=func_args, func_kwargs={}, ctx=ctx)
 
 
 @pytest.mark.parametrize("ctx, func_name", ctxs_randn)
@@ -83,6 +93,11 @@ def test_randn_forward_backward(seed, ctx, func_name, mu, sigma, shape):
         est_sigma = np.std(np.array(data))
         np.isclose(est_mu, mu, atol=sigma)
         np.isclose(est_sigma, sigma, atol=sigma)
+
+    # Checking recomputation
+    func_args = [mu, sigma, shape, seed]
+    recomputation_test(rng=None, func=F.randn, vinputs=[],
+                       func_args=func_args, func_kwargs={}, ctx=ctx)
 
 
 @pytest.mark.parametrize("ctx, func_name", ctxs_rand_beta)
@@ -113,6 +128,11 @@ def test_rand_beta_forward(seed, ctx, func_name, alpha, beta, shape):
     assert np.isclose(est_mu, mu, atol=5e-2)
     assert np.isclose(est_sigma, sigma, atol=5e-2)
 
+    # Checking recomputation
+    func_args = [alpha, beta, shape, seed]
+    recomputation_test(rng=None, func=F.rand_beta, vinputs=[],
+                       func_args=func_args, func_kwargs={}, ctx=ctx)
+
 
 @pytest.mark.parametrize("ctx, func_name", ctxs_rand_binomial)
 @pytest.mark.parametrize("n, p", [(1, 0.5), (1, 0.9), (5, 0.5), (5, 0.15), (10, 0.45)])
@@ -140,6 +160,11 @@ def test_rand_binomial_forward(seed, ctx, func_name, n, p, shape):
 
     assert np.isclose(est_mu, mu, atol=5e-2)
     assert np.isclose(est_sigma, sigma, atol=5e-2)
+
+    # Checking recomputation
+    func_args = [n, p, shape, seed]
+    recomputation_test(rng=None, func=F.rand_binomial, vinputs=[],
+                       func_args=func_args, func_kwargs={}, ctx=ctx)
 
 
 @pytest.mark.parametrize("ctx, func_name", ctxs_rand_gamma)
@@ -171,3 +196,8 @@ def test_rand_gamma_forward(seed, ctx, func_name, k, theta, shape):
 
     assert np.isclose(est_mu, mu, atol=5e-2)
     assert np.isclose(est_sigma, sigma, atol=5e-2)
+
+    # Checking recomputation
+    func_args = [k, theta, shape, seed]
+    recomputation_test(rng=None, func=F.rand_gamma, vinputs=[],
+                       func_args=func_args, func_kwargs={}, ctx=ctx)

--- a/python/test/function/test_random_shift.py
+++ b/python/test/function/test_random_shift.py
@@ -84,3 +84,21 @@ def test_random_shift_forward_backward(seed, inshape, shifts, border_mode, const
     o_grad = rng.randn(*i.shape).astype(i.data.dtype)
     o.backward(o_grad)
     assert np.all(i.g == 0)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("inshape", [(7, 8, 9)])
+@pytest.mark.parametrize("shifts", [None, (0, 0, 2,), (0, 2, 0), (0, 2, 2)])
+@pytest.mark.parametrize("border_mode", ["nearest", "reflect", "constant"])
+@pytest.mark.parametrize("constant_value", [0, -100])
+@pytest.mark.parametrize("func_seed", [-1, 412])
+def test_random_shift_recomputation(seed, inshape, shifts, border_mode, constant_value, func_seed, ctx, func_name):
+    from nbla_test_utils import recomputation_test
+    rng = np.random.RandomState(seed)
+    vinputs = [nn.Variable(inshape)]
+
+    base_axis = 0
+    func_args = [shifts, border_mode, constant_value, base_axis, func_seed]
+    recomputation_test(rng=rng, func=F.random_shift, vinputs=vinputs,
+                       func_args=func_args, func_kwargs={}, ctx=ctx)

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -322,6 +322,54 @@ def half_test(rng, func, finputs, hinputs, func_args, func_kwargs, backward, ctx
             ff, hh, atol=atol, err_msg="{} half backward test fails.".format(func_name))
 
 
+def recomputation_test(rng, func, vinputs, func_args, func_kwargs, ctx):
+    def copy_data(vinputs, voutputs):
+        i_data = []
+        o_data = []
+        for i in vinputs:
+            i_data.append(copy.deepcopy(i.d))
+        for o in voutputs:
+            o_data.append(copy.deepcopy(o.d))
+        return i_data, o_data
+
+    with nn.context_scope(ctx):
+        voutputs = func(*(vinputs + func_args), **func_kwargs)
+
+    voutputs = force_list(voutputs)
+
+    for o in voutputs:
+        o.recompute = True
+
+    f = voutputs[0].parent
+
+    need_setup_recompute = False
+    for o_idx in range(len(voutputs)):
+        need_setup_recompute |= f.need_setup_recompute(o_idx)
+
+    # Filter None inputs
+    vinputs = list(filter(lambda x: x is not None, vinputs))
+
+    # Forward
+    if need_setup_recompute:
+        f.setup_recompute(vinputs, voutputs)
+    f.forward(vinputs, voutputs)
+    exp_is, exp_os = copy_data(vinputs, voutputs)
+
+    # Claer outputs by zeroing
+    for o in voutputs:
+        o.data.zero()
+
+    # Recompute
+    f.recompute(vinputs, voutputs)
+    act_is, act_os = copy_data(vinputs, voutputs)
+
+    for exp_i, act_i in zip(exp_is, act_is):
+        assert_allclose(exp_i, act_i)
+
+    for exp_o, act_o in zip(exp_os, act_os):
+        assert_allclose(exp_o, act_o)
+
+
 def create_function_nnp(inputs, outputs, func_name, func_args, func_kwargs):
     if func_name is None:
         return
@@ -543,6 +591,11 @@ def function_tester(rng, func, ref_func, inputs,
         res = o[i].d
         assert_allclose(ref, res, atol=atol_f,
                         err_msg="{} forward test fails".format(func_name))
+
+    # Checking recomputation
+    vinputs = create_variables(inputs, backward)
+    recomputation_test(rng, func, vinputs, func_args,
+                       func_kwargs, ctx)
 
     # Checking function name
     try:

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -324,12 +324,8 @@ def half_test(rng, func, finputs, hinputs, func_args, func_kwargs, backward, ctx
 
 def recomputation_test(rng, func, vinputs, func_args, func_kwargs, ctx):
     def copy_data(vinputs, voutputs):
-        i_data = []
-        o_data = []
-        for i in vinputs:
-            i_data.append(copy.deepcopy(i.d))
-        for o in voutputs:
-            o_data.append(copy.deepcopy(o.d))
+        i_data = [copy.deepcopy(i.d) for i in vinputs]
+        o_data = [copy.deepcopy(o.d) for o in voutputs]
         return i_data, o_data
 
     with nn.context_scope(ctx):
@@ -355,9 +351,9 @@ def recomputation_test(rng, func, vinputs, func_args, func_kwargs, ctx):
     f.forward(vinputs, voutputs)
     exp_is, exp_os = copy_data(vinputs, voutputs)
 
-    # Claer outputs by zeroing
+    # Claer outputs
     for o in voutputs:
-        o.data.zero()
+        o.data.clear()
 
     # Recompute
     f.recompute(vinputs, voutputs)

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -923,6 +923,24 @@ class TestRecomputation():
 
         self.check_recomputation(seed, graph, inputs)
 
+    # Check `setup_recompute`
+    @pytest.mark.parametrize("seed", [313])
+    def test_grad_value_with_random_function(self, seed):
+        x1 = nn.Variable((2, 3), need_grad=True)
+
+        inputs = (x1,)
+
+        def graph(x1):
+            x1 = F.identity(x1).apply(recompute=True)
+            x2 = F.randn(shape=x1.shape, seed=123).apply(recompute=True)
+            x3 = F.rand(shape=x1.shape, seed=456).apply(recompute=True)
+            y = F.mul2(x1, x2).apply(recompute=True)
+            y = F.mul2(y, x3).apply(recompute=True)
+            y = F.identity(y)
+            return y
+
+        self.check_recomputation(seed, graph, inputs)
+
     # Check clear of data on outside of backward path
     def test_clear_data_on_not_bwd_path(self):
         a0 = nn.Variable((2, 3), need_grad=True)

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -754,9 +754,11 @@ class TestClearOutputGrad():
 
 
 class TestRecomputation():
+    def teardown_method(self):
+        clear_called_flag_recorder.deactivate_clear_called_flag_recorder()
+
     def check_input_data_clear_called_flags(self, answer):
         result = clear_called_flag_recorder.get_input_clear_called_flags()
-        print(result)
         assert len(result) == len(answer)
         for i, flags in enumerate(answer):
             assert len(result[i]) == len(flags)
@@ -772,7 +774,7 @@ class TestRecomputation():
 
             y.forward(clear_no_need_grad=clear_no_need_grad,
                       clear_buffer=clear_buffer)
-            y.backward()
+            y.backward(clear_buffer=True)
 
             # Get grads
             grads = []
@@ -941,13 +943,13 @@ class TestRecomputation():
 
         self.check_recomputation(seed, graph, inputs)
 
-    # Check clear of recomputed data on the subgraph which does not be back-propagated.
+    # Check clear of recomputed data on the subgraph which is not back-propagated.
     def test_clear_data_on_not_bwd_path(self):
         a0 = nn.Variable((2, 3), need_grad=True)
         a1 = F.identity(a0).apply(recompute=True)
         a2 = F.sin(a1).apply(recompute=True)
 
-        # These three variables don't be back-propagated.
+        # These three variables are not back-propagated.
         b0 = nn.Variable((2, 3), need_grad=False)
         b1 = F.identity(b0).apply(recompute=True)
         b2 = F.sin(b1).apply(recompute=True)

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -301,19 +301,16 @@ public:
 
     bool need_setup_recompute = false;
     const int n_outputs = outputs.size();
-    vector<bool> need_recompute(n_outputs, false);
     for (int i = 0; i < n_outputs; i++) {
       if (outputs[i]->recompute() &&
           func->function()->need_setup_recompute(i)) {
-        need_recompute[i] = true;
         need_setup_recompute = true;
       }
     }
 
     if (as_recomputation_) {
       try {
-        func->function()->recompute(func->function_inputs(), voutputs,
-                                    need_recompute);
+        func->function()->recompute(func->function_inputs(), voutputs);
       } catch (...) {
         error_trace("Error during recomputation:", func->function()->name());
         throw;
@@ -322,8 +319,7 @@ public:
       // Setup for recomputation before forward execution
       if (need_setup_recompute) {
         try {
-          func->function()->setup_recompute(func->function_inputs(), voutputs,
-                                            need_recompute);
+          func->function()->setup_recompute(func->function_inputs(), voutputs);
         } catch (...) {
           error_trace(
               "Error setup for recomputation during forward propagation:",

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -277,6 +277,7 @@ public:
   }
 
   void error_trace(const string &message, const string &name_on_error) {
+    // TODO: Optional verbosity
     std::cerr << message << std::endl;
     for (auto &name : history_) {
       std::cerr << "  " << name << std::endl;
@@ -746,7 +747,7 @@ void CgVariable::visit_function_backward(
   set<tuple<int, uint64_t, CgFunctionPtr>> open;
   open.insert(make_tuple(-p->rank(), get_id(p), p));
 
-  // for forward recomputation
+  // For forward recomputation
   ForwardCallback forward_callback(false /* clear_buffer */,
                                    true /* clear_no_need_grad */,
                                    true /* recomputation */, nullptr, nullptr);

--- a/src/nbla/function.cpp
+++ b/src/nbla/function.cpp
@@ -163,19 +163,17 @@ void Function::backward(const Variables &inputs, const Variables &outputs,
 }
 
 void Function::setup_recompute(const Variables &inputs,
-                               const Variables &outputs,
-                               const vector<bool> &need_recompute) {
-  this->setup_recompute_impl(inputs, outputs, need_recompute);
+                               const Variables &outputs) {
+  this->setup_recompute_impl(inputs, outputs);
 }
 
-void Function::recompute(const Variables &inputs, const Variables &outputs,
-                         const vector<bool> &need_recompute) {
+void Function::recompute(const Variables &inputs, const Variables &outputs) {
   if (fall_back_func_) {
     // Fall back to the specified Function.
-    fall_back_func_->recompute(inputs, outputs, need_recompute);
+    fall_back_func_->recompute(inputs, outputs);
     return;
   }
-  this->recompute_impl(inputs, outputs, need_recompute);
+  this->recompute_impl(inputs, outputs);
 }
 
 Context Function::context() const { return ctx_; }

--- a/src/nbla/function.cpp
+++ b/src/nbla/function.cpp
@@ -162,5 +162,21 @@ void Function::backward(const Variables &inputs, const Variables &outputs,
   this->backward_impl(inputs, outputs, propagate_down, accum);
 }
 
+void Function::setup_recompute(const Variables &inputs,
+                               const Variables &outputs,
+                               const vector<bool> &need_recompute) {
+  this->setup_recompute_impl(inputs, outputs, need_recompute);
+}
+
+void Function::recompute(const Variables &inputs, const Variables &outputs,
+                         const vector<bool> &need_recompute) {
+  if (fall_back_func_) {
+    // Fall back to the specified Function.
+    fall_back_func_->recompute(inputs, outputs, need_recompute);
+    return;
+  }
+  this->recompute_impl(inputs, outputs, need_recompute);
+}
+
 Context Function::context() const { return ctx_; }
 }

--- a/src/nbla/function/generic/batch_normalization.cpp
+++ b/src/nbla/function/generic/batch_normalization.cpp
@@ -141,8 +141,7 @@ void BatchNormalization<T>::forward_impl(const Variables &inputs,
 
 template <class T>
 void BatchNormalization<T>::recompute_impl(const Variables &inputs,
-                                           const Variables &outputs,
-                                           const vector<bool> &need_recompute) {
+                                           const Variables &outputs) {
   if (batch_stat_) { // Training mode.
     // Prohibit updating running mean and running variance during recomputation
     forward_impl_batch(inputs, outputs,

--- a/src/nbla/function/generic/dropout.cpp
+++ b/src/nbla/function/generic/dropout.cpp
@@ -39,8 +39,7 @@ void Dropout<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 
 template <typename T>
 void Dropout<T>::setup_recompute_impl(const Variables &inputs,
-                                      const Variables &outputs,
-                                      const vector<bool> &need_recompute) {
+                                      const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -72,8 +71,7 @@ void Dropout<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void Dropout<T>::recompute_impl(const Variables &inputs,
-                                const Variables &outputs,
-                                const vector<bool> &need_recompute) {
+                                const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   dropout(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/dropout.cpp
+++ b/src/nbla/function/generic/dropout.cpp
@@ -41,7 +41,7 @@ template <typename T>
 void Dropout<T>::setup_recompute_impl(const Variables &inputs,
                                       const Variables &outputs,
                                       const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <class T>
@@ -63,8 +63,8 @@ void Dropout<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   dropout(inputs, outputs, rgen);
@@ -74,8 +74,7 @@ template <typename T>
 void Dropout<T>::recompute_impl(const Variables &inputs,
                                 const Variables &outputs,
                                 const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   dropout(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/fused_batch_normalization.cpp
+++ b/src/nbla/function/generic/fused_batch_normalization.cpp
@@ -84,6 +84,32 @@ void FusedBatchNormalization<T>::forward_impl(const Variables &inputs,
 }
 
 template <class T>
+void FusedBatchNormalization<T>::recompute_impl(
+    const Variables &inputs, const Variables &outputs,
+    const vector<bool> &need_recompute) {
+
+  NBLA_CHECK(bn_, error_code::value, "setup is not called.");
+  // Naive non-fused implementation by layer composition.
+  // 1. Perform BatchNormalization
+  Variables inputs_bn(inputs.begin(), inputs.begin() + 5);
+  bn_->recompute(inputs_bn, outputs, need_recompute);
+
+  // 2. Perform Add2
+  // NOTE: Output buffer are re-used by inplacing.
+  if (inputs.size() == 6) {
+    auto add2 = create_Add2(this->ctx_, true);
+    add2->setup(Variables{outputs[0], inputs[5]}, Variables{outputs[0]});
+    add2->forward(Variables{outputs[0], inputs[5]}, Variables{outputs[0]});
+  }
+
+  // 3. Perform ReLU
+  // NOTE: Output buffer are re-used by inplacing.
+  auto relu = create_ReLU(this->ctx_, true);
+  relu->setup(Variables{outputs[0]}, Variables{outputs[0]});
+  relu->forward(Variables{outputs[0]}, Variables{outputs[0]});
+}
+
+template <class T>
 void FusedBatchNormalization<T>::backward_impl(
     const Variables &inputs, const Variables &outputs,
     const vector<bool> &propagate_down, const vector<bool> &accum) {

--- a/src/nbla/function/generic/fused_batch_normalization.cpp
+++ b/src/nbla/function/generic/fused_batch_normalization.cpp
@@ -84,15 +84,14 @@ void FusedBatchNormalization<T>::forward_impl(const Variables &inputs,
 }
 
 template <class T>
-void FusedBatchNormalization<T>::recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void FusedBatchNormalization<T>::recompute_impl(const Variables &inputs,
+                                                const Variables &outputs) {
 
   NBLA_CHECK(bn_, error_code::value, "setup is not called.");
   // Naive non-fused implementation by layer composition.
   // 1. Perform BatchNormalization
   Variables inputs_bn(inputs.begin(), inputs.begin() + 5);
-  bn_->recompute(inputs_bn, outputs, need_recompute);
+  bn_->recompute(inputs_bn, outputs);
 
   // 2. Perform Add2
   // NOTE: Output buffer are re-used by inplacing.

--- a/src/nbla/function/generic/fused_convolution.cpp
+++ b/src/nbla/function/generic/fused_convolution.cpp
@@ -223,6 +223,7 @@ void FusedConvolution<T>::setup_impl(const Variables &inputs,
   // array.
   std::unordered_set<CgFunctionPtr> fclosed;
   last_out->visit_function_recursive(last_out->parent(), fclosed,
+                                     false /* recomputation */,
                                      [](CgFunctionPtr fn) { fn->setup(); });
   this->last_output_cg_variable_ = last_out;
 }
@@ -264,7 +265,8 @@ void FusedConvolution<T>::backward_impl(const Variables &inputs,
   // Propagate need_grad states
   std::unordered_set<CgFunctionPtr> fclosed;
   last_output_cg_variable_->visit_function_recursive(
-      last_output_cg_variable_->parent(), fclosed, [](CgFunctionPtr fn) {});
+      last_output_cg_variable_->parent(), fclosed, false /* recomputation */,
+      [](CgFunctionPtr fn) {});
 
   last_output_cg_variable_->backward(outputs[0]->grad(), true);
 }

--- a/src/nbla/function/generic/fused_convolution.cpp
+++ b/src/nbla/function/generic/fused_convolution.cpp
@@ -223,7 +223,7 @@ void FusedConvolution<T>::setup_impl(const Variables &inputs,
   // array.
   std::unordered_set<CgFunctionPtr> fclosed;
   last_out->visit_function_recursive(last_out->parent(), fclosed,
-                                     false /* recomputation */,
+                                     false /* as_recomputation */,
                                      [](CgFunctionPtr fn) { fn->setup(); });
   this->last_output_cg_variable_ = last_out;
 }

--- a/src/nbla/function/generic/fused_convolution.cpp
+++ b/src/nbla/function/generic/fused_convolution.cpp
@@ -239,8 +239,7 @@ void FusedConvolution<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void FusedConvolution<T>::recompute_impl(const Variables &inputs,
-                                         const Variables &outputs,
-                                         const vector<bool> &need_recompute) {
+                                         const Variables &outputs) {
   // Prohibit updating running mean and running variance.
   // Use dummy buffers for rm and rv when batch_norm is fused and `batch_stat_
   // == true`.

--- a/src/nbla/function/generic/image_augmentation.cpp
+++ b/src/nbla/function/generic/image_augmentation.cpp
@@ -52,9 +52,8 @@ void ImageAugmentation<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
-void ImageAugmentation<T>::setup_recompute_impl(
-    const Variables &inputs, const Variables &outputs,
-    const vector<bool> &need_recompute) {
+void ImageAugmentation<T>::setup_recompute_impl(const Variables &inputs,
+                                                const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -306,8 +305,7 @@ void ImageAugmentation<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void ImageAugmentation<T>::recompute_impl(const Variables &inputs,
-                                          const Variables &outputs,
-                                          const vector<bool> &need_recompute) {
+                                          const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   image_augmentation(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/image_augmentation.cpp
+++ b/src/nbla/function/generic/image_augmentation.cpp
@@ -55,7 +55,7 @@ template <typename T>
 void ImageAugmentation<T>::setup_recompute_impl(
     const Variables &inputs, const Variables &outputs,
     const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -297,8 +297,8 @@ void ImageAugmentation<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   image_augmentation(inputs, outputs, rgen);
@@ -308,8 +308,7 @@ template <typename T>
 void ImageAugmentation<T>::recompute_impl(const Variables &inputs,
                                           const Variables &outputs,
                                           const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   image_augmentation(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/inq_affine.cpp
+++ b/src/nbla/function/generic/inq_affine.cpp
@@ -203,6 +203,18 @@ void INQAffine<T, T1>::forward_impl(const Variables &inputs,
 }
 
 template <typename T, typename T1>
+void INQAffine<T, T1>::recompute_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &need_recompute) {
+  // Just exec affine with inputs which prepared in previous forward execution.
+  if (inputs.size() == 4) { // with bias
+    affine_->forward(Variables{inputs[0], inputs[1], inputs[3]}, outputs);
+  } else {
+    affine_->forward(Variables{inputs[0], inputs[1]}, outputs);
+  }
+}
+
+template <typename T, typename T1>
 void INQAffine<T, T1>::backward_impl(const Variables &inputs,
                                      const Variables &outputs,
                                      const vector<bool> &prop_down,

--- a/src/nbla/function/generic/inq_affine.cpp
+++ b/src/nbla/function/generic/inq_affine.cpp
@@ -204,8 +204,7 @@ void INQAffine<T, T1>::forward_impl(const Variables &inputs,
 
 template <typename T, typename T1>
 void INQAffine<T, T1>::recompute_impl(const Variables &inputs,
-                                      const Variables &outputs,
-                                      const vector<bool> &need_recompute) {
+                                      const Variables &outputs) {
   // Just exec affine with inputs which prepared in previous forward execution.
   if (inputs.size() == 4) { // with bias
     affine_->forward(Variables{inputs[0], inputs[1], inputs[3]}, outputs);

--- a/src/nbla/function/generic/inq_convolution.cpp
+++ b/src/nbla/function/generic/inq_convolution.cpp
@@ -206,6 +206,19 @@ void INQConvolution<T, T1>::forward_impl(const Variables &inputs,
 }
 
 template <typename T, typename T1>
+void INQConvolution<T, T1>::recompute_impl(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &need_recompute) {
+  // Just exec convolution with inputs which prepared in previous forward
+  // execution.
+  if (inputs.size() == 4) { // with bias
+    convolution_->forward(Variables{inputs[0], inputs[1], inputs[3]}, outputs);
+  } else {
+    convolution_->forward(Variables{inputs[0], inputs[1]}, outputs);
+  }
+}
+
+template <typename T, typename T1>
 void INQConvolution<T, T1>::backward_impl(const Variables &inputs,
                                           const Variables &outputs,
                                           const vector<bool> &prop_down,

--- a/src/nbla/function/generic/inq_convolution.cpp
+++ b/src/nbla/function/generic/inq_convolution.cpp
@@ -207,8 +207,7 @@ void INQConvolution<T, T1>::forward_impl(const Variables &inputs,
 
 template <typename T, typename T1>
 void INQConvolution<T, T1>::recompute_impl(const Variables &inputs,
-                                           const Variables &outputs,
-                                           const vector<bool> &need_recompute) {
+                                           const Variables &outputs) {
   // Just exec convolution with inputs which prepared in previous forward
   // execution.
   if (inputs.size() == 4) { // with bias

--- a/src/nbla/function/generic/mean_subtraction.cpp
+++ b/src/nbla/function/generic/mean_subtraction.cpp
@@ -82,6 +82,13 @@ void MeanSubtraction<T>::forward_impl(const Variables &inputs,
 }
 
 template <class T>
+void MeanSubtraction<T>::recompute_impl(const Variables &inputs,
+                                        const Variables &outputs,
+                                        const vector<bool> &need_recompute) {
+  forward_impl_global(inputs, outputs);
+}
+
+template <class T>
 void MeanSubtraction<T>::forward_impl_batch(const Variables &inputs,
                                             const Variables &outputs) {
   // Inputs

--- a/src/nbla/function/generic/mean_subtraction.cpp
+++ b/src/nbla/function/generic/mean_subtraction.cpp
@@ -83,8 +83,7 @@ void MeanSubtraction<T>::forward_impl(const Variables &inputs,
 
 template <class T>
 void MeanSubtraction<T>::recompute_impl(const Variables &inputs,
-                                        const Variables &outputs,
-                                        const vector<bool> &need_recompute) {
+                                        const Variables &outputs) {
   forward_impl_global(inputs, outputs);
 }
 

--- a/src/nbla/function/generic/rand.cpp
+++ b/src/nbla/function/generic/rand.cpp
@@ -33,8 +33,7 @@ void Rand<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 
 template <typename T>
 void Rand<T>::setup_recompute_impl(const Variables &inputs,
-                                   const Variables &outputs,
-                                   const vector<bool> &need_recompute) {
+                                   const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -57,8 +56,8 @@ void Rand<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
 }
 
 template <typename T>
-void Rand<T>::recompute_impl(const Variables &inputs, const Variables &outputs,
-                             const vector<bool> &need_recompute) {
+void Rand<T>::recompute_impl(const Variables &inputs,
+                             const Variables &outputs) {
   std::uniform_real_distribution<typename force_float<T>::type> rdist(low_,
                                                                       high_);
   auto rgen = rgen_for_recompute_;

--- a/src/nbla/function/generic/rand.cpp
+++ b/src/nbla/function/generic/rand.cpp
@@ -35,7 +35,7 @@ template <typename T>
 void Rand<T>::setup_recompute_impl(const Variables &inputs,
                                    const Variables &outputs,
                                    const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -46,8 +46,8 @@ void Rand<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -61,7 +61,7 @@ void Rand<T>::recompute_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &need_recompute) {
   std::uniform_real_distribution<typename force_float<T>::type> rdist(low_,
                                                                       high_);
-  std::mt19937 &rgen = *rgen_for_recompute_;
+  auto rgen = rgen_for_recompute_;
 
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < outputs[0]->size(); s++) {

--- a/src/nbla/function/generic/rand.cpp
+++ b/src/nbla/function/generic/rand.cpp
@@ -32,12 +32,37 @@ void Rand<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 }
 
 template <typename T>
+void Rand<T>::setup_recompute_impl(const Variables &inputs,
+                                   const Variables &outputs,
+                                   const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
 void Rand<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   std::uniform_real_distribution<typename force_float<T>::type> rdist(low_,
                                                                       high_);
   std::mt19937 &rgen =
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
+  for (int s = 0; s < outputs[0]->size(); s++) {
+    y[s] = rdist(rgen);
+  }
+}
+
+template <typename T>
+void Rand<T>::recompute_impl(const Variables &inputs, const Variables &outputs,
+                             const vector<bool> &need_recompute) {
+  std::uniform_real_distribution<typename force_float<T>::type> rdist(low_,
+                                                                      high_);
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < outputs[0]->size(); s++) {
     y[s] = rdist(rgen);

--- a/src/nbla/function/generic/rand_beta.cpp
+++ b/src/nbla/function/generic/rand_beta.cpp
@@ -35,8 +35,7 @@ void RandBeta<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandBeta<T>::setup_recompute_impl(const Variables &inputs,
-                                       const Variables &outputs,
-                                       const vector<bool> &need_recompute) {
+                                       const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -99,8 +98,7 @@ void RandBeta<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandBeta<T>::recompute_impl(const Variables &inputs,
-                                 const Variables &outputs,
-                                 const vector<bool> &need_recompute) {
+                                 const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   random_beta(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/rand_beta.cpp
+++ b/src/nbla/function/generic/rand_beta.cpp
@@ -37,7 +37,7 @@ template <typename T>
 void RandBeta<T>::setup_recompute_impl(const Variables &inputs,
                                        const Variables &outputs,
                                        const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -90,8 +90,8 @@ void RandBeta<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   random_beta(inputs, outputs, rgen);
@@ -101,8 +101,7 @@ template <typename T>
 void RandBeta<T>::recompute_impl(const Variables &inputs,
                                  const Variables &outputs,
                                  const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   random_beta(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/rand_beta.cpp
+++ b/src/nbla/function/generic/rand_beta.cpp
@@ -34,14 +34,18 @@ void RandBeta<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
-void RandBeta<T>::forward_impl(const Variables &inputs,
-                               const Variables &outputs) {
+void RandBeta<T>::setup_recompute_impl(const Variables &inputs,
+                                       const Variables &outputs,
+                                       const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
+void RandBeta<T>::random_beta(const Variables &inputs, const Variables &outputs,
+                              std::mt19937 &rgen) {
   std::uniform_real_distribution<typename force_float<T>::type> rdist(0.0, 1.0);
   std::gamma_distribution<typename force_float<T>::type> gdist1(alpha_, 1);
   std::gamma_distribution<typename force_float<T>::type> gdist2(beta_, 1);
-  std::mt19937 &rgen =
-      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
-                  : rgen_;
 
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   if ((alpha_ <= 1.0) && (beta_ <= 1.0)) {
@@ -77,6 +81,29 @@ void RandBeta<T>::forward_impl(const Variables &inputs,
       y[s] = Ga / (Ga + Gb);
     }
   }
+}
+
+template <typename T>
+void RandBeta<T>::forward_impl(const Variables &inputs,
+                               const Variables &outputs) {
+  std::mt19937 &rgen =
+      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
+                  : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  random_beta(inputs, outputs, rgen);
+}
+
+template <typename T>
+void RandBeta<T>::recompute_impl(const Variables &inputs,
+                                 const Variables &outputs,
+                                 const vector<bool> &need_recompute) {
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
+  random_beta(inputs, outputs, rgen);
 }
 
 template <typename T>

--- a/src/nbla/function/generic/rand_binomial.cpp
+++ b/src/nbla/function/generic/rand_binomial.cpp
@@ -36,8 +36,7 @@ void RandBinomial<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandBinomial<T>::setup_recompute_impl(const Variables &inputs,
-                                           const Variables &outputs,
-                                           const vector<bool> &need_recompute) {
+                                           const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -61,8 +60,7 @@ void RandBinomial<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandBinomial<T>::recompute_impl(const Variables &inputs,
-                                     const Variables &outputs,
-                                     const vector<bool> &need_recompute) {
+                                     const Variables &outputs) {
   std::binomial_distribution<int> rdist(n_, p_);
   auto rgen = rgen_for_recompute_;
 

--- a/src/nbla/function/generic/rand_binomial.cpp
+++ b/src/nbla/function/generic/rand_binomial.cpp
@@ -38,7 +38,7 @@ template <typename T>
 void RandBinomial<T>::setup_recompute_impl(const Variables &inputs,
                                            const Variables &outputs,
                                            const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -49,8 +49,8 @@ void RandBinomial<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -64,7 +64,7 @@ void RandBinomial<T>::recompute_impl(const Variables &inputs,
                                      const Variables &outputs,
                                      const vector<bool> &need_recompute) {
   std::binomial_distribution<int> rdist(n_, p_);
-  std::mt19937 &rgen = *rgen_for_recompute_;
+  auto rgen = rgen_for_recompute_;
 
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < outputs[0]->size(); s++) {

--- a/src/nbla/function/generic/rand_gamma.cpp
+++ b/src/nbla/function/generic/rand_gamma.cpp
@@ -36,7 +36,7 @@ template <typename T>
 void RandGamma<T>::setup_recompute_impl(const Variables &inputs,
                                         const Variables &outputs,
                                         const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -47,8 +47,8 @@ void RandGamma<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -62,7 +62,7 @@ void RandGamma<T>::recompute_impl(const Variables &inputs,
                                   const Variables &outputs,
                                   const vector<bool> &need_recompute) {
   std::gamma_distribution<typename force_float<T>::type> rdist(k_, theta_);
-  std::mt19937 &rgen = *rgen_for_recompute_;
+  auto rgen = rgen_for_recompute_;
 
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < outputs[0]->size(); s++) {

--- a/src/nbla/function/generic/rand_gamma.cpp
+++ b/src/nbla/function/generic/rand_gamma.cpp
@@ -34,8 +34,7 @@ void RandGamma<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandGamma<T>::setup_recompute_impl(const Variables &inputs,
-                                        const Variables &outputs,
-                                        const vector<bool> &need_recompute) {
+                                        const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -59,8 +58,7 @@ void RandGamma<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandGamma<T>::recompute_impl(const Variables &inputs,
-                                  const Variables &outputs,
-                                  const vector<bool> &need_recompute) {
+                                  const Variables &outputs) {
   std::gamma_distribution<typename force_float<T>::type> rdist(k_, theta_);
   auto rgen = rgen_for_recompute_;
 

--- a/src/nbla/function/generic/rand_gamma.cpp
+++ b/src/nbla/function/generic/rand_gamma.cpp
@@ -33,12 +33,37 @@ void RandGamma<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
+void RandGamma<T>::setup_recompute_impl(const Variables &inputs,
+                                        const Variables &outputs,
+                                        const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
 void RandGamma<T>::forward_impl(const Variables &inputs,
                                 const Variables &outputs) {
   std::gamma_distribution<typename force_float<T>::type> rdist(k_, theta_);
   std::mt19937 &rgen =
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
+  for (int s = 0; s < outputs[0]->size(); s++) {
+    y[s] = (T)rdist(rgen);
+  }
+}
+
+template <typename T>
+void RandGamma<T>::recompute_impl(const Variables &inputs,
+                                  const Variables &outputs,
+                                  const vector<bool> &need_recompute) {
+  std::gamma_distribution<typename force_float<T>::type> rdist(k_, theta_);
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < outputs[0]->size(); s++) {
     y[s] = (T)rdist(rgen);

--- a/src/nbla/function/generic/randint.cpp
+++ b/src/nbla/function/generic/randint.cpp
@@ -33,8 +33,7 @@ void Randint<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 
 template <typename T>
 void Randint<T>::setup_recompute_impl(const Variables &inputs,
-                                      const Variables &outputs,
-                                      const vector<bool> &need_recompute) {
+                                      const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -59,8 +58,7 @@ void Randint<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void Randint<T>::recompute_impl(const Variables &inputs,
-                                const Variables &outputs,
-                                const vector<bool> &need_recompute) {
+                                const Variables &outputs) {
   std::uniform_int_distribution<int> rdist(low_, high_ - 1);
   auto rgen = rgen_for_recompute_;
 

--- a/src/nbla/function/generic/randn.cpp
+++ b/src/nbla/function/generic/randn.cpp
@@ -33,8 +33,7 @@ void Randn<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 
 template <typename T>
 void Randn<T>::setup_recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute) {
+                                    const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -56,8 +55,8 @@ void Randn<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
 }
 
 template <typename T>
-void Randn<T>::recompute_impl(const Variables &inputs, const Variables &outputs,
-                              const vector<bool> &need_recompute) {
+void Randn<T>::recompute_impl(const Variables &inputs,
+                              const Variables &outputs) {
   std::normal_distribution<typename force_float<T>::type> rdist(mu_, sigma_);
   auto rgen = rgen_for_recompute_;
 

--- a/src/nbla/function/generic/randn.cpp
+++ b/src/nbla/function/generic/randn.cpp
@@ -32,11 +32,35 @@ void Randn<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 }
 
 template <typename T>
+void Randn<T>::setup_recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
 void Randn<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   std::normal_distribution<typename force_float<T>::type> rdist(mu_, sigma_);
   std::mt19937 &rgen =
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
+  for (int s = 0; s < outputs[0]->size(); s++) {
+    y[s] = (T)rdist(rgen);
+  }
+}
+
+template <typename T>
+void Randn<T>::recompute_impl(const Variables &inputs, const Variables &outputs,
+                              const vector<bool> &need_recompute) {
+  std::normal_distribution<typename force_float<T>::type> rdist(mu_, sigma_);
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < outputs[0]->size(); s++) {
     y[s] = (T)rdist(rgen);

--- a/src/nbla/function/generic/random_choice.cpp
+++ b/src/nbla/function/generic/random_choice.cpp
@@ -58,8 +58,16 @@ void RandomChoice<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
-void RandomChoice<T>::forward_impl(const Variables &inputs,
-                                   const Variables &outputs) {
+void RandomChoice<T>::setup_recompute_impl(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
+void RandomChoice<T>::random_choice(const Variables &inputs,
+                                    const Variables &outputs,
+                                    std::mt19937 &rgen) {
   using std::uniform_real_distribution;
   using std::partial_sum;
   using std::count_if;
@@ -71,9 +79,6 @@ void RandomChoice<T>::forward_impl(const Variables &inputs,
   auto idxbuf = idxbuf_.cast_data_and_get_pointer<int>(this->ctx_, true);
   auto w_size = inputs[0]->shape().back(); // size of each weight vector
   auto less_0 = std::bind(std::less<T>(), std::placeholders::_1, (T)0);
-  std::mt19937 &rgen =
-      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
-                  : rgen_;
 
   if (replace_ == true) {
     vector<T> w_sum(w_size);
@@ -131,6 +136,29 @@ void RandomChoice<T>::forward_impl(const Variables &inputs,
       x_data += w_size;
     }
   }
+}
+
+template <typename T>
+void RandomChoice<T>::forward_impl(const Variables &inputs,
+                                   const Variables &outputs) {
+  std::mt19937 &rgen =
+      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
+                  : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  random_choice(inputs, outputs, rgen);
+}
+
+template <typename T>
+void RandomChoice<T>::recompute_impl(const Variables &inputs,
+                                     const Variables &outputs,
+                                     const vector<bool> &need_recompute) {
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
+  random_choice(inputs, outputs, rgen);
 }
 
 template <typename T>

--- a/src/nbla/function/generic/random_choice.cpp
+++ b/src/nbla/function/generic/random_choice.cpp
@@ -61,7 +61,7 @@ template <typename T>
 void RandomChoice<T>::setup_recompute_impl(const Variables &inputs,
                                            const Variables &outputs,
                                            const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -145,8 +145,8 @@ void RandomChoice<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   random_choice(inputs, outputs, rgen);
@@ -156,8 +156,7 @@ template <typename T>
 void RandomChoice<T>::recompute_impl(const Variables &inputs,
                                      const Variables &outputs,
                                      const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   random_choice(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/random_choice.cpp
+++ b/src/nbla/function/generic/random_choice.cpp
@@ -59,8 +59,7 @@ void RandomChoice<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandomChoice<T>::setup_recompute_impl(const Variables &inputs,
-                                           const Variables &outputs,
-                                           const vector<bool> &need_recompute) {
+                                           const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -154,8 +153,7 @@ void RandomChoice<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomChoice<T>::recompute_impl(const Variables &inputs,
-                                     const Variables &outputs,
-                                     const vector<bool> &need_recompute) {
+                                     const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   random_choice(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/random_crop.cpp
+++ b/src/nbla/function/generic/random_crop.cpp
@@ -129,7 +129,7 @@ template <typename T>
 void RandomCrop<T>::setup_recompute_impl(const Variables &inputs,
                                          const Variables &outputs,
                                          const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -169,8 +169,8 @@ void RandomCrop<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   random_crop(inputs, outputs, rgen);
@@ -180,8 +180,7 @@ template <typename T>
 void RandomCrop<T>::recompute_impl(const Variables &inputs,
                                    const Variables &outputs,
                                    const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   random_crop(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/random_crop.cpp
+++ b/src/nbla/function/generic/random_crop.cpp
@@ -127,8 +127,7 @@ void RandomCrop<T>::slice_backward_recursive(Variable *outp,
 
 template <typename T>
 void RandomCrop<T>::setup_recompute_impl(const Variables &inputs,
-                                         const Variables &outputs,
-                                         const vector<bool> &need_recompute) {
+                                         const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -178,8 +177,7 @@ void RandomCrop<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomCrop<T>::recompute_impl(const Variables &inputs,
-                                   const Variables &outputs,
-                                   const vector<bool> &need_recompute) {
+                                   const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   random_crop(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/random_erase.cpp
+++ b/src/nbla/function/generic/random_erase.cpp
@@ -220,8 +220,7 @@ void RandomErase<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void RandomErase<T>::setup_recompute_impl(const Variables &inputs,
-                                          const Variables &outputs,
-                                          const vector<bool> &need_recompute) {
+                                          const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -294,8 +293,7 @@ void RandomErase<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomErase<T>::recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute) {
+                                    const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   random_erase(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/random_erase.cpp
+++ b/src/nbla/function/generic/random_erase.cpp
@@ -219,8 +219,16 @@ void RandomErase<T>::setup_impl(const Variables &inputs,
 }
 
 template <typename T>
-void RandomErase<T>::forward_impl(const Variables &inputs,
-                                  const Variables &outputs) {
+void RandomErase<T>::setup_recompute_impl(const Variables &inputs,
+                                          const Variables &outputs,
+                                          const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
+void RandomErase<T>::random_erase(const Variables &inputs,
+                                  const Variables &outputs,
+                                  std::mt19937 &rgen) {
   NBLA_CHECK(!channel_last_, error_code::value,
              "Channel Last is not supported in CPU.");
 
@@ -232,9 +240,6 @@ void RandomErase<T>::forward_impl(const Variables &inputs,
   auto H = shape[base_axis_ + 1];
   auto W = shape[base_axis_ + 2];
   auto Bs = C * H * W;
-  std::mt19937 &rgen =
-      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
-                  : rgen_;
 
   const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, !inplace_);
@@ -271,6 +276,29 @@ void RandomErase<T>::forward_impl(const Variables &inputs,
   if (!ste_fine_grained_) {
     this->random_coordinates_ = nullptr;
   }
+}
+
+template <typename T>
+void RandomErase<T>::forward_impl(const Variables &inputs,
+                                  const Variables &outputs) {
+  std::mt19937 &rgen =
+      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
+                  : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  random_erase(inputs, outputs, rgen);
+}
+
+template <typename T>
+void RandomErase<T>::recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute) {
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
+  random_erase(inputs, outputs, rgen);
 }
 
 template <typename T>

--- a/src/nbla/function/generic/random_erase.cpp
+++ b/src/nbla/function/generic/random_erase.cpp
@@ -222,7 +222,7 @@ template <typename T>
 void RandomErase<T>::setup_recompute_impl(const Variables &inputs,
                                           const Variables &outputs,
                                           const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -285,8 +285,8 @@ void RandomErase<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   random_erase(inputs, outputs, rgen);
@@ -296,8 +296,7 @@ template <typename T>
 void RandomErase<T>::recompute_impl(const Variables &inputs,
                                     const Variables &outputs,
                                     const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   random_erase(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/random_flip.cpp
+++ b/src/nbla/function/generic/random_flip.cpp
@@ -84,7 +84,7 @@ template <typename T>
 void RandomFlip<T>::setup_recompute_impl(const Variables &inputs,
                                          const Variables &outputs,
                                          const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -113,8 +113,8 @@ void RandomFlip<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   random_flip(inputs, outputs, rgen);
@@ -124,8 +124,7 @@ template <typename T>
 void RandomFlip<T>::recompute_impl(const Variables &inputs,
                                    const Variables &outputs,
                                    const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   random_flip(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/random_flip.cpp
+++ b/src/nbla/function/generic/random_flip.cpp
@@ -81,11 +81,15 @@ void RandomFlip<T>::flip_recursive(const Variable *inp, const T *x, T *y,
 }
 
 template <typename T>
-void RandomFlip<T>::forward_impl(const Variables &inputs,
-                                 const Variables &outputs) {
-  std::mt19937 &rgen =
-      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
-                  : rgen_;
+void RandomFlip<T>::setup_recompute_impl(const Variables &inputs,
+                                         const Variables &outputs,
+                                         const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
+void RandomFlip<T>::random_flip(const Variables &inputs,
+                                const Variables &outputs, std::mt19937 &rgen) {
   flip_.resize(size_);
   auto input0_shape_size = inputs[0]->shape().size();
   for (int i = 0; i < size_; i++) {
@@ -100,6 +104,29 @@ void RandomFlip<T>::forward_impl(const Variables &inputs,
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   int flip_index = 0;
   flip_recursive(inputs[0], x, y, false, 0, 0, 0, flip_index);
+}
+
+template <typename T>
+void RandomFlip<T>::forward_impl(const Variables &inputs,
+                                 const Variables &outputs) {
+  std::mt19937 &rgen =
+      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
+                  : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  random_flip(inputs, outputs, rgen);
+}
+
+template <typename T>
+void RandomFlip<T>::recompute_impl(const Variables &inputs,
+                                   const Variables &outputs,
+                                   const vector<bool> &need_recompute) {
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
+  random_flip(inputs, outputs, rgen);
 }
 
 template <typename T>

--- a/src/nbla/function/generic/random_flip.cpp
+++ b/src/nbla/function/generic/random_flip.cpp
@@ -82,8 +82,7 @@ void RandomFlip<T>::flip_recursive(const Variable *inp, const T *x, T *y,
 
 template <typename T>
 void RandomFlip<T>::setup_recompute_impl(const Variables &inputs,
-                                         const Variables &outputs,
-                                         const vector<bool> &need_recompute) {
+                                         const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -122,8 +121,7 @@ void RandomFlip<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomFlip<T>::recompute_impl(const Variables &inputs,
-                                   const Variables &outputs,
-                                   const vector<bool> &need_recompute) {
+                                   const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   random_flip(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/random_shift.cpp
+++ b/src/nbla/function/generic/random_shift.cpp
@@ -142,7 +142,7 @@ template <typename T>
 void RandomShift<T>::setup_recompute_impl(const Variables &inputs,
                                           const Variables &outputs,
                                           const vector<bool> &need_recompute) {
-  rgen_for_recompute_.reset();
+  save_rng_ = true;
 }
 
 template <typename T>
@@ -171,8 +171,8 @@ void RandomShift<T>::forward_impl(const Variables &inputs,
       seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
                   : rgen_;
   // Remember the random state for recomputation.
-  if (!rgen_for_recompute_) {
-    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  if (save_rng_) {
+    rgen_for_recompute_ = rgen;
   }
 
   random_shift(inputs, outputs, rgen);
@@ -182,8 +182,7 @@ template <typename T>
 void RandomShift<T>::recompute_impl(const Variables &inputs,
                                     const Variables &outputs,
                                     const vector<bool> &need_recompute) {
-  std::mt19937 &rgen = *rgen_for_recompute_;
-
+  auto rgen = rgen_for_recompute_;
   random_shift(inputs, outputs, rgen);
 }
 

--- a/src/nbla/function/generic/random_shift.cpp
+++ b/src/nbla/function/generic/random_shift.cpp
@@ -139,11 +139,16 @@ void RandomShift<T>::shift_backward_recursive(const Variable *inp, const T *dy,
 }
 
 template <typename T>
-void RandomShift<T>::forward_impl(const Variables &inputs,
-                                  const Variables &outputs) {
-  std::mt19937 &rgen =
-      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
-                  : rgen_;
+void RandomShift<T>::setup_recompute_impl(const Variables &inputs,
+                                          const Variables &outputs,
+                                          const vector<bool> &need_recompute) {
+  rgen_for_recompute_.reset();
+}
+
+template <typename T>
+void RandomShift<T>::random_shift(const Variables &inputs,
+                                  const Variables &outputs,
+                                  std::mt19937 &rgen) {
   addr_table_.resize(size_);
   for (int i = 0; i < size_; i++) {
     vector<int> shifts;
@@ -157,6 +162,29 @@ void RandomShift<T>::forward_impl(const Variables &inputs,
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   int shift_index = 0;
   shift_recursive(inputs[0], x, y, 0, 0, 0, shift_index);
+}
+
+template <typename T>
+void RandomShift<T>::forward_impl(const Variables &inputs,
+                                  const Variables &outputs) {
+  std::mt19937 &rgen =
+      seed_ == -1 ? SingletonManager::get<RandomManager>()->get_rand_generator()
+                  : rgen_;
+  // Remember the random state for recomputation.
+  if (!rgen_for_recompute_) {
+    rgen_for_recompute_ = std::make_shared<std::mt19937>(rgen);
+  }
+
+  random_shift(inputs, outputs, rgen);
+}
+
+template <typename T>
+void RandomShift<T>::recompute_impl(const Variables &inputs,
+                                    const Variables &outputs,
+                                    const vector<bool> &need_recompute) {
+  std::mt19937 &rgen = *rgen_for_recompute_;
+
+  random_shift(inputs, outputs, rgen);
 }
 
 template <typename T>

--- a/src/nbla/function/generic/random_shift.cpp
+++ b/src/nbla/function/generic/random_shift.cpp
@@ -140,8 +140,7 @@ void RandomShift<T>::shift_backward_recursive(const Variable *inp, const T *dy,
 
 template <typename T>
 void RandomShift<T>::setup_recompute_impl(const Variables &inputs,
-                                          const Variables &outputs,
-                                          const vector<bool> &need_recompute) {
+                                          const Variables &outputs) {
   save_rng_ = true;
 }
 
@@ -180,8 +179,7 @@ void RandomShift<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void RandomShift<T>::recompute_impl(const Variables &inputs,
-                                    const Variables &outputs,
-                                    const vector<bool> &need_recompute) {
+                                    const Variables &outputs) {
   auto rgen = rgen_for_recompute_;
   random_shift(inputs, outputs, rgen);
 }

--- a/src/nbla/function/generic/spectral_norm.cpp
+++ b/src/nbla/function/generic/spectral_norm.cpp
@@ -219,6 +219,7 @@ void SpectralNorm<T>::setup_impl(const Variables &inputs,
   // array.
   std::unordered_set<CgFunctionPtr> fclosed;
   last_out->visit_function_recursive(last_out->parent(), fclosed,
+                                     false /* recomputation */,
                                      [](CgFunctionPtr fn) { fn->setup(); });
   this->last_output_cg_variable_ = last_out;
 }

--- a/src/nbla/function/generic/spectral_norm.cpp
+++ b/src/nbla/function/generic/spectral_norm.cpp
@@ -219,7 +219,7 @@ void SpectralNorm<T>::setup_impl(const Variables &inputs,
   // array.
   std::unordered_set<CgFunctionPtr> fclosed;
   last_out->visit_function_recursive(last_out->parent(), fclosed,
-                                     false /* recomputation */,
+                                     false /* as_recomputation */,
                                      [](CgFunctionPtr fn) { fn->setup(); });
   this->last_output_cg_variable_ = last_out;
 }

--- a/src/nbla/function/generic/spectral_norm.cpp
+++ b/src/nbla/function/generic/spectral_norm.cpp
@@ -226,8 +226,7 @@ void SpectralNorm<T>::setup_impl(const Variables &inputs,
 
 template <typename T>
 void SpectralNorm<T>::setup_recompute_impl(const Variables &inputs,
-                                           const Variables &outputs,
-                                           const vector<bool> &need_recompute) {
+                                           const Variables &outputs) {
   // data region of `u` will be rewrited in forward prop.
   // On the other hand, we need original `u` for forward recalculation.
   // Therefore, we keep `u` into `u_org_`.
@@ -256,8 +255,7 @@ void SpectralNorm<T>::forward_impl(const Variables &inputs,
 
 template <typename T>
 void SpectralNorm<T>::recompute_impl(const Variables &inputs,
-                                     const Variables &outputs,
-                                     const vector<bool> &need_recompute) {
+                                     const Variables &outputs) {
   // Temporally restore `u` remembered in previous forward prop to prevent
   // double iteration of `u`
   u_->set_array(u_orig_->array());

--- a/src/nbla/function/generic/sync_batch_normalization.cpp
+++ b/src/nbla/function/generic/sync_batch_normalization.cpp
@@ -38,7 +38,8 @@ void SyncBatchNormalization<T>::setup_impl(const Variables &inputs,
 
 template <class T>
 void SyncBatchNormalization<T>::forward_impl_batch(const Variables &inputs,
-                                                   const Variables &outputs) {
+                                                   const Variables &outputs,
+                                                   const bool update_inputs) {
   // Check whether it outputs batch mean and var.
   Variable *batch_mean = &this->mean_;
   Variable *batch_var = &this->var_;
@@ -95,9 +96,11 @@ void SyncBatchNormalization<T>::forward_impl_batch(const Variables &inputs,
 
     auto n = this->size02_ * this->num_processes_;
     // Moving mean and var
-    rm[i1] = this->decay_rate_ * rm[i1] + (1 - this->decay_rate_) * m[i1];
-    rv[i1] = this->decay_rate_ * rv[i1] +
-             (1 - this->decay_rate_) * v[i1] * n / (n - 1);
+    if (update_inputs) {
+      rm[i1] = this->decay_rate_ * rm[i1] + (1 - this->decay_rate_) * m[i1];
+      rv[i1] = this->decay_rate_ * rv[i1] +
+               (1 - this->decay_rate_) * v[i1] * n / (n - 1);
+    }
 
     // v[i1] = 1 / std::sqrt(v[i1] + (T)eps_);
     // Subtract mean and divide by std, and apply beta and gamma.


### PR DESCRIPTION
All cleared buffers during forward computation will be re-calculated in the middle of backward propagation if it's needed to compute gradient.

nnabla-ext-cuda: https://github.com/sony/nnabla-ext-cuda/pull/311