### PR TITLE
Bugfix: fix nn.grad for floating variables

### DIFF
--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -70,8 +70,8 @@ class Grad(object):
         for o in f.outputs:
             # address `floating` variables; no function takes it as input.
             # e.g., when dx, db, dg = dBN(...), (db, dg) are not used afterwards.
-            #v = vf_vb_map[o] if o in vf_vb_map else [None]
-            v = vf_vb_map[o] if o in vf_vb_map else [0]
+            # [0] is not enough, e.g., F.concatenate
+            v = vf_vb_map[o] if o in vf_vb_map else [F.constant(0.0, o.shape)]
             if len(v) > 1:
                 grad_inputs += [sum(v)]
                 #grad_inputs += [F.add_n(v)]

--- a/python/src/nnabla/grad.py
+++ b/python/src/nnabla/grad.py
@@ -71,7 +71,7 @@ class Grad(object):
             # address `floating` variables; no function takes it as input.
             # e.g., when dx, db, dg = dBN(...), (db, dg) are not used afterwards.
             # [0] is not enough, e.g., F.concatenate
-            v = vf_vb_map[o] if o in vf_vb_map else [F.constant(0.0, o.shape)]
+            v = vf_vb_map.get(o, [F.constant(0.0, o.shape)])
             if len(v) > 1:
                 grad_inputs += [sum(v)]
                 #grad_inputs += [F.add_n(v)]

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -385,3 +385,13 @@ def test_nn_grad_propagate_down_check():
     # If IdentityForwardOnlyFunction_backward is called in nn.grad, an error will occur.
     v = nn.grad(w, [z])
     v[0].forward()
+
+
+def test_double_backward_floating_variables():
+    x = nn.Variable((2, 2), need_grad=True)
+    y = nn.Variable((2, 3), need_grad=True)
+    z = nn.Variable((2, 4), need_grad=True)
+    w = F.concatenate(*[x, y, z], axis=-1)
+    o = F.sin(w)
+    dx = nn.grad([o], [x])[0]
+    ddx = nn.grad([dx], [x])[0]  # Error must not happen


### PR DESCRIPTION
The following code did not work before since the grad of floating variable in nn.grad was [0].

```python
def test_double_backward_floating_variables():
    x = nn.Variable((2, 2), need_grad=True)
    y = nn.Variable((2, 3), need_grad=True)
    z = nn.Variable((2, 4), need_grad=True)
    w = F.concatenate(*[x, y, z], axis=-1)
    o = F.sin(w)
    dx = nn.grad([o], [x])[0]
    ddx = nn.grad([dx], [x])[0]  # Error must not happen
```
