### PR TITLE
 Bugfix: forward(clear_no_need_grad=True) and nn.grad of Dropout

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -270,3 +270,5 @@
   Meshgrid_B: 334
 33:
   SoftPlus_f: 335
+34:
+  Dropout_fiB: 336

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -5175,11 +5175,16 @@ Stochasticity:
         doc: Random seed. When -1, seed is sampled from global random number generator.
         type: int64
         default: '-1'
+      output_mask:
+        doc: Whether or not to output mask.
+        type: bool
+        default: 'False'
     outputs:
       y:
         doc: N-D array with the same shape as x
     function_ids:
       fi: 86
+      fiB: 336
     c_runtime: support
   TopKData:
     snake_name: top_k_data

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -2591,7 +2591,7 @@ Arithmetic:
         doc: N-D array
     arguments:
       inplace:
-        doc: The output array is shared with the 1st input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2634,7 +2634,7 @@ Arithmetic:
         doc: N-D array
     arguments:
       inplace:
-        doc: The output array is shared with the 1st input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2659,7 +2659,7 @@ Arithmetic:
         doc: N-D array
     arguments:
       inplace:
-        doc: The output array is shared with the 1st input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2741,7 +2741,7 @@ Arithmetic:
         type: double
         default: '1'
       inplace:
-        doc: The output array is shared with the input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:

--- a/include/nbla/function.hpp
+++ b/include/nbla/function.hpp
@@ -199,7 +199,7 @@ public:
       its gradient, this function must be overridden to return appropriate
       boolean value. Otherwise, backward computation will be incorrect.
    */
-  virtual bool grad_depends_output_data(int i, int o) const { return false; }
+  virtual bool grad_depends_output_data(int i, int o) const { return true; }
   /** Dependency flag for checking if in-grad depends on in-data.
 
       Checking if i-th input' gradient computation requires j-th input's data or
@@ -363,13 +363,11 @@ protected:
   };
 
   /**
-    If any of inputs requires an input variable data when computing its
-    gradient, this function must be overridden to return appropriate boolean
-    value. Otherwise, backward computation will be incorrect.
+    If any of inputs does not require an input variable data when computing its
+    gradient, this function can be overridden to return appropriate boolean
+    value for memory optimization.
   */
-  virtual bool grad_depends_input_data_impl(int i, int j) const {
-    return false;
-  }
+  virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
 
   /**
     If any of inputs are overwritten in forward, this function must be

--- a/include/nbla/function/adaptive_separable_convolution.hpp
+++ b/include/nbla/function/adaptive_separable_convolution.hpp
@@ -51,6 +51,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "AdaptiveSeparableConvolution"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/add2.hpp
+++ b/include/nbla/function/add2.hpp
@@ -82,6 +82,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/add2.hpp
+++ b/include/nbla/function/add2.hpp
@@ -71,6 +71,7 @@ public:
     // 0 is okay because never be called in the case of i != 0.
     return 0;
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/add_n.hpp
+++ b/include/nbla/function/add_n.hpp
@@ -53,6 +53,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "AddN"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/add_n.hpp
+++ b/include/nbla/function/add_n.hpp
@@ -64,6 +64,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/add_scalar.hpp
+++ b/include/nbla/function/add_scalar.hpp
@@ -40,6 +40,6 @@ Outputs:
 \ingroup FunctionImplGrp
  */
 NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(AddScalar, x + (T)a0, dy, false, false,
-                                      double);
+                                      double, false);
 }
 #endif

--- a/include/nbla/function/affine.hpp
+++ b/include/nbla/function/affine.hpp
@@ -73,6 +73,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/affine_grid.hpp
+++ b/include/nbla/function/affine_grid.hpp
@@ -73,6 +73,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "AffineGrid"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/arange.hpp
+++ b/include/nbla/function/arange.hpp
@@ -65,6 +65,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Arange"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/arange.hpp
+++ b/include/nbla/function/arange.hpp
@@ -76,6 +76,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/assign.hpp
+++ b/include/nbla/function/assign.hpp
@@ -54,6 +54,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Assign"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/assign.hpp
+++ b/include/nbla/function/assign.hpp
@@ -65,6 +65,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
   virtual bool overwrite_input_data_in_forward_impl(int i) const {
     if (i == 0)
       return true;

--- a/include/nbla/function/average_pooling.hpp
+++ b/include/nbla/function/average_pooling.hpp
@@ -69,6 +69,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/average_pooling.hpp
+++ b/include/nbla/function/average_pooling.hpp
@@ -60,6 +60,7 @@ public:
                                  this->channel_last_, including_pad_);
   }
   virtual string name() { return "AveragePooling"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void forward_impl(const Variables &inputs,

--- a/include/nbla/function/batch_inv.hpp
+++ b/include/nbla/function/batch_inv.hpp
@@ -64,6 +64,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/batch_logdet.hpp
+++ b/include/nbla/function/batch_logdet.hpp
@@ -50,6 +50,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "BatchLogdet"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/batch_matmul.hpp
+++ b/include/nbla/function/batch_matmul.hpp
@@ -89,6 +89,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/bc_add2.hpp
+++ b/include/nbla/function/bc_add2.hpp
@@ -31,6 +31,6 @@ broadcastable Add2. If Add2's inputs require broadcasting, it's fallback into
 BcAdd2 operation. See setup_impl of add2.cpp.
  */
 NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(BcAdd2, x0 + x1, dy, dy, false, false,
-                                     false, false);
+                                     false, false, false);
 }
 #endif

--- a/include/nbla/function/binary_connect_affine.hpp
+++ b/include/nbla/function/binary_connect_affine.hpp
@@ -103,6 +103,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/binary_connect_convolution.hpp
+++ b/include/nbla/function/binary_connect_convolution.hpp
@@ -131,6 +131,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/binary_cross_entropy.hpp
+++ b/include/nbla/function/binary_cross_entropy.hpp
@@ -60,6 +60,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/binary_error.hpp
+++ b/include/nbla/function/binary_error.hpp
@@ -75,6 +75,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/binary_error.hpp
+++ b/include/nbla/function/binary_error.hpp
@@ -64,6 +64,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/binary_weight_affine.hpp
+++ b/include/nbla/function/binary_weight_affine.hpp
@@ -102,6 +102,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/binary_weight_convolution.hpp
+++ b/include/nbla/function/binary_weight_convolution.hpp
@@ -128,6 +128,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/broadcast.hpp
+++ b/include/nbla/function/broadcast.hpp
@@ -58,6 +58,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/broadcast.hpp
+++ b/include/nbla/function/broadcast.hpp
@@ -69,6 +69,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/broadcast_to.hpp
+++ b/include/nbla/function/broadcast_to.hpp
@@ -68,6 +68,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/broadcast_to.hpp
+++ b/include/nbla/function/broadcast_to.hpp
@@ -57,6 +57,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/categorical_cross_entropy.hpp
+++ b/include/nbla/function/categorical_cross_entropy.hpp
@@ -75,6 +75,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/celu.hpp
+++ b/include/nbla/function/celu.hpp
@@ -61,6 +61,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/clip_grad_by_norm.hpp
+++ b/include/nbla/function/clip_grad_by_norm.hpp
@@ -80,6 +80,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/clip_grad_by_norm.hpp
+++ b/include/nbla/function/clip_grad_by_norm.hpp
@@ -69,6 +69,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/clip_grad_by_value.hpp
+++ b/include/nbla/function/clip_grad_by_value.hpp
@@ -70,6 +70,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/concatenate.hpp
+++ b/include/nbla/function/concatenate.hpp
@@ -61,6 +61,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/concatenate.hpp
+++ b/include/nbla/function/concatenate.hpp
@@ -72,6 +72,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/confusion_matrix.hpp
+++ b/include/nbla/function/confusion_matrix.hpp
@@ -75,6 +75,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/confusion_matrix.hpp
+++ b/include/nbla/function/confusion_matrix.hpp
@@ -64,6 +64,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/constant.hpp
+++ b/include/nbla/function/constant.hpp
@@ -50,6 +50,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/constant.hpp
+++ b/include/nbla/function/constant.hpp
@@ -61,6 +61,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/convolution.hpp
+++ b/include/nbla/function/convolution.hpp
@@ -124,6 +124,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/crelu.hpp
+++ b/include/nbla/function/crelu.hpp
@@ -67,6 +67,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/cumprod.hpp
+++ b/include/nbla/function/cumprod.hpp
@@ -66,10 +66,6 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "CumProd"; }
-  // TODO: This must be overridden if any of input grad depends on a output
-  // data. See doc in function.hpp.
-  // virtual bool grad_depends_output_data(int i, int o) const {
-  // }
   // TODO: If any of data/grad storage is inplaced with any of output, you must
   // override some of these. See doc in function.hpp.
   // virtual int inplace_data(int i) const {
@@ -86,6 +82,7 @@ public:
   // virtual bool prohibit_zero_input_grad() const {
   //   return true;
   // }
+  virtual bool grad_depends_output_data(int i, int o) const { return true; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/cumprod.hpp
+++ b/include/nbla/function/cumprod.hpp
@@ -93,6 +93,7 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
 };
 }
 #endif

--- a/include/nbla/function/cumsum.hpp
+++ b/include/nbla/function/cumsum.hpp
@@ -86,6 +86,7 @@ public:
   // virtual bool prohibit_zero_input_grad() const {
   //   return true;
   // }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/cumsum.hpp
+++ b/include/nbla/function/cumsum.hpp
@@ -97,6 +97,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/deconvolution.hpp
+++ b/include/nbla/function/deconvolution.hpp
@@ -116,6 +116,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/deformable_convolution.hpp
+++ b/include/nbla/function/deformable_convolution.hpp
@@ -108,6 +108,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "DeformableConvolution"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/depthwise_convolution.hpp
+++ b/include/nbla/function/depthwise_convolution.hpp
@@ -104,6 +104,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/depthwise_deconvolution.hpp
+++ b/include/nbla/function/depthwise_deconvolution.hpp
@@ -96,6 +96,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/dequantize_linear.hpp
+++ b/include/nbla/function/dequantize_linear.hpp
@@ -62,6 +62,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "DequantizeLinear"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/div2.hpp
+++ b/include/nbla/function/div2.hpp
@@ -39,8 +39,9 @@ Outputs:
 @tparam T Data type for computation.
 \ingroup FunctionImplGrp
  */
+// Inplacing is obsoleted.
 NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(Div2, x0 / x1, dy / x1,
-                                     dy *(-(inplace ? y *x1 : x0) / (x1 * x1)),
-                                     false, false, true, true);
+                                     -dy *x0 / (x1 * x1), false, false, true,
+                                     true, true);
 }
 #endif

