### PR TITLE
Fix duplicate calls in forward_all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@
 *.h5
 tmp.*/
 *.zip
+
+# macOS
+.DS_store

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -180,6 +180,13 @@ void forward_all(const vector<CgVariablePtr> variables, bool clear_buffer,
 
   unordered_set<CgFunctionPtr> fclosed;
   for (vector<CgVariablePtr>::size_type i = 0; i < variables.size(); ++i) {
+    // Check if the parent function has been seen before.
+    // Important to avoid duplicate calls of a function
+    // which has more than two outputs.
+    auto parent = variables.at(i)->parent();
+    if (!parent || fclosed.find(parent) != fclosed.end()) {
+      continue;
+    }
     variables[i]->forward(clear_buffer, clear_no_need_grad, &fclosed,
                           function_pre_hook, function_post_hook);
   }


### PR DESCRIPTION
Check if the parent function has been seen before. It is Important to avoid duplicate calls in a function which has more than two outputs.

Check if the parent function has been seen before. It is Important to avoid duplicate calls in a function which has more than two outputs.

 Build
 Add test (using function hooks?)

Update
Sorry that I didn’t fully describe the problem. The problem occurs when we have a function which has two outputs at the leaf.

values, indices = F.sort(p, with_index=True)
...
# The following line executes Sort twice.
nn.forward_all([values, indices])
Probably it does not give any difference in output, but function is called twice (redundant). You can see it if you set a function hook which shows the function name.
It’s caused by the fact that the test of fclosed is performed in visit_function_recursive . It means that when Variable::foward() is called on a Variable instance, it always executes its parent function.
