### PR TITLE
 Boolean Indexing Functions

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -274,3 +274,7 @@
   Dropout_fiB: 336
 35:
   SpectralNorm_iifBB: 337
+36:
+  BoolFill_f: 341
+  BoolGather_Empty: 339
+  BoolScatter_Empty: 340

--- a/build-tools/code_generator/function_types.yaml
+++ b/build-tools/code_generator/function_types.yaml
@@ -590,10 +590,19 @@ Gather:
 GatherNd:
   float: [float]
   half: [Half]
+BoolGather:
+  float: [float]
+  half: [Half]
 ScatterNd:
   float: [float]
   half: [Half]
 ScatterAdd:
+  float: [float]
+  half: [Half]
+BoolScatter:
+  float: [float]
+  half: [Half]
+BoolFill:
   float: [float]
   half: [Half]
 MaxPoolingBackward:

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -4792,6 +4792,43 @@ Array Manipulation:
     c_runtime: not support
     function_ids:
       Empty: 264
+  BoolGather:
+    snake_name: bool_gather
+    doc: |
+      Gather from the input data according to the mask. 
+
+      Given an input of :math:`(B_1, \ldots, B_N, D_1, \ldots, D_M)` shape and mask of :math:`(B_1, \ldots, B_N)` shape, the function returns an output of :math:`(nnz, D_1, \ldots, D_M)` shape and :math:`nnz` is the number of non-zero elements in mask.
+
+      .. code-block:: python
+
+        import numpy as np
+        import nnabla as nn
+        import nnabla.functions as F
+
+        nn.set_auto_forward(True)
+
+        input = nn.Variable.from_numpy_array([[1, 2], [3, 4], [5, 6]])
+        mask = nn.Variable.from_numpy_array([1, 0, 1])
+        output = F.bool_gather(input, mask)
+        
+        print(output.d) # [[1, 2], [5, 6]]
+
+
+      Note that this function is normally used with the dynamic graph 
+      since this function outputs a variable-length output. If used with the static graph, 
+      a network has to be constructed all time in iteration.
+    inputs:
+      input:
+        doc: Data from which to gather.
+      mask:
+        doc: Mask with which to gather. Non-zero/zero elements are supposed to be
+          a binary mask as 1/0. No gradients are computed with respect to mask.
+    outputs:
+      output:
+        doc: Gathered output.
+    c_runtime: not support
+    function_ids:
+      Empty: 339
   ScatterNd:
     snake_name: scatter_nd
     doc: |2
@@ -4891,6 +4928,82 @@ Array Manipulation:
     c_runtime: not support
     function_ids:
       i: 315
+  BoolScatter:
+    snake_name: bool_scatter
+    doc: |
+      Scatter the `input` according to the `mask`.
+
+      Given an input of :math:`(nnz, D_1, \ldots, D_M)` shape and mask of :math:`(B_1, \ldots, B_N)` shape, the function returns an output :math:`(B_1, \ldots, B_N, D_1, \ldots, D_M)` and :math:`nnz` is the number of non-zero elements in the mask.
+
+      .. code-block:: python
+
+        import numpy as np
+        import nnabla as nn
+        import nnabla.functions as F
+
+        nn.set_auto_forward(True)
+
+        input0 = nn.Variable.from_numpy_array([[1, 2], [3, 4], [5, 6]])
+        mask = nn.Variable.from_numpy_array([1, 0, 1])
+        output0 = F.bool_gather(input0, mask)
+        
+        input1 = output0 + 10
+        output1 = F.bool_scatter(input1, mask)
+        
+        print(output1.d)  # [[11, 12], [0, 0], [15, 16]] 
+
+      Note that the higher-order gradients of this function relies on F.gather, thus 
+      the higher-order gradients of this function is normally used with the dynamic graph.
+    inputs:
+      input:
+        doc: Data to be scattered.
+      mask:
+        doc: Mask with which to scatter. Non-zero/zero elements are supposed to be
+          a binary mask as 1/0. No gradients are computed with respect to mask.
+      output:
+        doc: Distination of output. If specified, data are inplaced.
+        optional: true
+    outputs:
+      y:
+        doc: Scattered output.
+    c_runtime: not support
+    function_ids:
+      Empty: 340
+  BoolFill:
+    snake_name: bool_fill
+    doc: |
+      Fill the data with the value to according to the mask.
+
+      .. code-block:: python
+
+        import numpy as np
+        import nnabla as nn
+        import nnabla.functions as F
+
+        nn.set_auto_forward(True)
+
+        input = nn.Variable.from_numpy_array([[np.inf, 2], [3, np.nan]])
+        mask = nn.Variable.from_numpy_array([[1, 0], [0, 1]])
+        output = F.bool_fill(input, mask, -1)
+        
+        print(output.d)  # [[-1, 2], [3, -1]]
+    inputs:
+      data:
+        doc: Data to be filled.
+      mask:
+        doc: Mask with which to fill. Non-zero/zero elements are supposed to be a
+          binary mask as 1/0. No gradients are computed with respect to mask.
+    arguments:
+      value:
+        doc: Value to fill.
+        type: float
+        default: '0'
+    outputs:
+      y:
+        doc: Filled output.
+    c_runtime: not support
+    function_ids:
+      f: 341
   PackPaddedSequence:
     snake_name: pack_padded_sequence
     doc: |

--- a/doc/python/api/function.rst
+++ b/doc/python/api/function.rst
@@ -237,6 +237,9 @@ Array Manipulation
 .. autofunction:: pack_padded_sequence
 .. autofunction:: pad_packed_sequence
 .. autofunction:: searchsorted
+.. autofunction:: bool_gather
+.. autofunction:: bool_scatter
+.. autofunction:: bool_fill
 
 
 Stochasticity

--- a/include/nbla/function/bool_fill.hpp
+++ b/include/nbla/function/bool_fill.hpp
@@ -1,0 +1,82 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_BOOL_FILL_HPP
+#define NBLA_FUNCTION_BOOL_FILL_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function/broadcast.hpp>
+#include <nbla/function_registry.hpp>
+
+#include <algorithm>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(BoolFill, float);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T> class BoolFill : public BaseFunction<float> {
+protected:
+  float value_;
+  FunctionPtr broadcast_func_ = nullptr;
+
+public:
+  BoolFill(const Context &ctx, float value)
+      : BaseFunction(ctx, value), value_(value) {}
+  virtual ~BoolFill() {}
+  virtual shared_ptr<Function> copy() const {
+    return create_BoolFill(ctx_, value_);
+  }
+  virtual int min_inputs() { return 2; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "BoolFill"; }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    if (i == 0 && j == 1)
+      return true;
+    if (i == 1 && j == 0)
+      return true;
+    return false;
+  }
+
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
+};
+}
+#endif

