### PR TITLE
change image_utils imread behavior for pillow backend compatibility

### DIFF
--- a/python/src/nnabla/utils/image_utils/backend_events/pil_backend.py
+++ b/python/src/nnabla/utils/image_utils/backend_events/pil_backend.py
@@ -80,7 +80,7 @@ class PilBackend(ImageUtilsBackend):
     def pil_image_to_ndarray(pil_image, grayscale, num_channels, return_palette_indices):
         ret = PilBackend.convert_pil(pil_image, grayscale, num_channels,
                                      return_palette_indices)
-        return np.asarray(ret, dtype=np.uint8)
+        return np.asarray(ret).astype(np.uint8)
 
     @staticmethod
     def pil_resize_from_ndarray(arr, size, resample):


### PR DESCRIPTION
For pillow v8.3.0 update, change image_utils imread behavior for compatibility.
