### PR TITLE
Properly close file handlers at exception

### DIFF
--- a/python/src/nnabla/utils/get_file_handle.py
+++ b/python/src/nnabla/utils/get_file_handle.py
@@ -61,9 +61,11 @@ def get_file_handle_load(nnp, path, ext):
         else:
             raise ValueError("Currently, ext == {} is not support".format(ext))
 
-        yield f
-        if need_close:
-            f.close()
+        try:
+            yield f
+        finally:
+            if need_close:
+                f.close()
     else:
         if ext in ['.h5']:
             # if nnp is not None and extension is .h5
@@ -73,8 +75,10 @@ def get_file_handle_load(nnp, path, ext):
                 yield f
         else:
             f = nnp.open(path, 'r')
-            yield f
-            f.close()
+            try:
+                yield f
+            finally:
+                f.close()
 
 
 @contextlib.contextmanager
@@ -101,12 +105,13 @@ def get_file_handle_save(path, ext):
             f = open(path, 'wb')
     else:
         raise ValueError("Currently, ext == {} is not support".format(ext))
-
-    yield f
-    if need_close:
-        f.close()
-    if hasattr(path, 'seek'):
-        path.seek(0)
+    try:
+        yield f
+    finally:
+        if need_close:
+            f.close()
+        if hasattr(path, 'seek'):
+            path.seek(0)
 
 
 def get_buf_type(filename):

--- a/python/test/core/test_get_file_handle.py
+++ b/python/test/core/test_get_file_handle.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2020-2021 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from helper import create_temp_with_dir
+from nnabla.utils.get_file_handle import get_file_handle_save, get_file_handle_load
+
+
+@pytest.mark.parametrize("extension", [".nntxt", ".protobuf"])
+def test_file_close_exception(extension):
+    with pytest.raises(ZeroDivisionError) as excinfo:
+        with create_temp_with_dir("tmp{}".format(extension)) as filename:
+            with get_file_handle_save(filename, ext=extension) as f:
+                file_handler = f
+                1 / 0
+    assert file_handler.closed
+
+    with pytest.raises(ZeroDivisionError) as excinfo:
+        with create_temp_with_dir("tmp{}".format(extension)) as filename:
+            # create a file at first
+            with open(filename, "w") as f:
+                f.write("\n")
+
+            with get_file_handle_load(None, filename, ext=extension) as f:
+                file_handler = f
+                1 / 0
+    assert file_handler.closed


### PR DESCRIPTION
Seems like some file handlers are not properly closed when an exception is raised.
