### PR TITLE
fix error when save network with F.mean() 

### DIFF
--- a/python/src/nnabla/core/variable_batch_size.py
+++ b/python/src/nnabla/core/variable_batch_size.py
@@ -82,7 +82,8 @@ def variable_batch_size(network):
             pf.args['shape'] = [-1] + arg_shape[1:]
 
     for var in network.variables.values():
-        if var.name not in special_variable and var.shape[0] == expect_batch_size:
-            var.shape = (-1,) + var.shape[1:]
+        if var.shape:
+            if var.name not in special_variable and var.shape[0] == expect_batch_size:
+                var.shape = (-1,) + var.shape[1:]
 
     network.batch_size = expect_batch_size

--- a/python/test/core/test_variable_batch_size.py
+++ b/python/test/core/test_variable_batch_size.py
@@ -20,7 +20,7 @@ import nnabla.parametric_functions as PF
 from nnabla.utils import load
 from nnabla.utils import save
 from nnabla.utils import nnp_graph
-from helper import forward_variable
+from helper import forward_variable, create_temp_with_dir
 
 
 def base_axis_0_reshape_with_neg_1(x):
@@ -174,3 +174,22 @@ def test_variable_batch_size(tmpdir, batch_size, variable_batch_size, model_def,
     if expect_batch_size != -1:
         batch_size = expect_batch_size
     assert (batch_size == out.shape[0])
+
+
+def test_scalar_save_variable_batch_size():
+    x = nn.Variable((128, 1, 28, 28))
+    h = PF.convolution(x, 32, kernel=(3, 3))
+    loss = F.mean(h)
+    with create_temp_with_dir("tmp.nnp") as temp_nnp_file_name:
+        runtime_contents = {
+            'networks': [
+                {'name': 'runtime',
+                 'batch_size': 1,
+                 'outputs': {'loss': loss},
+                 'names': {'x': x}}],
+            'executors': [
+                {'name': 'runtime',
+                 'network': 'runtime',
+                 'data': ['x'],
+                 'output': ['loss']}]}
+        nn.utils.save.save(temp_nnp_file_name, runtime_contents)

--- a/python/test/utils/test_graph_converters/ref_graphs/resnets.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/resnets.py
@@ -279,9 +279,8 @@ def bsf_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
     with nn.parameter_scope(name):
         h = PF.convolution(x, maps, kernel=kernel, pad=pad,
                            stride=stride, with_bias=w_bias)
-        z = h
         h = PF.batch_normalization(h, batch_stat=False)
-    return F.relu(h + z)
+    return F.relu(h + x)
 
 
 def small_bsf_resnet(image, w_bias=False, name='bn-graph-ref'):


### PR DESCRIPTION
This commit tends to fix a problem when save a model with F.mean().
This F.mean() will reduce shape to (), an empty tuple. our code does not handle this case properly. This commit fixed this problem.

This PR also includes a fix for unittest of graph_converter. This problem occurs only when this commit is applied. Hence, we expected these 2 commits be merged at the same time.