--- a/include/nbla/function/bool_gather.hpp
+++ b/include/nbla/function/bool_gather.hpp
@@ -1,5 +1,4 @@
-// Copyright 2017,2018,2019,2020,2021 Sony Corporation.
-// Copyright 2021 Sony Group Corporation.
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -13,15 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-/** Broadcast
- */
-#ifndef __NBLA_FUNCTION_BROADCAST_HPP__
-#define __NBLA_FUNCTION_BROADCAST_HPP__
-
-#ifndef NBLA_BROADCAST_MAX_DIM
-/// Maximum number of dimensions Broadcast function supports.
-#define NBLA_BROADCAST_MAX_DIM 8
-#endif
+#ifndef NBLA_FUNCTION_BOOL_GATHER_HPP
+#define NBLA_FUNCTION_BOOL_GATHER_HPP
 
 #include <nbla/cpu.hpp>
 #include <nbla/function.hpp>
@@ -29,46 +21,36 @@
 
 namespace nbla {
 
-inline Shape_t expand_shape(Shape_t source_shape, int target_ndim) {
-  Shape_t expanded_shape(target_ndim, 1);
-  for (unsigned int i = 0; i < source_shape.size(); ++i) {
-    // insert from the end
-    expanded_shape[expanded_shape.size() - 1 - i] =
-        source_shape[source_shape.size() - 1 - i];
-  }
-  return expanded_shape;
-}
+NBLA_REGISTER_FUNCTION_HEADER(BoolGather);
 
-NBLA_REGISTER_FUNCTION_HEADER(Broadcast, const vector<int> &);
+/**
+    @todo Write doc.
 
-/** Broadcast N-D array to shape.
+Inputs:
 
-@param shape The shape input array broadcasted to. Dimensions broadcasted in
-    input array must be size one.
+Outputs:
+
+\ingroup FunctionImplGrp
  */
-template <typename T>
-class Broadcast : public BaseFunction<const vector<int> &> {
+template <typename T> class BoolGather : public BaseFunction<> {
 protected:
-  const vector<int> shape_;
-
-  Variable stride_x_;
-  Variable shape_y_;
+  shared_ptr<Function> f_sum_;
 
 public:
-  Broadcast(const Context &ctx, const vector<int> &shape)
-      : BaseFunction<const vector<int> &>(ctx, shape), shape_(shape) {}
-  virtual ~Broadcast() {}
-  virtual shared_ptr<Function> copy() const {
-    return create_Broadcast(ctx_, shape_);
-  }
-  virtual vector<dtypes> in_types() { return vector<dtypes>{get_dtype<T>()}; }
-  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
-  virtual int min_inputs() { return 1; }
+  BoolGather(const Context &ctx) : BaseFunction(ctx) {}
+  virtual ~BoolGather() {}
+  virtual shared_ptr<Function> copy() const { return create_BoolGather(ctx_); }
+  virtual int min_inputs() { return 2; }
   virtual int min_outputs() { return 1; }
-  virtual string name() { return "Broadcast"; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
   }
+  virtual string name() { return "BoolGather"; }
+
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
@@ -81,7 +63,9 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
-    return false;
+    if (i == 0 && j == 1)
+      return true;
+    return true;
   }
 };
 }

--- a/include/nbla/function/bool_scatter.hpp
+++ b/include/nbla/function/bool_scatter.hpp
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef NBLA_FUNCTION_BOOL_SCATTER_HPP
+#define NBLA_FUNCTION_BOOL_SCATTER_HPP
+
+#include <nbla/cpu.hpp>
+#include <nbla/function.hpp>
+#include <nbla/function_registry.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_HEADER(BoolScatter);
+
+/**
+    @todo Write doc.
+
+Inputs:
+
+Outputs:
+
+\ingroup FunctionImplGrp
+ */
+template <typename T> class BoolScatter : public BaseFunction<> {
+
+public:
+  BoolScatter(const Context &ctx) : BaseFunction(ctx) {}
+
+  virtual ~BoolScatter() {}
+  virtual shared_ptr<Function> copy() const { return create_BoolScatter(ctx_); }
+  virtual int min_inputs() { return 2; }
+  virtual int min_outputs() { return 1; }
+  virtual vector<dtypes> in_types() {
+    return vector<dtypes>{get_dtype<T>(), get_dtype<T>(), get_dtype<T>()};
+  }
+  virtual vector<dtypes> out_types() { return vector<dtypes>{get_dtype<T>()}; }
+  virtual vector<string> allowed_array_classes() {
+    return SingletonManager::get<Cpu>()->array_classes();
+  }
+  virtual string name() { return "BoolScatter"; }
+
+  virtual int inplace_data(int i) const {
+    return i == 2 ? Function::INPLACE : Function::NOT_INPLACE;
+  }
+  virtual int inplace_data_with(int i) const { return 0; }
+
+protected:
+  NBLA_API virtual void setup_impl(const Variables &inputs,
+                                   const Variables &outputs);
+  NBLA_API virtual void forward_impl(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void backward_impl(const Variables &inputs,
+                                      const Variables &outputs,
+                                      const vector<bool> &propagate_down,
+                                      const vector<bool> &accum);
+  virtual bool grad_depends_input_data_impl(int i, int j) const {
+    if (i == 0 && j == 1)
+      return true;
+    if (i == 2 && j == 1)
+      return true;
+    return false;
+  }
+
+  virtual bool grad_depends_output_data(int i, int o) const { return false; }
+};
+}
+#endif