--- a/include/nbla/function/dropout.hpp
+++ b/include/nbla/function/dropout.hpp
@@ -97,6 +97,9 @@ protected:
                                        const Variables &outputs);
   void dropout(const Variables &inputs, const Variables &outputs,
                std::mt19937 &rgen);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/dropout.hpp
+++ b/include/nbla/function/dropout.hpp
@@ -80,6 +80,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/embed.hpp
+++ b/include/nbla/function/embed.hpp
@@ -54,6 +54,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/exp.hpp
+++ b/include/nbla/function/exp.hpp
@@ -26,6 +26,6 @@ namespace nbla {
 /** @class Exp
     @brief Take elementwise \f$\exp(x)\f$.
  */
-NBLA_DEFINE_TRANSFORM_UNARY(Exp, std::exp(x), std::exp(x) * dy, false, true);
+NBLA_DEFINE_TRANSFORM_UNARY(Exp, std::exp(x), y *dy, true, false);
 }
 #endif

--- a/include/nbla/function/fft.hpp
+++ b/include/nbla/function/fft.hpp
@@ -54,6 +54,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "FFT"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/fft.hpp
+++ b/include/nbla/function/fft.hpp
@@ -65,6 +65,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/fixed_point_quantize.hpp
+++ b/include/nbla/function/fixed_point_quantize.hpp
@@ -68,6 +68,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/flip.hpp
+++ b/include/nbla/function/flip.hpp
@@ -77,6 +77,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   void flip_recursive(Variable *inp, const T *x, T *y,

--- a/include/nbla/function/flip.hpp
+++ b/include/nbla/function/flip.hpp
@@ -66,6 +66,7 @@ public:
   }
 
   std::vector<int> &axes() { return axes_; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/function_impl.hpp.tmpl
+++ b/include/nbla/function/function_impl.hpp.tmpl
@@ -81,7 +81,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "${name}"; }
-  // TODO: This must be overridden if any of input grad depends on a output data. See doc in function.hpp.
+  // TODO: This must be overridden if any of input grad does not depend on a output data. See doc in function.hpp.
   // virtual bool grad_depends_output_data(int i, int o) const {
   // }
   // TODO: If any of data/grad storage is inplaced with any of output, you must override some of these. See doc in function.hpp.
@@ -111,7 +111,7 @@ protected:
   // TODO: This must be overridden if there are something need to be saved for recomputation. See doc in function.hpp.
   // NBLA_API virtual void setup_recompute_impl(const Variables &inputs, const Variables &outputs);
   // NBLA_API virtual void recompute_impl(const Variables &inputs, const Variables &outputs);
-  // TODO: This must be overridden if any of input grad depends on a input data. See doc in function.hpp.
+  // TODO: This must be overridden if any of input grad does not depend on a input data. See doc in function.hpp.
   // virtual bool grad_depends_input_data_impl(int i, int j) const {
   // }
   // TODO: This must be overridden if any of input will be overwritten duaring forward. See doc in function.hpp.

--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -110,8 +110,8 @@ public:
   }
   virtual string name() { return "FusedBatchNormalization"; }
   virtual bool grad_depends_output_data(int i, int o) const {
-    // Gradient computation always requires output mean and var.
-    return o > 0;
+    // Gradient computation always requires output y, mean and var.
+    return o >= 0;
   }
 
 protected:

--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -110,8 +110,13 @@ public:
   }
   virtual string name() { return "FusedBatchNormalization"; }
   virtual bool grad_depends_output_data(int i, int o) const {
-    // Gradient computation always requires output y, mean and var.
-    return o >= 0;
+    // Gradient computation always requires output mean and var.
+    // If nonlinearity is relu, then y is also needed.
+    if (nonlinearity_ == "relu") {
+      return o >= 0;
+    } else {
+      return o > 0;
+    }
   }
 
 protected:

--- a/include/nbla/function/gather.hpp
+++ b/include/nbla/function/gather.hpp
@@ -90,6 +90,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Gather"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/gather_nd.hpp
+++ b/include/nbla/function/gather_nd.hpp
@@ -68,6 +68,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "GatherNd"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/global_average_pooling.hpp
+++ b/include/nbla/function/global_average_pooling.hpp
@@ -56,6 +56,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/global_average_pooling.hpp
+++ b/include/nbla/function/global_average_pooling.hpp
@@ -45,6 +45,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/gru.hpp
+++ b/include/nbla/function/gru.hpp
@@ -94,6 +94,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "GRU"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/gru.hpp
+++ b/include/nbla/function/gru.hpp
@@ -109,6 +109,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   vector<vector<CgVariablePtr>> create_fixed_length_gru_graph(

--- a/include/nbla/function/identity.hpp
+++ b/include/nbla/function/identity.hpp
@@ -70,6 +70,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/identity.hpp
+++ b/include/nbla/function/identity.hpp
@@ -59,6 +59,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/ifft.hpp
+++ b/include/nbla/function/ifft.hpp
@@ -53,6 +53,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "IFFT"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/ifft.hpp
+++ b/include/nbla/function/ifft.hpp
@@ -64,6 +64,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/image_augmentation.hpp
+++ b/include/nbla/function/image_augmentation.hpp
@@ -156,6 +156,9 @@ protected:
                                        const Variables &outputs);
   void image_augmentation(const Variables &inputs, const Variables &outputs,
                           std::mt19937 &rgen);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/image_augmentation.hpp
+++ b/include/nbla/function/image_augmentation.hpp
@@ -139,6 +139,7 @@ public:
     return vector<string>{"CpuArray"};
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/inq_affine.hpp
+++ b/include/nbla/function/inq_affine.hpp
@@ -115,6 +115,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/inq_convolution.hpp
+++ b/include/nbla/function/inq_convolution.hpp
@@ -134,6 +134,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/interpolate.hpp
+++ b/include/nbla/function/interpolate.hpp
@@ -87,6 +87,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Interpolate"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/interpolate.hpp
+++ b/include/nbla/function/interpolate.hpp
@@ -98,6 +98,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/istft.hpp
+++ b/include/nbla/function/istft.hpp
@@ -70,6 +70,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "ISTFT"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/istft.hpp
+++ b/include/nbla/function/istft.hpp
@@ -83,6 +83,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/kl_multinomial.hpp
+++ b/include/nbla/function/kl_multinomial.hpp
@@ -57,6 +57,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return vector<string>{"CpuArray"};
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/leaky_relu.hpp
+++ b/include/nbla/function/leaky_relu.hpp
@@ -74,7 +74,7 @@ public:
     return inplace_ ? Function::INPLACE : Function::NOT_INPLACE;
   }
   virtual int inplace_data_with(int i) const { return 0; }
-  virtual bool grad_depends_output_data(int i, int o) const { return false; }
+  virtual bool grad_depends_output_data(int i, int o) const { return inplace_; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -85,7 +85,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return !inplace_;
+  }
 };
 }
 #endif

--- a/include/nbla/function/leaky_relu.hpp
+++ b/include/nbla/function/leaky_relu.hpp
@@ -74,6 +74,7 @@ public:
     return inplace_ ? Function::INPLACE : Function::NOT_INPLACE;
   }
   virtual int inplace_data_with(int i) const { return 0; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/log_softmax.hpp
+++ b/include/nbla/function/log_softmax.hpp
@@ -70,6 +70,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/lstm.hpp
+++ b/include/nbla/function/lstm.hpp
@@ -108,6 +108,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   vector<vector<CgVariablePtr>> create_fixed_length_lstm_graph(

--- a/include/nbla/function/lstm.hpp
+++ b/include/nbla/function/lstm.hpp
@@ -93,6 +93,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "LSTM"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/matrix_diag.hpp
+++ b/include/nbla/function/matrix_diag.hpp
@@ -44,6 +44,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/matrix_diag.hpp
+++ b/include/nbla/function/matrix_diag.hpp
@@ -55,6 +55,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/matrix_diag_part.hpp
+++ b/include/nbla/function/matrix_diag_part.hpp
@@ -46,6 +46,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/matrix_diag_part.hpp
+++ b/include/nbla/function/matrix_diag_part.hpp
@@ -57,6 +57,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/max.hpp
+++ b/include/nbla/function/max.hpp
@@ -62,6 +62,9 @@ protected:
                                             int reduction_size);
   NBLA_API virtual void backward_impl_reduce(const T *dy, T *dx, int outer_size,
                                              int reduction_size, bool accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/max.hpp
+++ b/include/nbla/function/max.hpp
@@ -51,6 +51,7 @@ public:
                       this->with_index_, this->only_index_);
   }
   virtual string name() { return "Max"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/max_pooling.hpp
+++ b/include/nbla/function/max_pooling.hpp
@@ -70,6 +70,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/max_pooling.hpp
+++ b/include/nbla/function/max_pooling.hpp
@@ -59,6 +59,7 @@ public:
                              this->channel_last_);
   }
   virtual string name() { return "MaxPooling"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/max_pooling_backward.hpp
+++ b/include/nbla/function/max_pooling_backward.hpp
@@ -78,6 +78,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/max_pooling_backward.hpp
+++ b/include/nbla/function/max_pooling_backward.hpp
@@ -67,6 +67,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "MaxPoolingBackward"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/max_pooling_backward.hpp
+++ b/include/nbla/function/max_pooling_backward.hpp
@@ -78,9 +78,7 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  virtual bool grad_depends_input_data_impl(int i, int j) const {
-    return false;
-  }
+  virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
 };
 }
 #endif

--- a/include/nbla/function/mean.hpp
+++ b/include/nbla/function/mean.hpp
@@ -48,6 +48,9 @@ protected:
                                             int reduction_size);
   NBLA_API virtual void backward_impl_reduce(const T *dy, T *dx, int outer_size,
                                              int reduction_size, bool accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/mean.hpp
+++ b/include/nbla/function/mean.hpp
@@ -41,6 +41,7 @@ public:
     return create_Mean(this->ctx_, this->axes_, this->keep_dims_);
   }
   virtual string name() { return "Mean"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void forward_impl_reduce(const T *x, T *y, int outer_size,

--- a/include/nbla/function/mean_subtraction.hpp
+++ b/include/nbla/function/mean_subtraction.hpp
@@ -90,6 +90,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/meshgrid.hpp
+++ b/include/nbla/function/meshgrid.hpp
@@ -103,6 +103,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/meshgrid.hpp
+++ b/include/nbla/function/meshgrid.hpp
@@ -92,6 +92,7 @@ public:
   // virtual bool prohibit_zero_input_grad() const {
   //   return true;
   // }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/min.hpp
+++ b/include/nbla/function/min.hpp
@@ -50,6 +50,9 @@ public:
 protected:
   NBLA_API virtual void forward_impl_reduce(const T *x, T *y, int outer_size,
                                             int reduction_size);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/min.hpp
+++ b/include/nbla/function/min.hpp
@@ -45,6 +45,7 @@ public:
                       this->with_index_, this->only_index_);
   }
   virtual string name() { return "Min"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void forward_impl_reduce(const T *x, T *y, int outer_size,

--- a/include/nbla/function/min_max_quantize.hpp
+++ b/include/nbla/function/min_max_quantize.hpp
@@ -96,6 +96,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "MinMaxQuantize"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/mul2.hpp
+++ b/include/nbla/function/mul2.hpp
@@ -37,8 +37,8 @@ Outputs:
 @tparam T Data type for computation.
 \ingroup FunctionImplGrp
  */
-NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(Mul2, x0 *x1, dy *x1,
-                                     inplace ? dy *y / x1 : dy *x0, false,
-                                     false, true, true);
+// Inplacing is obsoleted.
+NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(Mul2, x0 *x1, dy *x1, dy *x0, false, false,
+                                     true, true, true);
 }
 #endif

--- a/include/nbla/function/mul_scalar.hpp
+++ b/include/nbla/function/mul_scalar.hpp
@@ -40,6 +40,6 @@ Outputs:
 \ingroup FunctionImplGrp
 */
 NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(MulScalar, x *(T)a0, dy *(T)a0, false,
-                                      false, double);
+                                      false, double, false);
 }
 #endif

