### PR TITLE
Support multiple callback

### DIFF
--- a/python/src/nnabla/utils/callback.py
+++ b/python/src/nnabla/utils/callback.py
@@ -17,95 +17,118 @@ from nnabla.logger import logger
 
 ################################################################################
 # Import callback module
-callback = None
+callback_list = []
 
 import importlib
 try:
-    callback = importlib.import_module(nnabla_config.get('CALLBACK',
-                                                         'util_callback_module'))
+    module_list_str = nnabla_config.get('CALLBACK', 'util_callback_module')
+    module_list = module_list_str.strip('[]').replace(' ', '').split(',')
+    for module in module_list:
+        callback_list.append(importlib.import_module(module))
 except:
-    callback = None
+    callback_list = []
+
+
+def _get_callback(func_name):
+    for callback in callback_list:
+        if func_name in dir(callback):
+            return callback
+    return None
 
 
 def alternative_cli(args):
-    if callback is not None and 'alternative_cli' in dir(callback):
+    callback = _get_callback("alternative_cli")
+    if callback:
         return callback.alternative_cli(args)
     else:
         return None
 
 
 def get_callback_version():
-    if callback is not None:
+    callback = _get_callback("get_callback_version")
+    if callback:
         return callback.get_callback_version()
     else:
         return None
 
 
 def get_best_from_status(args):
-    if callback is not None and 'get_best_from_status' in dir(callback):
+    callback = _get_callback("get_best_from_status")
+    if callback:
         return callback.get_best_from_status(args)
     else:
         return None, None
 
 
 def update_time_train(prediction=None):
-    if callback is not None and 'update_time_train' in dir(callback):
+    callback = _get_callback("update_time_train")
+    if callback:
         callback.update_time_train(prediction)
 
 
 def save_train_snapshot():
-    if callback is not None and 'save_train_snapshot' in dir(callback):
+    callback = _get_callback("save_train_snapshot")
+    if callback:
         callback.save_train_snapshot()
 
 
 def update_status(state=None, start=False, start_time=None):
-    if callback is not None and 'update_status' in dir(callback):
+    callback = _get_callback("update_status")
+    if callback:
         callback.update_status(state, start, start_time)
 
 
 def add_train_command_arg(subparser):
-    if callback is not None and 'add_train_command_arg' in dir(callback):
+    callback = _get_callback('add_train_command_arg')
+    if callback:
         callback.add_train_command_arg(subparser)
 
 
 def get_timelimit(args):
-    if callback is not None and 'get_timelimit' in dir(callback):
+    callback = _get_callback("get_timelimit")
+    if callback:
         return callback.get_timelimit(args)
     else:
         return -1
 
 
 def process_evaluation_result(outdir, filename):
-    if callback is not None and 'process_evaluation_result' in dir(callback):
+    callback = _get_callback("process_evaluation_result")
+    if callback:
         callback.process_evaluation_result(outdir, filename)
 
 
 def update_forward_time():
-    if callback is not None and 'update_forward_time' in dir(callback):
+    callback = _get_callback("update_forward_time")
+    if callback:
         callback.update_forward_time()
 
 
 def check_training_time(args, config, timeinfo, epoch, last_epoch):
-    if callback is not None and 'check_training_time' in dir(callback):
+    callback = _get_callback("check_training_time")
+    if callback:
         return callback.check_training_time(args, config, timeinfo, epoch, last_epoch)
     else:
         return True
 
 
 def result_base(base, suffix, outdir):
-    if callback is not None and 'result_base' in dir(callback):
+    callback = _get_callback("result_base")
+    if callback:
         return callback.result_base(base, suffix, outdir)
     else:
         return None
 
 
 def update_progress(text):
-    if callback is not None and 'update_progress' in dir(callback):
+    callback = _get_callback("update_progress")
+    if callback:
         callback.update_progress(text)
 
 
 def get_load_image_func(ext):
-    if callback is not None and 'get_load_image_func' in dir(callback):
+    callback = _get_callback("get_load_image_func")
+    if callback:
         return callback.get_load_image_func(ext)
     else:
         return None


### PR DESCRIPTION
Support multiple callback, such as:
```python
util_callback_module = [nnabla_console.callback, nnabla_ssh.callback]
```
and when these callback have same function,  the front has higher priority than the latter