--- a/include/nbla/function/broadcast.hpp
+++ b/include/nbla/function/broadcast.hpp
@@ -29,6 +29,17 @@
 
 namespace nbla {
 
+inline Shape_t expand_shape(Shape_t source_shape, int target_ndim) {
+  Shape_t expanded_shape(target_ndim);
+  std::fill(expanded_shape.begin(), expanded_shape.end(), 1);
+  for (int i = 0; i < source_shape.size(); ++i) {
+    // insert from the end
+    expanded_shape[expanded_shape.size() - 1 - i] =
+        source_shape[source_shape.size() - 1 - i];
+  }
+  return expanded_shape;
+}
+
 NBLA_REGISTER_FUNCTION_HEADER(Broadcast, const vector<int> &);
 
 /** Broadcast N-D array to shape.

--- a/include/nbla/function/utils/bool_indexing.hpp
+++ b/include/nbla/function/utils/bool_indexing.hpp
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_FUNCTION_UTILS_BOOL_INDEXING_HPP__
+#define __NBLA_FUNCTION_UTILS_BOOL_INDEXING_HPP__
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+namespace nbla {
+
+template <typename T, bool accum = false>
+inline void kernel_bool_gather(int D, int B, int nnz, T *sdata, const T *gdata,
+                               const T *mask) {
+  for (int d = 0; d < D; ++d) {
+    auto idx_nnz = 0;
+    for (int b = 0; b < B && idx_nnz < nnz; ++b) {
+      auto mask_b = int(mask[b] != T(0));
+      auto masked_gdata = mask_b * gdata[b * D + d];
+      // After written, increment idx_nnz, thus no overwrite to the previously
+      // written value.
+      sdata[idx_nnz * D + d] =
+          accum ? sdata[idx_nnz * D + d] + masked_gdata : masked_gdata;
+      idx_nnz += mask_b;
+    }
+  }
+}
+
+template <typename T, bool accum = false, bool inplace = false>
+inline void kernel_bool_scatter(int D, int B, int nnz, T *gdata, const T *sdata,
+                                const T *mask) {
+  for (int d = 0; d < D; ++d) {
+    auto idx_nnz = 0;
+    for (int b = 0; b < B; ++b) {
+      auto mask_b = int(mask[b] != T(0));
+      auto sdata_i = sdata[idx_nnz * D + d];
+
+      auto masked_sdata_i = mask_b * sdata_i;
+      if (inplace) {
+        // (1 - mask_b)-multiply trick does not work if gdata is in {-inf, inf,
+        // nan}
+        masked_sdata_i = mask_b ? masked_sdata_i : gdata[b * D + d];
+      }
+
+      if (accum)
+        gdata[b * D + d] += masked_sdata_i;
+      else
+        gdata[b * D + d] = masked_sdata_i;
+      idx_nnz += mask_b;
+      idx_nnz = std::min(idx_nnz, nnz - 1); // prevent illegal memory access
+    }
+  }
+}
+}
+#endif

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -406,6 +406,19 @@ cdef class NdArray:
         """
         self.arrp.fill(value)
 
+    def bool_fill(self, mask, value):
+        """Return a new but inplaced :obj:`nnabla.NdArray` filled with value where mask is non-zero.
+
+        Args:
+            mask (:obj:`nnabla.NdArray`): Mask with which to fill. Non-zero/zero elements are supposed to be a binary mask as 1/0. No gradients are computed with respect to mask.
+            value (float): The value to fill.
+        
+        """
+        import nnabla.functions as F
+        return F.bool_fill(self, mask, value, outputs=[self])
+
+    masked_fill = bool_fill
+
     def clear(self):
         """
         Clear memories which this NdArray has and return them to allocator.

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -482,6 +482,23 @@ cdef class Variable:
     def g(self, value):
         self.grad.data = value
 
+    def bool_fill_(self, mask, value):
+        """
+        Return a new but inplaced :obj:`nnabla.Variable` filled with value where mask is non-zero.
+
+        Args:
+            mask (:obj:`nnabla.NdArray`): Mask with which to fill. Non-zero/zero elements are supposed to be a binary mask as 1/0. No gradients are computed with respect to mask.
+            value (float): The value to fill.
+
+        Returns:
+            :obj:`nnabla.Variable`
+
+        """
+        import nnabla.functions as F
+        return F.bool_fill(self, mask, value, outputs=[self.data])
+
+    masked_fill_ = bool_fill_
+
     @property
     def parent(self):
         """

--- a/python/src/nnabla/backward_function/bool_fill.py
+++ b/python/src/nnabla/backward_function/bool_fill.py
@@ -1,0 +1,37 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nnabla.functions as F
+from .utils import no_grad
+
+
+def bool_fill_backward(inputs, value=0):
+    """
+    Args:
+      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      kwargs (dict of arguments): Dictionary of the corresponding function arguments.
+
+    Return:
+      list of Variable: Return the gradients wrt inputs of the corresponding function.
+    """
+    dy = inputs[0]
+    x0 = inputs[1]
+    m0 = inputs[2]
+    m1 = F.equal_scalar(m0, 0.0)
+    m1 = F.broadcast(m1, dy.shape)
+    m1 = no_grad(m1)
+    dx = dy * m1
+    dm = None
+    return dx, dm

--- a/python/src/nnabla/backward_function/bool_gather.py
+++ b/python/src/nnabla/backward_function/bool_gather.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nnabla.functions as F
+
+
+def bool_gather_backward(inputs):
+    """
+    Args:
+      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      kwargs (dict of arguments): Dictionary of the corresponding function arguments.
+
+    Return:
+      list of Variable: Return the gradients wrt inputs of the corresponding function.
+    """
+    dy = inputs[0]
+    m0 = inputs[2]
+    dx = F.bool_scatter(dy, m0)
+    dm = None
+    return dx, dm

--- a/python/src/nnabla/backward_function/bool_scatter.py
+++ b/python/src/nnabla/backward_function/bool_scatter.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import nnabla.functions as F
+from .utils import no_grad
+
+
+def bool_scatter_backward(inputs):
+    """
+    Args:
+      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      kwargs (dict of arguments): Dictionary of the corresponding function arguments.
+
+    Return:
+      list of Variable: Return the gradients wrt inputs of the corresponding function.
+    """
+    dy = inputs[0]
+    x0 = inputs[1]
+    m0 = inputs[2]
+    o0 = inputs[3] if len(inputs) == 4 else None
+
+    dx = F.bool_gather(dy, m0)
+    dm = None
+
+    if o0 is None:
+        return dx, dm
+    else:
+        m1 = F.equal_scalar(m0, 0)
+        m1 = F.reshape(m1, m1.shape + (1, ) * (dy.ndim - m1.ndim))
+        m1 = F.broadcast(m1, dy.shape)
+        m1 = no_grad(m1)
+        do = dy * m1
+        return dx, dm, do

--- a/python/test/function/test_bool_fill.py
+++ b/python/test/function/test_bool_fill.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('BoolFill')
+
+
+def ref_bool_fill(data, mask, value):
+    data0 = np.copy(data)
+    bmask = np.broadcast_to(mask, data.shape)
+    data0[bmask.astype(np.bool)] = value
+    return data0
+
+
+@pytest.mark.parametrize("inf_or_nan", [0, np.inf, np.nan])
+@pytest.mark.parametrize("value", [1, -1.5])
+@pytest.mark.parametrize("dshape, mshape",
+                         [((2, 3), (2, 3)),
+                          ((5, ), (5, )),
+                          ((2, 3), (3, )),
+                          ((2, 3, 2, 2), (1, 2, 1))
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_bool_fill_forward_backward(seed, ctx, func_name, dshape, mshape, value, inf_or_nan):
+    from nbla_test_utils import function_tester
+
+    rng = np.random.RandomState(seed)
+    data = rng.randn(*dshape).astype(np.float32)
+    mask = rng.randint(0, 2, mshape)
+    backward = [True, False]
+    if inf_or_nan != 0:
+        bmask = np.broadcast_to(mask, data.shape)
+        data[bmask.astype(np.bool)] = inf_or_nan
+        # we can not compute the numerical gradients
+        backward = [False, False]
+    inputs = [data, mask]
+
+    function_tester(rng, F.bool_fill, ref_bool_fill, inputs,
+                    ctx=ctx, func_name=func_name, func_args=[value],
+                    backward=backward)
+
+
+@pytest.mark.parametrize("inf_or_nan", [0, np.inf, np.nan])
+@pytest.mark.parametrize("value", [1, -1.5])
+@pytest.mark.parametrize("dshape, mshape",
+                         [((2, 3), (2, 3)),
+                          ((5, ), (5, )),
+                          ((2, 3), (3, )),
+                          ((2, 3, 2, 2), (1, 2, 1))
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_bool_fill_double_backward(seed, ctx, func_name, dshape, mshape, value, inf_or_nan):
+    from nbla_test_utils import backward_function_tester
+
+    rng = np.random.RandomState(seed)
+    data = rng.randn(*dshape).astype(np.float32)
+    mask = rng.randint(0, 2, mshape)
+    backward = [True, False]
+    backward_b = [True, True, False]
+    if inf_or_nan != 0:
+        bmask = np.broadcast_to(mask, data.shape)
+        data[bmask.astype(np.bool)] = inf_or_nan
+        backward = [True, False]
+        # we can not compute the numerical gradients
+        backward_b = [False, False, False]
+    inputs = [data, mask]
+
+    backward_function_tester(rng, F.bool_fill, inputs, ctx=ctx,
+                             backward=backward,
+                             backward_b=backward_b)

--- a/python/test/function/test_bool_gather.py
+++ b/python/test/function/test_bool_gather.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('BoolGather')
+
+
+def ref_bool_gather(gdata, mask):
+    mask_bool = mask.astype(np.bool)
+    return gdata[mask_bool]
+
+
+@pytest.mark.parametrize("gshape, mask_shape",
+                         [((2, 3, 2), (2, 3)),
+                          ((3, 4), (3, 4)),
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_bool_gather_forward_backward(seed, ctx, func_name, gshape, mask_shape):
+    from nbla_test_utils import function_tester
+
+    rng = np.random.RandomState(seed)
+    gdata = rng.randn(*gshape).astype(np.float32)
+    mask = rng.randint(0, 2, size=mask_shape)
+    inputs = [gdata, mask]
+
+    function_tester(rng, F.bool_gather, ref_bool_gather, inputs,
+                    ctx=ctx, func_name=func_name,
+                    auto_forward=True,
+                    backward=[True, False])
+
+
+@pytest.mark.parametrize("gshape, mask_shape",
+                         [((2, 3, 2), (2, 3)),
+                          ((3, 4), (3, 4)),
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_bool_gather_double_backward(seed, ctx, func_name, gshape, mask_shape):
+    from nbla_test_utils import backward_function_tester
+
+    rng = np.random.RandomState(seed)
+    gdata = rng.randn(*gshape).astype(np.float32)
+    mask = rng.randint(0, 2, size=mask_shape)
+    inputs = [gdata, mask]
+
+    backward_function_tester(rng, F.bool_gather, inputs, ctx=ctx,
+                             backward=[True, False],
+                             backward_b=[True, True, False],
+                             auto_forward=True)

--- a/python/test/function/test_bool_scatter.py
+++ b/python/test/function/test_bool_scatter.py
@@ -1,0 +1,134 @@
+# Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.functions as F
+from nbla_test_utils import list_context
+
+ctxs = list_context('BoolScatter')
+
+
+def ref_bool_scatter(sdata, mask):
+    gdata_shape = mask.shape + sdata.shape[1:]
+    mask_bool = mask.astype(np.bool)
+    gdata = np.zeros(gdata_shape)
+    gdata[mask_bool] = sdata
+    return gdata
+
+
+def ref_bool_scatter_inplace(sdata, mask, gdata):
+    mask_bool = mask.astype(np.bool)
+    gdata0 = np.copy(gdata)
+    gdata0[mask_bool] = sdata
+    return gdata0
+
+
+@pytest.mark.parametrize("gshape, mask_shape",
+                         [((2, 3, 2), (2, 3)),
+                          ((3, 4), (3, 4)),
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_bool_scatter_forward_backward(seed, ctx, func_name, gshape, mask_shape):
+    from nbla_test_utils import cap_ignore_region, function_tester
+
+    rng = np.random.RandomState(seed)
+    gdata0 = rng.randn(*gshape).astype(np.float32)
+    mask = rng.randint(0, 2, size=mask_shape)
+    sdata = gdata0[mask.astype(np.bool)]
+
+    inputs = [sdata, mask]
+    backward = [True, False]
+
+    function_tester(rng, F.bool_scatter, ref_bool_scatter, inputs,
+                    ctx=ctx, func_name=func_name, func_args=[],
+                    backward=backward)
+
+
+@pytest.mark.parametrize("gshape, mask_shape",
+                         [((2, 3, 2), (2, 3)),
+                          ((3, 4), (3, 4)),
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_bool_scatter_double_backward(seed, ctx, func_name, gshape, mask_shape):
+    from nbla_test_utils import backward_function_tester
+
+    rng = np.random.RandomState(seed)
+    gdata0 = rng.randn(*gshape).astype(np.float32)
+    mask = rng.randint(0, 2, size=mask_shape).astype(np.float32)
+    sdata = gdata0[mask.astype(np.bool)]
+    inputs = [sdata, mask]
+    backward = [True, False]
+
+    backward_function_tester(rng, F.bool_scatter, inputs, ctx=ctx,
+                             backward=[True, False],
+                             backward_b=[True, True, False],
+                             auto_forward=True)
+
+
+@pytest.mark.parametrize("gshape, mask_shape",
+                         [((2, 3, 2), (2, 3)),
+                          ((3, 4), (3, 4)),
+                          ])
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+def test_bool_scatter_inplace(seed, ctx, func_name, gshape, mask_shape):
+    from nbla_test_utils import inplace_function_test_helper
+
+    rng = np.random.RandomState(seed)
+    gdata0 = rng.randn(*gshape).astype(np.float32)
+    mask = rng.randint(0, 2, size=mask_shape)
+    sdata = gdata0[mask.astype(np.bool)]
+    gdata1 = rng.randn(*gshape).astype(np.float32)
+
+    v_sdata = nn.Variable.from_numpy_array(sdata).apply(need_grad=True)
+    v_mask = nn.Variable.from_numpy_array(mask)
+    v_gdata1 = nn.Variable.from_numpy_array(gdata1).apply(need_grad=True)
+
+    with nn.auto_forward():
+        v_gdata2 = F.bool_scatter(v_sdata, v_mask, v_gdata1)
+
+    # inplace check
+    np.testing.assert_allclose(v_gdata2.d, v_gdata1.d,
+                               err_msg="F.bool_scatter(inplace) is not inplaced.")
+
+    # ref check
+    gdata2 = ref_bool_scatter_inplace(sdata, mask, gdata1)
+    np.testing.assert_allclose(v_gdata2.d, gdata2,
+                               err_msg="F.bool_scatter(inplace) fails.")
+
+    # backward wrt inplaced variable (wrt sdata is checked in not-inplaced case)
+    egrad = rng.randn(*gdata2.shape)
+    mask = mask if mask.shape == gdata1.shape else \
+        mask.reshape(mask.shape + (1, ) * (gdata1.ndim - mask.ndim))
+    ref_grad = egrad * (1 - mask)
+    v_gdata1.grad.fill(0)
+    v_gdata2.backward(egrad)
+    np.testing.assert_allclose(v_gdata1.g, ref_grad,
+                               err_msg="F.bool_scatter(inplace) backward wrt inplace data fails.")
+
+    bgrad = rng.randn(*gdata1.shape)
+    v_gdata1.g = bgrad
+    v_gdata2.backward(egrad)
+    np.testing.assert_allclose(v_gdata1.g - bgrad, ref_grad, atol=1e-6,
+                               err_msg="F.bool_scatter(inplace) backward (accum) wrt inplace data fails.")
+
+    # nn.grad (wrt sdata is checked in not-inplaced case)
+    with nn.auto_forward():
+        d_gdata1 = nn.grad([v_gdata2], [v_gdata1], grad_outputs=[egrad])
+    np.testing.assert_allclose(d_gdata1[0].d, ref_grad, atol=1e-6,
+                               err_msg="nn.grad (F.bool_scatter(inplace)) wrt inplace data fails.")

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -538,7 +538,7 @@ def create_function_nnp(inputs, outputs, func_name, func_args, func_kwargs):
 
 
 def clear_no_need_grad_tester(rng, func, inputs, func_args=[], func_kwargs={}, backward=None, atol_f=1e-6, ctx=None,
-                              func_name=None, insert_identity=[]):
+                              func_name=None, insert_identity=[], auto_forward=False):
     if ctx is None:
         ctx = nn.Context()
     if backward is None:
@@ -568,7 +568,7 @@ def clear_no_need_grad_tester(rng, func, inputs, func_args=[], func_kwargs={}, b
     if not insert_identity:
         insert_identity = [True] * len(vinputs)
 
-    with nn.context_scope(ctx), nn.auto_forward(False):
+    with nn.context_scope(ctx), nn.auto_forward(auto_forward):
         for idx, i in enumerate(vinputs_clear_buffer):
             if i is None:
                 vinputs_identity_clear_buffer += [None]
@@ -578,7 +578,7 @@ def clear_no_need_grad_tester(rng, func, inputs, func_args=[], func_kwargs={}, b
                 vinputs_identity_clear_buffer += [i]
 
     # Checking forward(clear_no_need_grad=True)
-    with nn.context_scope(ctx), nn.auto_forward(False):
+    with nn.context_scope(ctx), nn.auto_forward(auto_forward):
         o = func(*(vinputs + func_args), **func_kwargs)
         o = force_tuple(o)
         F.sink(*o).forward(clear_no_need_grad=False)
@@ -632,7 +632,7 @@ def function_tester(rng, func, ref_func, inputs,
                     func_args=[], func_kwargs={},
                     atol_f=1e-6, atol_b=1e-3, atol_accum=1e-6, dstep=1e-3, backward=None,
                     ctx=None, func_name=None, ref_grad=None, disable_half_test=False, atol_half=1e-1,
-                    insert_identity=[], disable_clear_no_need_grad_test=False):
+                    insert_identity=[], disable_clear_no_need_grad_test=False, auto_forward=False):
     """ Automatic testing of forward/backward pass of `func` by comparing it
     to the reference implementation in `ref_func`.
 
@@ -689,7 +689,8 @@ def function_tester(rng, func, ref_func, inputs,
     # Checking forward(clear_no_need_grad=True)
     if not disable_clear_no_need_grad_test:
         clear_no_need_grad_tester(rng, func, inputs, func_args, func_kwargs,
-                                  backward, atol_f, ctx, func_name, insert_identity)
+                                  backward, atol_f, ctx, func_name, insert_identity,
+                                  auto_forward)
 
     # Checking function name
     try:
@@ -862,7 +863,8 @@ def backward_function_tester(rng, func, inputs=None,
                              func_args=[], func_kwargs={},
                              atol_f=1e-4, atol_b=1e-3, atol_accum=5e-2,
                              dstep=1e-3, backward=None, backward_b=None,
-                             ctx=None, non_accum_check=False, skip_backward_check=False, insert_identity=[]):
+                             ctx=None, non_accum_check=False, skip_backward_check=False, insert_identity=[],
+                             auto_forward=False):
     """ Automatic testing of backward function and backward pass of `func` by comparing it.
     The backward pass of `func` is the reference; therefore, 
     the backward pass of `func` must be tested first!
@@ -898,22 +900,23 @@ def backward_function_tester(rng, func, inputs=None,
         insert_identity = [True] * len(vinputs)
 
     for idx, i in enumerate(zip(vinputs, vinputs_for_clear_buffer, vinputs_for_nn_grad)):
-        i0, i1, i2 = i
-        if i0 is None:
-            vinputs_identity += [None]
-            vinputs_identity_for_clear_buffer += [None]
-            vinputs_identity_for_nn_grad += [None]
-        elif insert_identity[idx]:
-            vinputs_identity += [F.identity(i0)]
-            vinputs_identity_for_clear_buffer += [F.identity(i1)]
-            vinputs_identity_for_nn_grad += [F.identity(i2)]
-        else:
-            vinputs_identity += [i0]
-            vinputs_identity_for_clear_buffer += [i1]
-            vinputs_identity_for_nn_grad += [i2]
+        with nn.auto_forward(auto_forward):
+            i0, i1, i2 = i
+            if i0 is None:
+                vinputs_identity += [None]
+                vinputs_identity_for_clear_buffer += [None]
+                vinputs_identity_for_nn_grad += [None]
+            elif insert_identity[idx]:
+                vinputs_identity += [F.identity(i0)]
+                vinputs_identity_for_clear_buffer += [F.identity(i1)]
+                vinputs_identity_for_nn_grad += [F.identity(i2)]
+            else:
+                vinputs_identity += [i0]
+                vinputs_identity_for_clear_buffer += [i1]
+                vinputs_identity_for_nn_grad += [i2]
 
     # Forward and backward of the forward function with no buffer clear
-    with nn.context_scope(ctx), nn.auto_forward(False):
+    with nn.context_scope(ctx), nn.auto_forward(auto_forward):
         outputs0 = func(*(vinputs_identity + func_args), **func_kwargs)
         outputs0 = force_list(outputs0)
         F.sink(*outputs0).forward(clear_no_need_grad=False)
@@ -931,7 +934,7 @@ def backward_function_tester(rng, func, inputs=None,
     grad_inputs0 = [inp.g.copy() for inp in vinputs]
 
     # Forward and backward of the forward function with clear redundant buffer
-    with nn.context_scope(ctx), nn.auto_forward(False):
+    with nn.context_scope(ctx), nn.auto_forward(auto_forward):
         outputs_for_clear_buffer = func(
             *(vinputs_identity_for_clear_buffer + func_args), **func_kwargs)
         outputs_for_clear_buffer = force_list(outputs_for_clear_buffer)
@@ -961,7 +964,7 @@ def backward_function_tester(rng, func, inputs=None,
     grad_vinputs = grad_voutputs + vinputs
     grad_vinputs_identity = grad_voutputs + vinputs_identity
     func_info_args = output.parent.info.args
-    with nn.context_scope(ctx), nn.auto_forward(False):
+    with nn.context_scope(ctx), nn.auto_forward(auto_forward):
         ograds0 = func_backward(grad_vinputs_identity, **func_info_args)
         ograds0 = force_list(ograds0)
         ograds0_ = list(filter(lambda o: o is not None, ograds0))
@@ -989,7 +992,7 @@ def backward_function_tester(rng, func, inputs=None,
     vinputs = [v for b, v in zip(backward, vinputs) if b]
     vinputs = list(filter(lambda x: x is not None, vinputs))
 
-    with nn.context_scope(ctx), nn.auto_forward(False):
+    with nn.context_scope(ctx), nn.auto_forward(auto_forward):
         outputs0_for_nn_grad = func(
             *(vinputs_identity_for_nn_grad + func_args), **func_kwargs)
         outputs0_for_nn_grad = force_list(outputs0_for_nn_grad)

--- a/src/nbla/function/generic/bool_fill.cpp
+++ b/src/nbla/function/generic/bool_fill.cpp
@@ -1,0 +1,113 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/bool_fill.hpp>
+#include <nbla/imperative.hpp>
+#include <nbla/variable.hpp>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(BoolFill, float);
+
+template <typename T>
+void BoolFill<T>::setup_impl(const Variables &inputs,
+                             const Variables &outputs) {
+  auto data = inputs[0];
+  auto mask = inputs[1];
+  auto output = outputs[0];
+  NBLA_CHECK(data->ndim() >= mask->ndim(), error_code::value,
+             "Input dim (%s) >= mask ndim (%s) must hold.", data->ndim(),
+             mask->ndim());
+
+  // Broadcast case
+  if (data->shape() != mask->shape()) {
+    vector<int> tshape;
+    for (auto dim : data->shape()) {
+      tshape.push_back(dim);
+    }
+    broadcast_func_ = create_Broadcast(this->ctx_, tshape);
+  }
+
+  output->reshape(data->shape(), true);
+}
+
+template <typename T>
+void kernel_bool_fill_data_forward(const int N, T *output, const T *data,
+                                   const T *mask, const float value) {
+  for (int i = 0; i < N; ++i) {
+    output[i] = (mask[i] != 0) ? T(value) : data[i];
+  }
+}
+
+template <typename T>
+void BoolFill<T>::forward_impl(const Variables &inputs,
+                               const Variables &outputs) {
+  auto data = inputs[0]->get_data_pointer<T>(this->ctx_);
+  auto mask = inputs[1]->get_data_pointer<T>(this->ctx_);
+  auto output = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_);
+  auto N = inputs[0]->size();
+
+  if (broadcast_func_ != nullptr) {
+    Variable bmask;
+    nbla::execute(broadcast_func_, {inputs[1]}, {&bmask});
+    mask = bmask.get_data_pointer<T>(this->ctx_);
+    kernel_bool_fill_data_forward(N, output, data, mask, value_);
+  } else {
+    kernel_bool_fill_data_forward(N, output, data, mask, value_);
+  }
+}
+
+template <typename T, bool accum = false>
+void kernel_bool_fill_data_backward(const int N, T *g_data, const T *g_output,
+                                    const T *mask) {
+  for (int i = 0; i < N; ++i) {
+    auto mask_i = T(mask[i] != T(0));
+    g_data[i] = accum ? g_data[i] + g_output[i] * (T(1) - mask_i)
+                      : g_output[i] * (T(1) - mask_i);
+  }
+}
+
+template <typename T>
+void BoolFill<T>::backward_impl(const Variables &inputs,
+                                const Variables &outputs,
+                                const vector<bool> &propagate_down,
+                                const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+
+  auto mask = inputs[1]->get_data_pointer<T>(this->ctx_);
+
+  auto g_data = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
+  auto g_output = outputs[0]->get_grad_pointer<T>(this->ctx_);
+  auto N = inputs[0]->size();
+
+  if (propagate_down[0]) {
+    if (broadcast_func_ != nullptr) {
+      Variable bmask;
+      nbla::execute(broadcast_func_, {inputs[1]}, {&bmask});
+      mask = bmask.get_data_pointer<T>(this->ctx_);
+      auto kernel = accum[0] ? kernel_bool_fill_data_backward<T, true>
+                             : kernel_bool_fill_data_backward<T, false>;
+      kernel(N, g_data, g_output, mask);
+    } else {
+      auto kernel = accum[0] ? kernel_bool_fill_data_backward<T, true>
+                             : kernel_bool_fill_data_backward<T, false>;
+      kernel(N, g_data, g_output, mask);
+    }
+  }
+}
+}

--- a/src/nbla/function/generic/bool_gather.cpp
+++ b/src/nbla/function/generic/bool_gather.cpp
@@ -1,0 +1,117 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/bool_gather.hpp>
+#include <nbla/function/sum.hpp>
+#include <nbla/function/utils/bool_indexing.hpp>
+#include <nbla/imperative.hpp>
+#include <nbla/variable.hpp>
+
+#include <numeric>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(BoolGather);
+
+template <typename T>
+void BoolGather<T>::setup_impl(const Variables &inputs,
+                               const Variables &outputs) {
+  // gdata: B_1, ..., B_N, D_1, ..., D_M
+  // mask: B_1, ..., B_N
+  // sdata: NNZ, D_1, ..., D_M
+
+  // Setup_impl must be called all time
+  auto gdata = inputs[0];
+  auto mask = inputs[1];
+  auto sdata = outputs[0];
+  auto gshape = gdata->shape();
+  auto mshape = mask->shape();
+
+  // Error check
+  NBLA_CHECK(gdata->ndim() >= mask->ndim(), error_code::value,
+             "input.ndim (%d) >= mask.ndim (%d)", gdata->ndim(), mask->ndim());
+  for (int i = 0; i < mask->ndim(); ++i) {
+    NBLA_CHECK(mshape[i] == gshape[i], error_code::value,
+               "mask.shape must be equal to input.shape[:mask.ndim]. "
+               "mask.shape[%d] (%d) != input.shape[%d] (%d)",
+               i, mshape[i], i, gshape[i]);
+  }
+
+  // TODO: add F.not_equal_scalar == 0
+  // Number of non-zero elements
+  vector<int> axes(mask->ndim());
+  std::iota(axes.begin(), axes.end(), 0);
+  f_sum_ = create_Sum(this->ctx_, axes, false);
+  Variable nnz({1});
+  nbla::execute(f_sum_, {mask}, {&nnz});
+  nbla::Context cpu_ctx{{"cpu:float"}, "CpuCachedArray", "0"};
+  auto data_nnz = nnz.get_data_pointer<float>(cpu_ctx);
+
+  // Output shape
+  auto B = int(*data_nnz);
+  if (gdata->ndim() != mask->ndim()) {
+    auto D = std::accumulate(gshape.begin() + mask->ndim(), gshape.end(), 1,
+                             std::multiplies<int>());
+    Shape_t sshape({B, D});
+    sdata->reshape(sshape, true);
+  } else {
+    Shape_t sshape({B});
+    sdata->reshape(sshape, true);
+  }
+}
+
+template <typename T>
+void BoolGather<T>::forward_impl(const Variables &inputs,
+                                 const Variables &outputs) {
+  // Outputs
+  auto mshape = inputs[1]->shape();
+  auto B =
+      std::accumulate(mshape.begin(), mshape.end(), 1, std::multiplies<int>());
+  auto nnz = outputs[0]->shape()[0];
+  auto D = outputs[0]->size() / nnz;
+  T *sdata = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
+  const T *gdata = inputs[0]->get_data_pointer<T>(this->ctx_);
+  const T *mask = inputs[1]->get_data_pointer<T>(this->ctx_);
+
+  kernel_bool_gather<T>(D, B, nnz, sdata, gdata, mask);
+}
+
+template <typename T>
+void BoolGather<T>::backward_impl(const Variables &inputs,
+                                  const Variables &outputs,
+                                  const vector<bool> &propagate_down,
+                                  const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1])) {
+    return;
+  }
+
+  auto mshape = inputs[1]->shape();
+  auto B =
+      std::accumulate(mshape.begin(), mshape.end(), 1, std::multiplies<int>());
+  auto nnz = outputs[0]->shape()[0];
+  auto D = outputs[0]->size() / nnz;
+  const T *g_sdata = outputs[0]->get_grad_pointer<T>(this->ctx_);
+  const T *mask = inputs[1]->get_data_pointer<T>(this->ctx_);
+
+  if (propagate_down[0]) {
+    auto g_gdata =
+        inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
+    auto kernel =
+        accum[0] ? kernel_bool_scatter<T, true> : kernel_bool_scatter<T, false>;
+    kernel(D, B, nnz, g_gdata, g_sdata, mask);
+  }
+}
+}

--- a/src/nbla/function/generic/bool_scatter.cpp
+++ b/src/nbla/function/generic/bool_scatter.cpp
@@ -1,0 +1,136 @@
+// Copyright (c) 2017 Sony Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/array.hpp>
+#include <nbla/common.hpp>
+#include <nbla/function/bool_scatter.hpp>
+#include <nbla/function/utils/bool_indexing.hpp>
+#include <nbla/variable.hpp>
+
+#include <numeric>
+
+namespace nbla {
+
+NBLA_REGISTER_FUNCTION_SOURCE(BoolScatter);
+
+template <typename T>
+void BoolScatter<T>::setup_impl(const Variables &inputs,
+                                const Variables &outputs) {
+  // sdata: NNZ, D_1, ..., D_M
+  // mask: B_1, ..., B_N
+  // gdata: B_1, ..., B_N, D_1, ..., D_M
+
+  auto sdata = inputs[0];
+  auto mask = inputs[1];
+  auto gdata_inp = inputs.size() == 3 ? inputs[2] : nullptr;
+  auto gdata_out = outputs[0];
+
+  // Output shape
+  auto sshape = sdata->shape();
+  auto mshape = mask->shape();
+  Shape_t gshape_out;
+  for (auto &s : mshape)
+    gshape_out.push_back(s);
+  for (unsigned int i = 1; i < sshape.size(); i++)
+    gshape_out.push_back(sshape[i]);
+  gdata_out->reshape(gshape_out, true);
+
+  // Inplace
+  if (gdata_inp != nullptr) {
+    NBLA_CHECK(gdata_inp->ndim() == gdata_out->ndim(), error_code::value,
+               "Number of dimension of inplace output (%d) must be that of "
+               "output (%d).",
+               gdata_out->ndim(), gdata_inp->ndim());
+    auto gshape_out = gdata_out->shape();
+    auto gshape_inp = gdata_inp->shape();
+    for (int i = 0; i < gdata_out->ndim(); ++i) {
+      NBLA_CHECK(gshape_out[i] == gshape_inp[i], error_code::value,
+                 "Shape of the inplaced output must be same as a computed "
+                 "shape from inputs.");
+    }
+    gdata_out->data()->set_array(gdata_inp->data()->array());
+  }
+}
+
+template <typename T>
+void BoolScatter<T>::forward_impl(const Variables &inputs,
+                                  const Variables &outputs) {
+  auto mshape = inputs[1]->shape();
+  auto gshape = outputs[0]->shape();
+  auto B = inputs[1]->size();
+  auto nnz = inputs[0]->shape()[0];
+  auto D = inputs[0]->size() / nnz;
+
+  auto inplace = (inputs.size() > 2);
+
+  auto sdata = inputs[0]->get_data_pointer<T>(this->ctx_);
+  auto mask = inputs[1]->get_data_pointer<T>(this->ctx_);
+  auto gdata = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, !inplace);
+
+  auto kernel = inplace ? kernel_bool_scatter<T, false, true>
+                        : kernel_bool_scatter<T, false, false>;
+  kernel(D, B, nnz, gdata, sdata, mask);
+}
+
+template <typename T, bool accum = false>
+inline void kernel_masked_identity(int B, int D, T *g_gdata_inp,
+                                   const T *g_gdata_out, const T *mask) {
+  for (int b = 0; b < B; ++b) {
+    auto umask_b = T(mask[b] == T(0));
+    for (int d = 0; d < D; ++d) {
+      if (accum)
+        g_gdata_inp[b * D + d] += umask_b * g_gdata_out[b * D + d];
+      else
+        g_gdata_inp[b * D + d] = umask_b * g_gdata_out[b * D + d];
+    }
+  }
+}
+
+template <typename T>
+void BoolScatter<T>::backward_impl(const Variables &inputs,
+                                   const Variables &outputs,
+                                   const vector<bool> &propagate_down,
+                                   const vector<bool> &accum) {
+  if (!(propagate_down[0] || propagate_down[1] ||
+        (inputs.size() > 2 && propagate_down[2]))) {
+    return;
+  }
+
+  auto mshape = inputs[1]->shape();
+  auto gshape = outputs[0]->shape();
+  auto B = inputs[1]->size();
+  auto nnz = inputs[0]->shape()[0];
+  auto D = inputs[0]->size() / nnz;
+
+  auto g_gdata = outputs[0]->get_grad_pointer<T>(this->ctx_);
+  auto mask = inputs[1]->get_data_pointer<T>(this->ctx_);
+
+  if (propagate_down[0]) {
+    auto g_sdata =
+        inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
+    auto kernel =
+        accum[0] ? kernel_bool_gather<T, true> : kernel_bool_gather<T, false>;
+    kernel(D, B, nnz, g_sdata, g_gdata, mask);
+  }
+
+  // inplace
+  if (inputs.size() > 2 && propagate_down[2]) {
+    auto g_gdata_inp =
+        inputs[2]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[2]);
+    auto kernel = accum[2] ? kernel_masked_identity<T, true>
+                           : kernel_masked_identity<T, false>;
+    kernel(B, D, g_gdata_inp, g_gdata, mask);
+  }
+}
+}

--- a/src/nbla/function/generic/broadcast.cpp
+++ b/src/nbla/function/generic/broadcast.cpp
@@ -36,15 +36,15 @@ void Broadcast<T>::setup_impl(const Variables &inputs,
                shape_.size(), ndim);
   }
   // X Stride and Y shape.
-  stride_x_.reshape({shape_.size()}, true);
-  shape_y_.reshape({shape_.size()}, true);
+  stride_x_.reshape({(Size_t)(shape_.size())}, true);
+  shape_y_.reshape({(Size_t)(shape_.size())}, true);
   Context cpu = Context().set_array_class("CpuCachedArray");
   int *stride_x = stride_x_.cast_data_and_get_pointer<int>(cpu, true);
   int *shape_y = shape_y_.cast_data_and_get_pointer<int>(cpu, true);
   // Check shape, and store variables.
   auto eshape = expand_shape(inputs[0]->shape(), shape_.size());
   auto estride_x_in = get_c_contiguous_strides(eshape);
-  for (int d = 0; d < eshape.size(); ++d) {
+  for (unsigned int d = 0; d < eshape.size(); ++d) {
     NBLA_CHECK(eshape[d] == shape_[d] || eshape[d] == 1, error_code::value,
                "Trailing shapes must be same or dimension of trailing shape of "
                "input has 1."

--- a/src/nbla/function/generic/broadcast.cpp
+++ b/src/nbla/function/generic/broadcast.cpp
@@ -29,31 +29,34 @@ NBLA_REGISTER_FUNCTION_SOURCE(Broadcast, const vector<int> &);
 template <typename T>
 void Broadcast<T>::setup_impl(const Variables &inputs,
                               const Variables &outputs) {
-  auto inshape = inputs[0]->shape();
   auto ndim = inputs[0]->ndim();
   if (ndim > 0) {
-    NBLA_CHECK(shape_.size() == static_cast<unsigned>(ndim), error_code::value,
-               "Number of dimension must match. Shape: %d != input: %d.",
+    NBLA_CHECK(shape_.size() >= static_cast<unsigned>(ndim), error_code::value,
+               "Target shape dimension (%d) >= input dimension (%d) must hold.",
                shape_.size(), ndim);
   }
   // X Stride and Y shape.
-  stride_x_.reshape({ndim}, true);
-  shape_y_.reshape({ndim}, true);
+  stride_x_.reshape({shape_.size()}, true);
+  shape_y_.reshape({shape_.size()}, true);
   Context cpu = Context().set_array_class("CpuCachedArray");
   int *stride_x = stride_x_.cast_data_and_get_pointer<int>(cpu, true);
   int *shape_y = shape_y_.cast_data_and_get_pointer<int>(cpu, true);
-  auto stride_x_in = inputs[0]->strides();
   // Check shape, and store variables.
-  for (int d = 0; d < ndim; ++d) {
+  auto eshape = expand_shape(inputs[0]->shape(), shape_.size());
+  auto estride_x_in = get_c_contiguous_strides(eshape);
+  for (int d = 0; d < eshape.size(); ++d) {
+    NBLA_CHECK(eshape[d] == shape_[d] || eshape[d] == 1, error_code::value,
+               "Trailing shapes must be same or dimension of trailing shape of "
+               "input has 1."
+               "Input shpae = (%s), Target shape = (%s)",
+               string_join(inputs[0]->shape(), string(", ")).c_str(),
+               string_join(shape_, string(", ")).c_str());
+
     shape_y[d] = shape_[d];
-    if (inshape[d] == shape_[d]) {
-      stride_x[d] = stride_x_in[d];
+    if (eshape[d] == shape_[d]) {
+      stride_x[d] = estride_x_in[d];
       continue;
     }
-    NBLA_CHECK(
-        inshape[d] == 1, error_code::value,
-        "Size of a dimension broadcasted must be 1 (%d at the dimension %d).",
-        inshape[d], d);
     stride_x[d] = 0;
   }
   Shape_t outshape(shape_.begin(), shape_.end());
@@ -167,7 +170,7 @@ void Broadcast<T>::forward_impl(const Variables &inputs,
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   const int *stride_x = stride_x_.get_data_pointer<int>(this->ctx_);
   const int *shape_y = shape_y_.get_data_pointer<int>(this->ctx_);
-  int ndim = inputs[0]->ndim();
+  int ndim = outputs[0]->ndim();
   int size = outputs[0]->size();
   switch_broadcast<NBLA_BROADCAST_MAX_DIM, T>::call(ndim, size, x, stride_x,
                                                     shape_y, y);
@@ -187,7 +190,7 @@ void Broadcast<T>::backward_impl(const Variables &inputs,
   T *g = inputs[0]->cast_grad_and_get_pointer<T>(this->ctx_, !accum[0]);
   const int *stride_x = stride_x_.get_data_pointer<int>(this->ctx_);
   const int *shape_y = shape_y_.get_data_pointer<int>(this->ctx_);
-  int ndim = inputs[0]->ndim();
+  int ndim = outputs[0]->ndim();
   int size = outputs[0]->size();
   if (!accum[0])
     memset((void *)g, 0, sizeof(*g) * inputs[0]->size());


### PR DESCRIPTION
Issue: https://github.com/nnabla/nnabla/issues/483

The following functions are added.

- BoolGather
- BoolScatter
- BoolFill

The first two are forward/backward correspondences and typically used like

```python

import numpy as np
import nnabla as nn
import nnabla.functions as F

nn.set_auto_forward(True)

input0 = nn.Variable.from_numpy_array([[1, 2], [3, 4], [5, 6]])
mask = nn.Variable.from_numpy_array([1, 0, 1])
output0 = F.bool_gather(input0, mask)

input1 = output0 + 10 # do whatever for reduced array

output1 = F.bool_scatter(input1, mask)

print(output1.d)  # [[11, 12], [0, 0], [15, 16]]

```


BoolFill can be inplaced like

```python
import numpy as np
import nnabla as nn
import nnabla.functions as F

nn.set_auto_forward(True)

input = nn.Variable.from_numpy_array([[np.inf, 2], [3, np.nan]])
mask = nn.Variable.from_numpy_array([[1, 0], [0, 1]])
output = input.bool_fill(mask, 0)

print(output.d) # inf/nan are replaced with 0, and input.d == output.d

```

---

新規性、秘密情報、パテント情報なしです。