--- a/include/nbla/function/nms_detection2d.hpp
+++ b/include/nbla/function/nms_detection2d.hpp
@@ -81,6 +81,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/nms_detection2d.hpp
+++ b/include/nbla/function/nms_detection2d.hpp
@@ -68,6 +68,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/norm.hpp
+++ b/include/nbla/function/norm.hpp
@@ -59,6 +59,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Norm"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/norm_normalization.hpp
+++ b/include/nbla/function/norm_normalization.hpp
@@ -59,6 +59,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "NormNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/one_hot.hpp
+++ b/include/nbla/function/one_hot.hpp
@@ -71,6 +71,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/one_hot.hpp
+++ b/include/nbla/function/one_hot.hpp
@@ -60,6 +60,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/pack_padded_sequence.hpp
+++ b/include/nbla/function/pack_padded_sequence.hpp
@@ -75,6 +75,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/pack_padded_sequence.hpp
+++ b/include/nbla/function/pack_padded_sequence.hpp
@@ -64,6 +64,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "PackPaddedSequence"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return o > 0; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/pad.hpp
+++ b/include/nbla/function/pad.hpp
@@ -95,6 +95,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/pad.hpp
+++ b/include/nbla/function/pad.hpp
@@ -84,6 +84,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Pad"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/pad_packed_sequence.hpp
+++ b/include/nbla/function/pad_packed_sequence.hpp
@@ -78,6 +78,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "PadPackedSequence"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/patch_correlation.hpp
+++ b/include/nbla/function/patch_correlation.hpp
@@ -77,6 +77,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "PatchCorrelation"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/pow2.hpp
+++ b/include/nbla/function/pow2.hpp
@@ -39,11 +39,10 @@ Outputs:
 @tparam T Data type for computation.
 \ingroup FunctionImplGrp
  */
-NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(
-    Pow2, std::pow(x0, x1),
-    dy *x1 *std::pow(inplace ? std::pow(y, 1 / x1) : x0, x1 - (T)1),
-    dy *std::log(inplace ? std::pow(y, 1 / x1) : x0) *
-        std::pow(inplace ? std::pow(y, 1 / x1) : x0, x1),
-    false, false, true, true);
+// Inplacing is obsoleted.
+NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(Pow2, std::pow(x0, x1),
+                                     dy *x1 *std::pow(x0, x1 - (T)1),
+                                     dy *std::log(x0) * std::pow(x0, x1), false,
+                                     false, true, true, true);
 }
 #endif

--- a/include/nbla/function/pow2_quantize.hpp
+++ b/include/nbla/function/pow2_quantize.hpp
@@ -80,6 +80,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/pow_scalar.hpp
+++ b/include/nbla/function/pow_scalar.hpp
@@ -39,10 +39,11 @@ Outputs:
 @param val Value of the scalar.
 \ingroup FunctionImplGrp
  */
-NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(
-    PowScalar, a0 == 0.5f ? std::sqrt(x) : std::pow(x, (T)a0),
-    dy *(T)a0 *std::pow((inplace ? std::pow(y, (T)1 / (T)a0) : x),
-                        (T)a0 - (T)1),
-    false, true, double);
+// Inplacing is obsoleted.
+NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(PowScalar,
+                                      a0 == 0.5f ? std::sqrt(x)
+                                                 : std::pow(x, (T)a0),
+                                      dy *(T)a0 *std::pow(x, (T)a0 - (T)1),
+                                      false, true, double, true);
 }
 #endif

--- a/include/nbla/function/prelu.hpp
+++ b/include/nbla/function/prelu.hpp
@@ -71,6 +71,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/prune.hpp
+++ b/include/nbla/function/prune.hpp
@@ -66,6 +66,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Prune"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/prune.hpp
+++ b/include/nbla/function/prune.hpp
@@ -77,6 +77,10 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    // Because of STE (Straight Through Estimator)
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/quantize_linear.hpp
+++ b/include/nbla/function/quantize_linear.hpp
@@ -71,6 +71,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "QuantizeLinear"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/quantize_linear.hpp
+++ b/include/nbla/function/quantize_linear.hpp
@@ -83,10 +83,9 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
-    if (i == 0 && j == 1) {
-      return true;
-    }
-    return false;
+    // Return true since backward for inputs[1,2] may be implemented in the
+    // future.
+    return true;
   }
   NBLA_API virtual void round(Variable *inp, std::string round_mode);
   NBLA_API virtual void saturate(Variable *inp, int min_range, int max_range);

--- a/include/nbla/function/quantize_linear.hpp
+++ b/include/nbla/function/quantize_linear.hpp
@@ -81,6 +81,12 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    if (i == 0 && j == 1) {
+      return true;
+    }
+    return false;
+  }
   NBLA_API virtual void round(Variable *inp, std::string round_mode);
   NBLA_API virtual void saturate(Variable *inp, int min_range, int max_range);
 };

--- a/include/nbla/function/rand.hpp
+++ b/include/nbla/function/rand.hpp
@@ -63,6 +63,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/rand.hpp
+++ b/include/nbla/function/rand.hpp
@@ -78,6 +78,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/rand_beta.hpp
+++ b/include/nbla/function/rand_beta.hpp
@@ -86,6 +86,9 @@ protected:
                                        const Variables &outputs);
   void random_beta(const Variables &inputs, const Variables &outputs,
                    std::mt19937 &rgen);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/rand_beta.hpp
+++ b/include/nbla/function/rand_beta.hpp
@@ -69,6 +69,7 @@ public:
   }
   virtual string name() { return "RandBeta"; }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/rand_binomial.hpp
+++ b/include/nbla/function/rand_binomial.hpp
@@ -87,6 +87,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/rand_binomial.hpp
+++ b/include/nbla/function/rand_binomial.hpp
@@ -72,6 +72,7 @@ public:
   }
   virtual string name() { return "RandBinomial"; }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/rand_gamma.hpp
+++ b/include/nbla/function/rand_gamma.hpp
@@ -70,6 +70,7 @@ public:
   }
   virtual string name() { return "RandGamma"; }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/rand_gamma.hpp
+++ b/include/nbla/function/rand_gamma.hpp
@@ -85,6 +85,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/randint.hpp
+++ b/include/nbla/function/randint.hpp
@@ -65,6 +65,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/randint.hpp
+++ b/include/nbla/function/randint.hpp
@@ -80,6 +80,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/randn.hpp
+++ b/include/nbla/function/randn.hpp
@@ -62,6 +62,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/randn.hpp
+++ b/include/nbla/function/randn.hpp
@@ -77,6 +77,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/random_choice.hpp
+++ b/include/nbla/function/random_choice.hpp
@@ -139,6 +139,9 @@ protected:
 
   void random_choice(const Variables &inputs, const Variables &outputs,
                      std::mt19937 &rgen);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/random_choice.hpp
+++ b/include/nbla/function/random_choice.hpp
@@ -121,6 +121,7 @@ public:
   }
   virtual string name() { return "RandomChoice"; }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/random_crop.hpp
+++ b/include/nbla/function/random_crop.hpp
@@ -75,6 +75,7 @@ public:
     return vector<string>{"CpuArray"};
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/random_crop.hpp
+++ b/include/nbla/function/random_crop.hpp
@@ -90,6 +90,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   void slice_forward_recursive(const Variable *inp, Variable *outp, const T *x,

--- a/include/nbla/function/random_erase.hpp
+++ b/include/nbla/function/random_erase.hpp
@@ -111,6 +111,7 @@ public:
   }
   virtual int inplace_data_with(int i) const { return 0; }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/random_erase.hpp
+++ b/include/nbla/function/random_erase.hpp
@@ -129,6 +129,9 @@ protected:
 
   void random_erase(const Variables &inputs, const Variables &outputs,
                     std::mt19937 &rgen);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/random_flip.hpp
+++ b/include/nbla/function/random_flip.hpp
@@ -78,6 +78,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/random_flip.hpp
+++ b/include/nbla/function/random_flip.hpp
@@ -93,6 +93,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   void flip_recursive(const Variable *inp, const T *x, T *y, bool add,

--- a/include/nbla/function/random_shift.hpp
+++ b/include/nbla/function/random_shift.hpp
@@ -87,6 +87,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual bool need_setup_recompute(int o) const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/random_shift.hpp
+++ b/include/nbla/function/random_shift.hpp
@@ -102,6 +102,9 @@ protected:
                                              const Variables &outputs);
   NBLA_API virtual void recompute_impl(const Variables &inputs,
                                        const Variables &outputs);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
   vector<vector<int>> prepare_addr_table(const Variables &inputs,
                                          const vector<int> &shifts);

--- a/include/nbla/function/reduce_mean.hpp
+++ b/include/nbla/function/reduce_mean.hpp
@@ -53,6 +53,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/reduce_mean.hpp
+++ b/include/nbla/function/reduce_mean.hpp
@@ -64,6 +64,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/reduce_sum.hpp
+++ b/include/nbla/function/reduce_sum.hpp
@@ -53,6 +53,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/reduce_sum.hpp
+++ b/include/nbla/function/reduce_sum.hpp
@@ -64,6 +64,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/relu.hpp
+++ b/include/nbla/function/relu.hpp
@@ -64,7 +64,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
-  virtual bool grad_depends_output_data(int i, int o) const { return inplace_; }
+  virtual bool grad_depends_output_data(int i, int o) const { return true; }
   virtual int inplace_data(int i) const {
     return inplace_ ? Function::INPLACE : Function::NOT_INPLACE;
   }
