### PR TITLE
Fix recompute to check if data is cleared before backward without setup_recompute

### DIFF
--- a/include/nbla/function.hpp
+++ b/include/nbla/function.hpp
@@ -69,6 +69,9 @@ class NBLA_API Function {
   bool used_{false};
   // This flag turns true once Function::setup calls.
   bool called_setup_{false};
+  // This flag turns true when Function::setup_recompute called and turns false
+  // when Function::recompute called.
+  bool called_setup_recompute_{false};
 
 public:
   typedef shared_ptr<Function> Ptr;

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -785,7 +785,8 @@ void CgVariable::visit_function_backward(
         continue;
 
       // Whether i-th input data is cleared
-      if (!inputs[i]->variable()->data()->array()->clear_called())
+      if (!(inputs[i]->recompute() &&
+            inputs[i]->variable()->data()->array()->clear_called()))
         continue;
 
       // Whether i-th input data is needed for grad calculation


### PR DESCRIPTION
Re-computation may perform without the necessary setup_recompute execution.

Example:

```
x -> F.affine -> h1 -> F.dropout -> h2 -> F.affine -> y

y.forward()
h2.data.clear()
y.backward() # grad is computed incorrectly

# Dropout::setup_recompute() must be executed before recomputation
# but not called during forward prop because h2 is cleared after forward prop.
# Therefore, h2.data is recomputed incorrectly.
```
This PR handles this case and raises runtime error.