@@ -79,7 +79,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
-  virtual bool grad_depends_input_data_impl(int i, int j) const { return true; }
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/reshape.hpp
+++ b/include/nbla/function/reshape.hpp
@@ -82,6 +82,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/rnn.hpp
+++ b/include/nbla/function/rnn.hpp
@@ -109,6 +109,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   vector<vector<CgVariablePtr>> create_fixed_length_rnn_graph(

--- a/include/nbla/function/rnn.hpp
+++ b/include/nbla/function/rnn.hpp
@@ -94,6 +94,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "RNN"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/scatter_add.hpp
+++ b/include/nbla/function/scatter_add.hpp
@@ -105,6 +105,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "ScatterAdd"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/scatter_nd.hpp
+++ b/include/nbla/function/scatter_nd.hpp
@@ -94,6 +94,7 @@ public:
     return i == 2 ? Function::INPLACE : Function::NOT_INPLACE;
   }
   virtual int inplace_grad_with(int i) const { return 0; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/searchsorted.hpp
+++ b/include/nbla/function/searchsorted.hpp
@@ -66,6 +66,7 @@ public:
   // }
   // virtual int inplace_data_with(int i) const {
   // }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/searchsorted.hpp
+++ b/include/nbla/function/searchsorted.hpp
@@ -77,6 +77,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/selu.hpp
+++ b/include/nbla/function/selu.hpp
@@ -103,6 +103,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/shift.hpp
+++ b/include/nbla/function/shift.hpp
@@ -78,6 +78,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   template <bool is_backward>

--- a/include/nbla/function/shift.hpp
+++ b/include/nbla/function/shift.hpp
@@ -67,6 +67,7 @@ public:
   }
 
   std::vector<int> &shifts() { return shifts_; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/sigmoid_cross_entropy.hpp
+++ b/include/nbla/function/sigmoid_cross_entropy.hpp
@@ -65,6 +65,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/sink.hpp
+++ b/include/nbla/function/sink.hpp
@@ -54,6 +54,7 @@ public:
   // This avoids zero-ing grad buffers if one_input_grad_ is false
   // (i.e., use external gradients).
   virtual bool prohibit_zero_input_grad() const { return true; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/sink.hpp
+++ b/include/nbla/function/sink.hpp
@@ -65,6 +65,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/slice.hpp
+++ b/include/nbla/function/slice.hpp
@@ -79,6 +79,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/slice.hpp
+++ b/include/nbla/function/slice.hpp
@@ -90,6 +90,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
   NBLA_API bool skip_check(const Variables &outputs);
 
 private:

--- a/include/nbla/function/softmax.hpp
+++ b/include/nbla/function/softmax.hpp
@@ -78,6 +78,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/softmax_cross_entropy.hpp
+++ b/include/nbla/function/softmax_cross_entropy.hpp
@@ -80,6 +80,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/sort.hpp
+++ b/include/nbla/function/sort.hpp
@@ -81,6 +81,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Sort"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/sort.hpp
+++ b/include/nbla/function/sort.hpp
@@ -92,6 +92,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/split.hpp
+++ b/include/nbla/function/split.hpp
@@ -58,6 +58,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/split.hpp
+++ b/include/nbla/function/split.hpp
@@ -69,6 +69,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/stack.hpp
+++ b/include/nbla/function/stack.hpp
@@ -61,6 +61,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/stack.hpp
+++ b/include/nbla/function/stack.hpp
@@ -72,6 +72,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/stft.hpp
+++ b/include/nbla/function/stft.hpp
@@ -72,6 +72,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "STFT"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/stft.hpp
+++ b/include/nbla/function/stft.hpp
@@ -85,6 +85,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/sub2.hpp
+++ b/include/nbla/function/sub2.hpp
@@ -38,6 +38,6 @@ Outputs:
 \ingroup FunctionImplGrp
  */
 NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(Sub2, x0 - x1, dy, -dy, false, false,
-                                     false, false);
+                                     false, false, false);
 }
 #endif

--- a/include/nbla/function/sum.hpp
+++ b/include/nbla/function/sum.hpp
@@ -80,6 +80,10 @@ protected:
                                             int reduction_size);
   NBLA_API virtual void backward_impl_reduce(const T *dy, T *dx, int outer_size,
                                              int reduction_size, bool accum);
+
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/sum.hpp
+++ b/include/nbla/function/sum.hpp
@@ -64,6 +64,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/sum_pooling.hpp
+++ b/include/nbla/function/sum_pooling.hpp
@@ -63,6 +63,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/sum_pooling.hpp
+++ b/include/nbla/function/sum_pooling.hpp
@@ -54,6 +54,7 @@ public:
                              this->channel_last_);
   }
   virtual string name() { return "SumPooling"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void forward_impl(const Variables &inputs,

--- a/include/nbla/function/sync_batch_normalization.hpp
+++ b/include/nbla/function/sync_batch_normalization.hpp
@@ -92,6 +92,7 @@ public:
                                          this->eps_, this->batch_stat_);
   }
   virtual string name() override { return "SyncBatchNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return o > 0; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/tile.hpp
+++ b/include/nbla/function/tile.hpp
@@ -59,6 +59,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Tile"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/tile.hpp
+++ b/include/nbla/function/tile.hpp
@@ -70,6 +70,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/top_k_data.hpp
+++ b/include/nbla/function/top_k_data.hpp
@@ -83,6 +83,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "TopKData"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/top_k_data.hpp
+++ b/include/nbla/function/top_k_data.hpp
@@ -94,6 +94,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/top_k_grad.hpp
+++ b/include/nbla/function/top_k_grad.hpp
@@ -82,6 +82,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/top_k_grad.hpp
+++ b/include/nbla/function/top_k_grad.hpp
@@ -71,6 +71,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "TopKGrad"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/top_n_error.hpp
+++ b/include/nbla/function/top_n_error.hpp
@@ -84,6 +84,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/top_n_error.hpp
+++ b/include/nbla/function/top_n_error.hpp
@@ -73,6 +73,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return vector<string>{"CpuArray"};
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/transpose.hpp
+++ b/include/nbla/function/transpose.hpp
@@ -78,6 +78,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/transpose.hpp
+++ b/include/nbla/function/transpose.hpp
@@ -67,6 +67,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/unlink.hpp
+++ b/include/nbla/function/unlink.hpp
@@ -63,6 +63,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/unlink.hpp
+++ b/include/nbla/function/unlink.hpp
@@ -52,6 +52,7 @@ public:
   }
   virtual int inplace_data(int i) const { return Function::INPLACE_NOT_MODIFY; }
   virtual int inplace_data_with(int i) const { return 0; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/unpooling.hpp
+++ b/include/nbla/function/unpooling.hpp
@@ -79,6 +79,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 
 private:
   void unpooling_forward_recursive(const Variable *inp, Variable *outp,

--- a/include/nbla/function/unpooling.hpp
+++ b/include/nbla/function/unpooling.hpp
@@ -68,6 +68,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/utils/base_transform_binary.hpp
+++ b/include/nbla/function/utils/base_transform_binary.hpp
@@ -459,14 +459,15 @@ public:                                                                        \
     }                                                                          \
   }
 
-#define NBLA_DEFINE_TRANSFORM_BINARY_CLASS_INPLACE(NAME, DEP_Y_0, DEP_Y_1,     \
-                                                   DEP_X_0, DEP_X_1)           \
+#define NBLA_DEFINE_TRANSFORM_BINARY_CLASS_INPLACE(                            \
+    NAME, DEP_Y_0, DEP_Y_1, DEP_X_0, DEP_X_1, IGNORE_INPLACE)                  \
   template <typename T>                                                        \
   class NAME : public TransformBinary<T, NAME##BinaryOp> {                     \
     NBLA_DEFINE_TRANSFORM_BINARY_CLASS_COMMON(NAME, DEP_Y_0, DEP_Y_1, DEP_X_0, \
                                               DEP_X_1)                         \
     NAME(const Context &ctx, bool inplace)                                     \
-        : TransformBinary<T, NAME##BinaryOp>(ctx, inplace) {}                  \
+        : TransformBinary<T, NAME##BinaryOp>(                                  \
+              ctx, (IGNORE_INPLACE) ? false : inplace) {}                      \
     virtual shared_ptr<Function> copy() const {                                \
       return create_##NAME(this->ctx_, this->inplace_);                        \
     }                                                                          \
@@ -483,12 +484,12 @@ public:                                                                        \
   NBLA_DEFINE_BINARY_OP(NAME, OP, GOP0, GOP1);                                 \
   NBLA_DEFINE_TRANSFORM_BINARY_CLASS(NAME, DEP_Y_0, DEP_Y_1, DEP_X_0, DEP_X_1)
 
-#define NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(NAME, OP, GOP0, GOP1, DEP_Y_0,    \
-                                             DEP_Y_1, DEP_X_0, DEP_X_1)        \
+#define NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(                                  \
+    NAME, OP, GOP0, GOP1, DEP_Y_0, DEP_Y_1, DEP_X_0, DEP_X_1, IGNORE_INPLACE)  \
   NBLA_REGISTER_FUNCTION_HEADER(NAME, bool);                                   \
   NBLA_DEFINE_BINARY_OP(NAME, OP, GOP0, GOP1);                                 \
   NBLA_DEFINE_TRANSFORM_BINARY_CLASS_INPLACE(NAME, DEP_Y_0, DEP_Y_1, DEP_X_0,  \
-                                             DEP_X_1)
+                                             DEP_X_1, IGNORE_INPLACE)
 
 // ----------------------------------------------------------------------------
 // One argument

--- a/include/nbla/function/utils/base_transform_unary.hpp
+++ b/include/nbla/function/utils/base_transform_unary.hpp
@@ -211,12 +211,14 @@ Note : If DEP_Y is true, the gradient computation depends on output data.
     }                                                                          \
   }
 
-#define NBLA_DEFINE_TRANSFORM_UNARY_CLASS_1_INPLACE(NAME, DEP_Y, DEP_X, A0)    \
+#define NBLA_DEFINE_TRANSFORM_UNARY_CLASS_1_INPLACE(NAME, DEP_Y, DEP_X, A0,    \
+                                                    IGNORE_INPLACE)            \
   template <typename T>                                                        \
   class NAME : public TransformUnary<T, NAME##UnaryOp, A0> {                   \
     NBLA_DEFINE_TRANSFORM_UNARY_CLASS_COMMON(NAME, DEP_Y, DEP_X)               \
     NAME(const Context &ctx, const A0 &a0, bool inplace)                       \
-        : TransformUnary<T, NAME##UnaryOp, A0>(ctx, inplace, a0) {}            \
+        : TransformUnary<T, NAME##UnaryOp, A0>(                                \
+              ctx, (IGNORE_INPLACE) ? false : inplace, a0) {}                  \
     virtual shared_ptr<Function> copy() const {                                \
       return create_##NAME(this->ctx_, std::get<0>(this->args_),               \
                            this->inplace_);                                    \
@@ -237,10 +239,12 @@ Note : If DEP_Y is true, the gradient computation depends on output data.
   NBLA_DEFINE_UNARY_OP_1(NAME, OP, GOP, A0);                                   \
   NBLA_DEFINE_TRANSFORM_UNARY_CLASS_1(NAME, DEP_Y, DEP_X, A0)
 
-#define NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(NAME, OP, GOP, DEP_Y, DEP_X, A0) \
+#define NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(NAME, OP, GOP, DEP_Y, DEP_X, A0, \
+                                              IGNORE_INPLACE)                  \
   NBLA_REGISTER_FUNCTION_HEADER(NAME, A0, bool);                               \
   NBLA_DEFINE_UNARY_OP_1(NAME, OP, GOP, A0);                                   \
-  NBLA_DEFINE_TRANSFORM_UNARY_CLASS_1_INPLACE(NAME, DEP_Y, DEP_X, A0)
+  NBLA_DEFINE_TRANSFORM_UNARY_CLASS_1_INPLACE(NAME, DEP_Y, DEP_X, A0,          \
+                                              IGNORE_INPLACE)
 
 #define NBLA_DEFINE_UNARY_OP_1_NO_GRAD(NAME, OP, A0)                           \
   NBLA_DEFINE_UNARY_OP_CLASS(NAME) {                                           \

--- a/include/nbla/function/vat_noise.hpp
+++ b/include/nbla/function/vat_noise.hpp
@@ -61,6 +61,7 @@ public:
   virtual vector<string> allowed_array_classes() {
     return vector<string>{"CpuArray"};
   }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/vat_noise.hpp
+++ b/include/nbla/function/vat_noise.hpp
@@ -72,6 +72,9 @@ protected:
                                       const Variables &outputs,
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    return false;
+  }
 };
 }
 #endif

--- a/include/nbla/function/warp_by_flow.hpp
+++ b/include/nbla/function/warp_by_flow.hpp
@@ -64,6 +64,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "WarpByFlow"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/warp_by_grid.hpp
+++ b/include/nbla/function/warp_by_grid.hpp
@@ -91,6 +91,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "WarpByGrid"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/weight_normalization.hpp
+++ b/include/nbla/function/weight_normalization.hpp
@@ -61,6 +61,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "WeightNormalization"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/where.hpp
+++ b/include/nbla/function/where.hpp
@@ -53,6 +53,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "Where"; }
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -486,7 +486,7 @@ cdef class NdArray:
     def __imul__(self, x):
         import nnabla.functions as F
         if isinstance(x, (NdArray, Variable)):
-            F.mul2(self, x, inplace=True)
+            return F.mul2(self, x)
         else:
             F.mul_scalar(self, x, inplace=True)
         return self
@@ -494,7 +494,7 @@ cdef class NdArray:
     def __idiv__(self, x):
         import nnabla.functions as F
         if isinstance(x, (NdArray, Variable)):
-            F.div2(self, x, inplace=True)
+            return F.div2(self, x)
         else:
             F.mul_scalar(self, 1. / x, inplace=True)
         return self
@@ -502,7 +502,7 @@ cdef class NdArray:
     def __itruediv__(self, x):
         import nnabla.functions as F
         if isinstance(x, (NdArray, Variable)):
-            F.div2(self, x, inplace=True)
+            return F.div2(self, x)
         else:
             F.mul_scalar(self, 1. / x, inplace=True)
         return self
@@ -510,10 +510,9 @@ cdef class NdArray:
     def __ipow__(self, x):
         import nnabla.functions as F
         if isinstance(x, (NdArray, Variable)):
-            F.pow2(self, x, inplace=True)
+            return F.pow2(self, x)
         else:
-            F.pow_scalar(self, x, inplace=True)
-        return self
+            return F.pow_scalar(self, x)
 
     def copy_from(self, NdArray arr, use_current_context=True):
         """

--- a/python/src/nnabla/backward_function/backward_function.py
+++ b/python/src/nnabla/backward_function/backward_function.py
@@ -51,6 +51,12 @@ class UnaryDataGrad(PythonFunction):
     def min_outputs(self):
         return 1
 
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
     @property
     def xshape(self):
         return self._xshape
@@ -115,6 +121,12 @@ class LinearDataGrad(PythonFunction):
 
     def min_outputs(self):
         return 1
+
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return True
 
     @property
     def xshape(self):
@@ -207,6 +219,12 @@ class LinearFilterGrad(PythonFunction):
 
     def min_outputs(self):
         return 1
+
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return True
 
     @property
     def wshape(self):

--- a/python/src/nnabla/backward_function/batch_normalization.py
+++ b/python/src/nnabla/backward_function/batch_normalization.py
@@ -170,6 +170,12 @@ class BatchNormalizationBackward(PythonFunction):
     def min_outputs(self):
         return self.rm_idx - 1
 
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return True
+
     def setup_impl(self, inputs, outputs):
         # inputs:  dy, x, beta, gamma, rmean, rvar
         # outputs: dx, dbeta, dgamma

--- a/python/src/nnabla/backward_function/concatenate.py
+++ b/python/src/nnabla/backward_function/concatenate.py
@@ -48,6 +48,12 @@ class ConcatenateDataGrad(PythonFunction):
     def min_outputs(self):
         return len(self.xshapes)
 
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
     @property
     def xshapes(self):
         return self._xshapes

--- a/python/src/nnabla/backward_function/div2.py
+++ b/python/src/nnabla/backward_function/div2.py
@@ -14,7 +14,7 @@ import nnabla.functions as F
 from .utils import no_grad, sum_for_arithmetics
 
 
-def div2_backward(inputs, inplace=False):
+def div2_backward(inputs, inplace=False):  # Inplacing is obsoleted.
     """
     Args:
       inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
@@ -27,7 +27,7 @@ def div2_backward(inputs, inplace=False):
     x0 = inputs[1]
     x1 = inputs[2]
     dx0 = dy / x1
-    dx1 = -dy * x0 / x1 if inplace else -dy * x0 / x1 ** 2
+    dx1 = -dy * x0 / x1 ** 2
     dx0 = sum_for_arithmetics(dx0, x0)
     dx1 = sum_for_arithmetics(dx1, x1)
     return dx0, dx1

--- a/python/src/nnabla/backward_function/dropout.py
+++ b/python/src/nnabla/backward_function/dropout.py
@@ -14,7 +14,7 @@ import nnabla.functions as F
 from .utils import no_grad, get_output
 
 
-def dropout_backward(inputs, p=0.5, seed=-1):
+def dropout_backward(inputs, p=0.5, seed=-1, output_mask=False):
     """
     Args:
       inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
@@ -23,10 +23,15 @@ def dropout_backward(inputs, p=0.5, seed=-1):
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "Dropout")
-    m0 = F.not_equal_scalar(y0, 0)
-    m0 = no_grad(m0)
-    dx0 = dy * m0 / (1 - p)
+
+    if not output_mask:
+        raise ValueError(
+            "dropout_backward is supported for output_mask=True.")
+    dy0 = inputs[0]
+    dy1 = inputs[1]
+    x0 = inputs[2]
+
+    y1 = get_output(x0, "Dropout", nth_output=1)
+    m0 = y1.get_unlinked_variable()  # mask
+    dx0 = dy0 * m0 / (1 - p)
     return dx0

--- a/python/src/nnabla/backward_function/fused_batch_normalization.py
+++ b/python/src/nnabla/backward_function/fused_batch_normalization.py
@@ -112,6 +112,12 @@ class FusedBatchNormalizationBackward(PythonFunction):
     def min_outputs(self):
         return 4 if self._is_add else 3
 
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return True
+
     def setup_impl(self, inputs, outputs):
         # inputs:  dy, x, beta, gamma, rmean, rvar, y(, z)
         # outputs: dx, dbeta, dgamma(, dz)

--- a/python/src/nnabla/backward_function/log_softmax.py
+++ b/python/src/nnabla/backward_function/log_softmax.py
@@ -11,7 +11,7 @@
 
 
 import nnabla.functions as F
-from .utils import no_grad, positive_axis
+from .utils import no_grad, positive_axis, get_output
 
 
 def log_softmax_backward(inputs, axis=None):
@@ -25,8 +25,8 @@ def log_softmax_backward(inputs, axis=None):
     """
     dy = inputs[0]
     x0 = inputs[1]
-    y0 = F.softmax(x0, axis=axis)
+    y0 = get_output(x0, "LogSoftmax")
     D = len(x0.shape)
     axis = positive_axis(axis, D)
-    dx0 = dy - y0 * F.sum(dy, axis=axis, keepdims=True)
+    dx0 = dy - F.exp(y0) * F.sum(dy, axis=axis, keepdims=True)
     return dx0

--- a/python/src/nnabla/backward_function/max_pooling_backward.py
+++ b/python/src/nnabla/backward_function/max_pooling_backward.py
@@ -63,6 +63,12 @@ class MaxPoolingBackwardDataGrad(PythonFunction):
     def yshape(self, yshape):
         self._yshape = yshape
 
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return True
+
     def setup_impl(self, inputs, outputs):
         # inputs[0]:  gdx
         # inputs[1]:  x0

--- a/python/src/nnabla/backward_function/mul2.py
+++ b/python/src/nnabla/backward_function/mul2.py
@@ -14,7 +14,7 @@ import nnabla.functions as F
 from .utils import no_grad, sum_for_arithmetics
 
 
-def mul2_backward(inputs, inplace=False):
+def mul2_backward(inputs, inplace=False):  # Inplacing is obsoleted.
     """
     Args:
       inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
@@ -26,7 +26,6 @@ def mul2_backward(inputs, inplace=False):
     dy = inputs[0]
     x0 = inputs[1]
     x1 = inputs[2]
-    x0 = x0 / x1 if inplace else x0
     dx0 = dy * x1
     dx1 = dy * x0
     dx0 = sum_for_arithmetics(dx0, x0)

--- a/python/src/nnabla/backward_function/mul_scalar.py
+++ b/python/src/nnabla/backward_function/mul_scalar.py
@@ -24,7 +24,5 @@ def mul_scalar_backward(inputs, val=1, inplace=False):
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
     dy = inputs[0]
-    x0 = inputs[1]
-    x0 = x0 / val if inplace else x0
     dx0 = dy * val
     return dx0

--- a/python/src/nnabla/backward_function/pow2.py
+++ b/python/src/nnabla/backward_function/pow2.py
@@ -14,7 +14,7 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def pow2_backward(inputs, inplace=False):
+def pow2_backward(inputs, inplace=False):  # Inplacing is obsoleted.
     """
     Args:
       inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
@@ -26,7 +26,6 @@ def pow2_backward(inputs, inplace=False):
     dy = inputs[0]
     x0 = inputs[1]
     x1 = inputs[2]
-    x0 = x0 ** (1 / x1) if inplace else x0
     dx0 = dy * x1 * x0 ** (x1 - 1)
     dx1 = dy * (x0 ** x1) * F.log(x0)
     return dx0, dx1

--- a/python/src/nnabla/backward_function/pow_scalar.py
+++ b/python/src/nnabla/backward_function/pow_scalar.py
@@ -14,6 +14,7 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
+# Inplacing is obsoleted.
 def pow_scalar_backward(inputs, val=1, inplace=False):
     """
     Args:
@@ -25,6 +26,5 @@ def pow_scalar_backward(inputs, val=1, inplace=False):
     """
     dy = inputs[0]
     x0 = inputs[1]
-    dx0 = dy * val * x0 ** ((val - 1.0) /
-                            val) if inplace else dy * val * x0 ** (val - 1)
+    dx0 = dy * val * x0 ** (val - 1)
     return dx0

--- a/python/src/nnabla/backward_function/relu.py
+++ b/python/src/nnabla/backward_function/relu.py
@@ -25,7 +25,7 @@ def relu_backward(inputs, inplace=False):
     """
     dy = inputs[0]
     x0 = inputs[1]
-    x0 = get_output(x0, "ReLU") if inplace else x0
+    x0 = get_output(x0, "ReLU")
     m0 = F.greater_scalar(x0, 0)  # result is same even if inplace or not
     m0 = no_grad(m0)
     dx0 = dy * m0

--- a/python/src/nnabla/backward_function/utils.py
+++ b/python/src/nnabla/backward_function/utils.py
@@ -61,10 +61,10 @@ def force_tuple(x):
     return x
 
 
-def get_output(x, func_name):
+def get_output(x, func_name, nth_output=0):
     for func in x.function_references:
         if func.info.type_name == func_name:
-            return func.outputs[0]
+            return func.outputs[nth_output]
     raise ValueError("{} is not found.".format(func_name))
 
 

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -81,7 +81,9 @@ cdef extern from "nbla/function/callback.hpp":
         void(void *, const Variables&, const Variables &) nogil except+,
         void(void *, const Variables&, const Variables &,
              const vector[cpp_bool] &, const vector[cpp_bool] &) nogil except+,
-        void(void *) nogil) except +
+        void(void *) nogil,
+        cpp_bool(void *, int, int) nogil except+,
+        cpp_bool(void *, int, int) nogil except+) except +
 <%
 from utils.type_conv import type_from_proto
 %>    

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -511,7 +511,7 @@ cdef void forward_callback(void *cself, const Variables &cinputs,
     inputs = to_unsafe_variables(cinputs)
     outputs = to_unsafe_variables(coutputs)
 
-    # Call setup_impl in function.
+    # Call forward_impl in function.
     from nnabla import context_scope
     with context_scope(self.ctx):    
         self.forward_impl(inputs, outputs)
@@ -527,7 +527,7 @@ cdef void backward_callback(void *cself, const Variables &cinputs,
     inputs = to_unsafe_variables(cinputs)
     outputs = to_unsafe_variables(coutputs)
 
-    # Call setup_impl in function.
+    # Call backward_impl in function.
     from nnabla import context_scope
     with context_scope(self.ctx):    
         self.backward_impl(inputs, outputs,
@@ -539,6 +539,24 @@ cdef void cleanup_callback(void *cself) with gil:
     """
     Py_DECREF(<object> cself)
     
+
+cdef cpp_bool grad_depends_output_data_callback(void *cself, int i, int o) except+ with gil:
+    cdef object self
+    self = <object>cself
+
+    # Call grad_depends_output_data in function.
+    from nnabla import context_scope
+    with context_scope(self.ctx):
+        return self.grad_depends_output_data(i, o)
+
+cdef cpp_bool grad_depends_input_data_callback(void *cself, int i, int j) except+ with gil:
+    cdef object self
+    self = <object>cself
+
+    # Call grad_depends_input_data in function.
+    from nnabla import context_scope
+    with context_scope(self.ctx):
+        return self.grad_depends_input_data(i, j)
 
 class PythonFunction:
     """
@@ -603,6 +621,12 @@ class PythonFunction:
                         dx1 += F.mul2(dy, x0)
                     else:
                         dx1.copy_from(F.mul2(dy, x0))
+            
+            def grad_depends_output_data(self, i, o):
+                return False
+            
+            def grad_depends_input_data(self, i, j):
+                return True
 
         def mul2(x, y, ctx=None):
             func = Mul2(ctx)
@@ -635,7 +659,9 @@ class PythonFunction:
                             setup_callback,
                             forward_callback,
                             backward_callback,
-                            cleanup_callback), info)
+                            cleanup_callback,
+                            grad_depends_output_data_callback,
+                            grad_depends_input_data_callback), info)
         return f(*inputs, n_outputs=n_outputs,
                  auto_forward=get_auto_forward(), outputs=outputs)
 
@@ -663,6 +689,26 @@ class PythonFunction:
         Minimum number of outputs of the function.
         """
         raise NotImplementedError("Implement `min_outputs`.")
+
+    def grad_depends_output_data(self, i, o):
+        """
+        Checking if i-th input' gradient computation requires o-th output's data or not.
+
+        Args:
+            i: (list of :class:`nnabla.Variable`): Input variable index.
+            o: (list of :class:`nnabla.Variable`): Output variable index.
+        """
+        raise NotImplementedError("Implement `grad_depends_output_data`.")
+
+    def grad_depends_input_data(self, i, j):
+        """
+        Checking if i-th input' gradient computation requires j-th input's data or not.
+
+        Args:
+            i: (list of :class:`nnabla.Variable`): Input variable index.
+            i: (list of :class:`nnabla.Variable`): Input variable index.
+        """
+        raise NotImplementedError("Implement `grad_depends_input_data`.")
 
     def setup_impl(self, inputs, outputs):
         """
@@ -710,6 +756,12 @@ class Dummy(PythonFunction):
 
     def min_outputs(self):
         return 1
+    
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
 
     def setup_impl(self, inputs, outputs):
         pass

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -1130,6 +1130,45 @@ def _istft_v1(y_r, y_i, window_size, stride, fft_size, window_type='hanning', ce
     return x
 
 
+def dropout(x, p=0.5, seed=-1, output_mask=False):
+    """ Dropout.
+        Samples a number :math:`u` from a uniform distribution in :math:`[0, 1]` ,
+        and ignores the input if :math:`u \leq p`.
+
+        .. math::
+            y = \left\{
+            \begin{array}{ll}
+                \frac{x}{1 - p} & (u > p) \\
+                0 & ({\rm otherwise})
+            \end{array} \right.
+
+    Args:
+        x (Variable): An input variable.
+        p (float): math:`p` in definition. [default= `0.5` ]
+        seed (int): Random seed. When -1, seed is sampled from global random number generator. [default= `-1` ]
+        output_mask (bool): Whether or not to output mask. [default= `False` ]
+
+    Returns:
+        ~nnabla.Variable: N-D array.
+
+    Note:
+        Usually dropout only applied during training as below
+        (except `MC dropout`_). If you want to use dropout as an MC dropout, remove 'if train:'.
+
+        .. code-block:: python
+
+            h = PF.affine(x, num_hidden)
+            if train:
+                h = F.dropout(h, 0.5)
+
+    .. _MC dropout: https://arxiv.org/abs/1506.02142
+    """
+    from .function_bases import dropout as dropout_base
+
+    n_outputs = 2 if output_mask else 1
+    return dropout_base(x, p, seed, output_mask, n_outputs)
+
+
 def gather_nd(data, indices):
     """Gather elements or slices from `data` according to `indices`, which must
     be at least two-dimensional with the first dimension :math:`M` being less or

--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -285,8 +285,7 @@ class Grad(object):
 
             # Propagate down
             for inp, grad_out in zip(f.inputs, grad_outputs):
-                # if inp not in child_nodes and not inp.need_grad or grad_out is None:
-                if inp not in child_nodes and not inp.need_grad or grad_out is None:
+                if inp not in child_nodes or not inp.need_grad or grad_out is None:
                     continue
                 p_i = inp.parent
                 if not p_i:

--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -32,6 +32,12 @@ class GradEndFunction(PythonFunction):
     def min_outputs(self):
         return 1
 
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
     def setup_impl(self, inputs, outputs):
         i = inputs[0]
         o = outputs[0]

--- a/python/test/communicator/test_sync_batch_normalization.py
+++ b/python/test/communicator/test_sync_batch_normalization.py
@@ -203,6 +203,7 @@ def test_sync_batch_normalization_forward_backward(seed, axis, decay_rate, eps, 
 
     # TODO: enable test using function_tester when the backward is supported with batch_stat=True
     if batch_stat is True:
+        insert_identity = [True, True, True, False, False]
         function_tester(rng, F.sync_batch_normalization, ref_batch_normalization,
                         inputs,
                         ref_grad=ref_grad,
@@ -214,7 +215,8 @@ def test_sync_batch_normalization_forward_backward(seed, axis, decay_rate, eps, 
                             batch_stat=batch_stat,
                             output_stat=output_stat),
                         backward=[True, True, True, False, False],
-                        ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2)
+                        ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2,
+                        insert_identity=insert_identity)
     else:
         if no_mean or no_variance:
             return

--- a/python/test/function/test_batch_normalization.py
+++ b/python/test/function/test_batch_normalization.py
@@ -251,13 +251,18 @@ def test_batch_normalization_double_backward(seed, axis, decay_rate, eps,
     axes = [axis]
     func_args = [axes, decay_rate, eps, batch_stat, output_stat]
 
+    insert_identity = []
+    if batch_stat:
+        insert_identity = [True, True, True, False, False]
+
     # 2nd-order
     backward_function_tester(rng, F.batch_normalization,
                              inputs,
                              func_args=func_args,
                              backward=[True, not no_bias,
                                        not no_scale, False, False],
-                             ctx=ctx, atol_accum=1e-2, dstep=1e-3)
+                             ctx=ctx, atol_accum=1e-2, dstep=1e-3,
+                             insert_identity=insert_identity)
     # 3rd-order
     func_args = func_args[:-1] + [no_scale, no_bias]
     df = BatchNormalizationBackward(ctx, *func_args)

--- a/python/test/function/test_batch_normalization.py
+++ b/python/test/function/test_batch_normalization.py
@@ -122,12 +122,15 @@ def test_batch_normalization_forward_backward(seed, axis, decay_rate, eps,
         return
     else:
         inputs = mask_inputs(inputs, no_scale, no_bias, no_mean, no_variance)
+        insert_identity = []
+        if batch_stat:
+            insert_identity = [True, True, True, False, False]
         function_tester(rng, F.batch_normalization, ref_batch_normalization,
                         inputs,
                         func_args=[axes, decay_rate, eps,
                                    batch_stat, output_stat],
                         backward=[True, True, True, False, False],
-                        ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2)
+                        ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2, insert_identity=insert_identity)
 
     # Check if running mean and var works.
     if no_mean and no_variance:

--- a/python/test/function/test_binary_connect_affine.py
+++ b/python/test/function/test_binary_connect_affine.py
@@ -83,6 +83,7 @@ def test_binary_connect_affine_forward_backward(seed, base_axis, weight_shape, b
     else:
         inputs += [None]
 
+    insert_identity = [True, True, False, True]
     function_tester(rng, F.binary_connect_affine, ref_binary_connect_affine, inputs, func_args=[base_axis, quantize_zero_to],
                     atol_b=1e-2, backward=[True, True, False, True], ctx=ctx, func_name=func_name,
-                    ref_grad=ref_grad_binary_connect_affine)
+                    ref_grad=ref_grad_binary_connect_affine, insert_identity=insert_identity)

--- a/python/test/function/test_binary_connect_convolution.py
+++ b/python/test/function/test_binary_connect_convolution.py
@@ -89,8 +89,9 @@ def test_convolution_2d_forward_backward(inshape, kernel, outmaps, pad, stride,
     if with_bias:
         b = rng.randn(outmaps).astype(np.float32)
     inputs = [i, k, np.zeros_like(k), b]
+    insert_identity = [True, True, False, True]
     function_tester(rng, F.binary_connect_convolution, ref_binary_connect_convolution, inputs,
                     func_args=[base_axis, pad, stride,
                                dilation, group, quantize_zero_to],
                     atol_f=1e-4, atol_b=3e-3, atol_accum=1e-5, dstep=1e-2, backward=[True, True, False, True],
-                    ctx=ctx, func_name=func_name, ref_grad=ref_grad_binary_connect_convolution)
+                    ctx=ctx, func_name=func_name, ref_grad=ref_grad_binary_connect_convolution, insert_identity=insert_identity)

--- a/python/test/function/test_dropout.py
+++ b/python/test/function/test_dropout.py
@@ -26,8 +26,9 @@ ctxs = list_context('Dropout')
 @pytest.mark.parametrize("ctx, func_name", ctxs)
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("p", [p / 10. for p in range(1, 9)])
-def test_dropout_forward_backward(p, seed, ctx, func_name):
-    from nbla_test_utils import cap_ignore_region, function_tester
+@pytest.mark.parametrize("output_mask", [True, False])
+def test_dropout_forward_backward(output_mask, p, seed, ctx, func_name):
+    from nbla_test_utils import cap_ignore_region, function_tester, force_tuple
     rng = np.random.RandomState(seed)
     inputs = [
         cap_ignore_region(
@@ -37,17 +38,20 @@ def test_dropout_forward_backward(p, seed, ctx, func_name):
     i.d = inputs[0]
     # NNabla forward
     with nn.context_scope(ctx), nn.auto_forward():
-        o = F.dropout(i, p)
+        o = F.dropout(i, p, output_mask=output_mask)
+        o = force_tuple(o)
     scale = 1. / (1. - p)
-    mask = o.d != 0
-    assert_allclose(o.d, i.d * mask * scale)
-    assert o.parent.name == func_name
+    mask = o[0].d != 0
+    assert_allclose(o[0].d, i.d * mask * scale)
+    if output_mask:
+        assert_allclose(o[1].d, mask)
+    assert o[0].parent.name == func_name
 
     # NNabla backward
     orig_grad = rng.randn(*i.shape).astype(i.data.dtype)
     i.g[...] = orig_grad
     o_grad = rng.randn(*i.shape).astype(i.data.dtype)
-    o.backward(o_grad)
+    o[0].backward(o_grad)
     ref_grad = o_grad * mask * scale
 
     # Verify
@@ -55,19 +59,19 @@ def test_dropout_forward_backward(p, seed, ctx, func_name):
 
     # Check if accum option works
     i.g[...] = 1
-    o.g = o_grad
-    o.parent.backward([i], [o], [False])
+    o[0].g = o_grad
+    o[0].parent.backward([i], [*o], [False])
     assert_allclose(i.g, ref_grad)
 
     # Check accum=False with NaN gradient
     i.g = np.float32('nan')
-    o.parent.backward([i], [o], [False])
+    o[0].parent.backward([i], [*o], [False])
     assert not np.any(np.isnan(i.g))
 
     # Check if need_grad works
     i.g[...] = 0
     i.need_grad = False
-    o.backward(o_grad)
+    o[0].backward(o_grad)
     assert np.all(i.g == 0)
 
 
@@ -78,7 +82,8 @@ def test_dropout_double_backward(p, seed, ctx, func_name):
     from nbla_test_utils import backward_function_tester
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(2, 3, 4).astype(np.float32) * 2]
-    backward_function_tester(rng, F.dropout, inputs, func_args=[p, seed], ctx=ctx,
+    output_mask = True
+    backward_function_tester(rng, F.dropout, inputs, func_args=[p, seed, output_mask], ctx=ctx,
                              skip_backward_check=True)
 
 

--- a/python/test/function/test_fused_batch_normalization.py
+++ b/python/test/function/test_fused_batch_normalization.py
@@ -232,6 +232,10 @@ def test_fused_batch_normalization_double_backward(seed, axis, decay_rate, eps,
     func_args = [axes, decay_rate, eps, batch_stat, nonlinearity, output_stat]
     inputs = mask_inputs(inputs, no_scale, no_bias, no_mean, no_variance)
 
+    insert_identity = []
+    if batch_stat:
+        insert_identity = [True, True, True, False, False, False]
+
     # 2nd-order
     backward = [True, True, True, False, False, add] if batch_stat else \
         [False, False, False, False, False, False]
@@ -239,7 +243,8 @@ def test_fused_batch_normalization_double_backward(seed, axis, decay_rate, eps,
                              inputs,
                              func_args=func_args,
                              backward=backward,
-                             ctx=ctx)
+                             ctx=ctx,
+                             insert_identity=insert_identity)
     # 3rd-order
     func_args = func_args[:-1]
     fused_batch_normalization_backward, y = \
@@ -249,6 +254,7 @@ def test_fused_batch_normalization_double_backward(seed, axis, decay_rate, eps,
     fused_batch_normalization_backward.is_add = add
     ginputs = [rng.randn(*y.shape)] + inputs + [rng.randn(*y.shape)] if add else \
         [rng.randn(*y.shape)] + inputs[:-1] + [rng.randn(*y.shape)]
+
     backward_function_tester(rng, fused_batch_normalization_backward,
                              inputs=ginputs,
                              func_args=[],

--- a/python/test/function/test_fused_batch_normalization.py
+++ b/python/test/function/test_fused_batch_normalization.py
@@ -157,13 +157,14 @@ def test_fused_batch_normalization_forward_backward(seed, axis, decay_rate, eps,
     axes = [axis]
     batch_stat = True
     inputs = mask_inputs(inputs, no_scale, no_bias, no_mean, no_variance)
+    insert_identity = [True, True, True, False, False, False]
     function_tester(rng, F.fused_batch_normalization, ref_fused_batch_normalization,
                     inputs,
                     ref_grad=ref_grad_fused_batch_normalization,
                     func_args=[axes, decay_rate, eps,
                                batch_stat, nonlinearity, output_stat],
                     backward=[True, True, True, False, False, add],
-                    ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2)
+                    ctx=ctx, func_name=func_name, dstep=1e-2, atol_b=1e-2, insert_identity=insert_identity)
 
     # Check if running mean and var works.
     if no_mean and no_variance:

--- a/python/test/function/test_pack_padded_sequence.py
+++ b/python/test/function/test_pack_padded_sequence.py
@@ -64,11 +64,12 @@ def test_pack_padded_sequence_forward_backward(batch_first, shapes, seed, ctx, f
     lengths = np.array([seq.shape[0] for seq in sequences])
     inputs = [padded_sequence, lengths]
     func_args = [batch_first]
+    insert_identity = [True, False]
 
     function_tester(rng, F.pack_padded_sequence, ref_pack_padded_sequence, inputs,
                     ctx=ctx, func_name=func_name, func_args=func_args,
                     backward=[True, False], disable_half_test=False,
-                    atol_f=1e-3, atol_b=1e-2)
+                    atol_f=1e-3, atol_b=1e-2, insert_identity=insert_identity)
 
 
 @pytest.mark.parametrize("ctx, func_name", ctxs)
@@ -94,12 +95,13 @@ def test_pack_padded_long_sequence_forward_backward(total_length, padding_value,
     inputs = [padded_sequence, lengths]
     func_args0 = [batch_first]
     func_args1 = [batch_first, padding_value, total_length]
+    insert_identity = [True, False]
 
     # Forward
     function_tester(rng, F.pack_padded_sequence, ref_pack_padded_sequence, inputs,
                     ctx=ctx, func_name=func_name, func_args=func_args0,
                     backward=[False, False],
-                    atol_f=1e-3, atol_b=1e-2)
+                    atol_f=1e-3, atol_b=1e-2, insert_identity=insert_identity)
 
     # Backward
     import nnabla as nn

--- a/python/test/function/test_pad_packed_sequence.py
+++ b/python/test/function/test_pad_packed_sequence.py
@@ -72,10 +72,11 @@ def test_pad_packed_sequence_forward_backward(total_length, padding_value, batch
     batch_sizes = np.array(batch_sizes)
     inputs = [packed_sequence, batch_sizes]
     func_args = [batch_first, padding_value, total_length]
+    insert_identity = [True, False]
     function_tester(rng, F.pad_packed_sequence, ref_pad_packed_sequence, inputs,
                     ctx=ctx, func_name=func_name, func_args=func_args,
                     backward=[True, False], disable_half_test=False,
-                    atol_f=1e-3, atol_b=1e-2)
+                    atol_f=1e-3, atol_b=1e-2, insert_identity=insert_identity)
 
 
 @pytest.mark.parametrize("ctx, func_name", ctxs)
@@ -112,10 +113,11 @@ def test_pad_packed_long_sequence_forward_backward(total_length, padding_value,
             padded_sequence0, lengths, *func_args0)
     # Forward
     inputs = [packed_sequence0.d, batch_sizes.d]
+    insert_identity = [True, False]
     function_tester(rng, F.pad_packed_sequence, ref_pad_packed_sequence, inputs,
                     ctx=ctx, func_name=func_name, func_args=func_args1,
                     backward=[False, False],
-                    atol_f=1e-3, atol_b=1e-2)
+                    atol_f=1e-3, atol_b=1e-2, insert_identity=insert_identity)
 
     # Backward
     import nnabla as nn

--- a/python/test/function/test_slice.py
+++ b/python/test/function/test_slice.py
@@ -48,8 +48,15 @@ def ref_slice(x, start, stop, step):
 def test_slice_forward_backward(seed, inshape, start, stop, step, ctx, fname):
     rng = np.random.RandomState(seed)
     x = rng.randn(*inshape).astype(np.float32)
+
+    oshape = ref_slice(x, start, stop, step).shape
+    disable_clear_no_need_grad_test = False
+    # If oshape has a dimention of size 0, disable clear_no_need_grad_test.
+    if 0 in oshape:
+        disable_clear_no_need_grad_test = True
     function_tester(rng, F.slice, ref_slice, [x], ctx=ctx, func_name=fname,
-                    func_args=[start, stop, step], atol_f=1e-4, atol_b=1e-2)
+                    func_args=[start, stop, step], atol_f=1e-4, atol_b=1e-2,
+                    disable_clear_no_need_grad_test=disable_clear_no_need_grad_test)
 
 
 @pytest.mark.parametrize("ctx, fname", ctxs)

--- a/python/test/function/test_top_k_grad.py
+++ b/python/test/function/test_top_k_grad.py
@@ -52,10 +52,16 @@ def ref_top_k_grad_bw(x, g, k, abs, base_axis, **kw):
 def test_forward_backward(seed, ishape, k, abs, base_axis, ctx, fname):
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*ishape).astype(np.float32)]
+    if fname.endswith('Cuda'):
+        # TopKGradCuda backward use unstable sort, so the result will change each run.
+        disable_clear_no_need_grad_test = True
+    else:
+        disable_clear_no_need_grad_test = False
     function_tester(rng, F.top_k_grad, ref_top_k_grad_fw, inputs, ctx=ctx,
                     func_name=fname, ref_grad=ref_top_k_grad_bw,
                     func_args=[k, abs, base_axis],
-                    disable_half_test=k > 10)
+                    disable_half_test=k > 10,
+                    disable_clear_no_need_grad_test=disable_clear_no_need_grad_test)
 
     # Note: FP16 has too many duplicate value for larger K to get the
     # same sort order as FP32 and this makes the function tester fail

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -816,7 +816,7 @@ def backward_function_tester(rng, func, inputs=None,
         outputs_for_clear_buffer = func(*(vinputs_identity_for_clear_buffer + func_args), **func_kwargs)
         outputs_for_clear_buffer = force_list(outputs_for_clear_buffer)
         outputs_for_clear_buffer = list(map(lambda x: F.identity(x) if x is not None else None, outputs_for_clear_buffer))
-        F.sink(*outputs_for_clear_buffer).forward(clear_no_need_grad=False)
+        F.sink(*outputs_for_clear_buffer).forward(clear_no_need_grad=True)
 
     for o, ref_o in zip(outputs_for_clear_buffer, outputs0):
         o.g = ref_o.g
@@ -841,7 +841,7 @@ def backward_function_tester(rng, func, inputs=None,
         ograds0 = func_backward(grad_vinputs_identity, **func_info_args)
         ograds0 = force_list(ograds0)
         ograds0_ = list(filter(lambda o: o is not None, ograds0))
-        F.sink(*ograds0_).forward(clear_no_need_grad=False)
+        F.sink(*ograds0_).forward(clear_no_need_grad=True)
     outputs1 = []
     for i, ograd in enumerate(ograds0):
         outputs1.append(ograd.d.copy()) if ograd is not None else \
@@ -901,7 +901,7 @@ def backward_function_tester(rng, func, inputs=None,
         sum_ograd = F.sum(ograd) * rgrad
         numerical_grads = approx_fprime(
             grad_inputs1, obj_func, dstep, sum_ograd, grad_vinputs)
-        sum_ograd.forward()
+        sum_ograd.forward(clear_no_need_grad=True)
         sum_ograd.backward()
         analytical_grads = np.concatenate(
             [v.g.flatten() for v in grad_vinputs])
@@ -933,7 +933,7 @@ def backward_function_tester(rng, func, inputs=None,
     with nn.context_scope(ctx), nn.auto_forward(False):
         ograds1 = nn.grad(outputs0, vinputs_identity,
                           grad_outputs=[g.d.copy() for g in grad_voutputs])
-        F.sink(*ograds1).forward(clear_no_need_grad=False)
+        F.sink(*ograds1).forward(clear_no_need_grad=True)
     ograds0 = list(filter(lambda o: o is not None, ograds0))
     ograds1 = list(filter(lambda o: o is not None, ograds1))
     for i in range(len(ograds0)):

--- a/python/test/test_ndarray_arithmetic_ops.py
+++ b/python/test/test_ndarray_arithmetic_ops.py
@@ -47,8 +47,20 @@ def test_ndarray_arithmetic_ops2(seed, op, x_var, y_var, shape):
 
     # Inplace test
     vx_bak = vx
-    exec_("vx {0}= vy".format(op))
+    if op == '+':
+        vx += vy
+    elif op == '-':
+        vx -= vy
+    elif op == '*':
+        vx *= vy
+    elif op == '/':
+        vx /= vy
+    elif op == '**':
+        vx **= vy
     assert_allclose(vx.data, vz.data)
+    if op == '*' or op == '/' or op == '**':
+        # In-placing for `*`, `/` and `**` is obsoleted.
+        return
     assert vx is vx_bak
 
 
@@ -67,8 +79,20 @@ def test_ndarray_arithmetic_scalar_ops(seed, op, shape):
 
     # Inplace test
     vx_bak = vx
-    exec_("vx {0}= a".format(op))
+    if op == '+':
+        vx += a
+    elif op == '-':
+        vx -= a
+    elif op == '*':
+        vx *= a
+    elif op == '/':
+        vx /= a
+    elif op == '**':
+        vx **= a
     assert_allclose(vx.data, vz.data)
+    if op == "**":
+        # In-placing for `**` is obsoleted.
+        return
     assert vx is vx_bak
 
 

--- a/python/test/test_python_function.py
+++ b/python/test/test_python_function.py
@@ -32,6 +32,12 @@ class Add2(PythonFunction):
     def min_outputs(self):
         return 1
 
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
     def setup_impl(self, inputs, outputs):
         outputs[0].reset_shape(inputs[0].shape, True)
 

--- a/src/nbla/function/generic/fused_batch_normalization.cpp
+++ b/src/nbla/function/generic/fused_batch_normalization.cpp
@@ -116,17 +116,17 @@ void FusedBatchNormalization<T>::backward_impl(
 
   // Naive non-fused implementation by layer composition.
   // 1. Perform ReLU backward
-  // NOTE: Output buffer are re-used by inplacing.
   bool prop_down_add2 = (inputs.size() == 6 && propagate_down[5]);
   bool prop_down_bn =
       std::accumulate(propagate_down.begin(), propagate_down.begin() + 3, false,
                       std::logical_or<bool>());
   auto y = outputs[0]->get_data_pointer<T>(this->ctx_);
-  auto dx = outputs[0]->cast_grad_and_get_pointer<T>(this->ctx_);
+  Variable relu_x(outputs[0]->shape());
+  auto relu_dx = relu_x.cast_grad_and_get_pointer<T>(this->ctx_);
   auto dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
   auto size = outputs[0]->size();
   if (prop_down_add2 || prop_down_bn) {
-    fused_batch_normalization::relu_backward(size, dx, dy, y);
+    fused_batch_normalization::relu_backward(size, relu_dx, dy, y);
   }
 
   // 2. Perform Add2 backward
@@ -135,13 +135,16 @@ void FusedBatchNormalization<T>::backward_impl(
   // nothing done for it.
   if (prop_down_add2) {
     auto dx1 = inputs[5]->cast_grad_and_get_pointer<T>(this->ctx_);
-    fused_batch_normalization::add2_backward(size, dx1, dx, accum[5]);
+    fused_batch_normalization::add2_backward(size, dx1, relu_dx, accum[5]);
   }
   // 3. Perform BN backward
   Variables inputs_bn(inputs.begin(), inputs.begin() + 5);
   vector<bool> prop_down_bn_inputs(propagate_down.begin(),
                                    propagate_down.begin() + 5);
   vector<bool> accum_bn_inputs(accum.begin(), accum.begin() + 5);
-  bn_->backward(inputs_bn, outputs, prop_down_bn_inputs, accum_bn_inputs);
+
+  Variables outputs_bn = outputs;
+  outputs_bn[0] = &relu_x;
+  bn_->backward(inputs_bn, outputs_bn, prop_down_bn_inputs, accum_bn_inputs);
 }
 } // namespace nbla

--- a/src/nbla/function/generic/relu.cpp
+++ b/src/nbla/function/generic/relu.cpp
@@ -41,12 +41,12 @@ void ReLU<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   }
 }
 template <typename T, bool accum>
-void relu_backward_cpu(int size, T *dx, const T *dy, const T *x) {
+void relu_backward_cpu(int size, T *dx, const T *dy, const T *y) {
   for (int s = 0; s < size; ++s) {
     if (accum)
-      dx[s] += (x[s] > 0 ? dy[s] : (T)0);
+      dx[s] += (y[s] > 0 ? dy[s] : (T)0);
     else
-      dx[s] = (x[s] > 0 ? dy[s] : (T)0);
+      dx[s] = (y[s] > 0 ? dy[s] : (T)0);
   }
 }
 
@@ -57,12 +57,12 @@ void ReLU<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   if (!propagate_down[0]) {
     return;
   }
-  const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
+  const T *y = outputs[0]->get_data_pointer<T>(this->ctx_);
   T *dx = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
   const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
   if (accum[0])
-    relu_backward_cpu<T, true>(inputs[0]->size(), dx, dy, x);
+    relu_backward_cpu<T, true>(inputs[0]->size(), dx, dy, y);
   else
-    relu_backward_cpu<T, false>(inputs[0]->size(), dx, dy, x);
+    relu_backward_cpu<T, false>(inputs[0]->size(), dx, dy, y);
 }
 }


### PR DESCRIPTION
Bugfixes for the follows: 

1. forward(clear_no_need_grad=True)
- PythonFunction was ignored in conjunction with clear_no_need_grad=True, resulting in the unnecessary memory buffer clear
- PythonFunction is now taken care of with clear_no_need_grad=True
- Besides, tests of clear_no_need_grad=True for all functions and backward functions are added now to ensure the same results between clear_no_need_grad=True and False.

2. Dropout mask
- In the backward function of the dropout, the original 0 values were also masked regardless of the dropout mask.
- Now, the dropout returns a mask as option used in nn.grad.

3. nn.grad w.r.t. intermediate variables
- Graph expansion by nn.grad w.r.t. intermediate variables ignored the corresponding flag, resulting in unnecessary longer expansion

