### PR TITLE
Ignore label less than 0 in cross entropy

### DIFF
--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -5900,7 +5900,8 @@ Loss Functions:
         parameter: true
       target:
         doc: N-D array of labels. :math:`(D_1 \times ... \times 1 \times ... \times
-          D_N)`
+          D_N)` , each label should be the index from 0 to n-class, -1 if not belongs
+          any class.
         template: TI
         parameter: true
     arguments:
@@ -5932,7 +5933,8 @@ Loss Functions:
         parameter: true
       target:
         doc: N-D array of labels. :math:`(D_1 \times ... \times 1 \times ... \times
-          D_N)`
+          D_N)`, each label should be the index from 0 to n-class, -1 if not belongs
+          any class.
         template: TI
         parameter: true
     arguments:

--- a/python/test/function/test_softmax_cross_entropy.py
+++ b/python/test/function/test_softmax_cross_entropy.py
@@ -14,8 +14,10 @@
 
 import pytest
 import numpy as np
+import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context
+from nnabla.testing import assert_allclose
 
 ctxs = list_context('SoftmaxCrossEntropy')
 
@@ -30,6 +32,7 @@ def ref_softmax_cross_entropy(x, l, axis):
         np.log(
             np.maximum(x[np.arange(x.shape[0]), ll],
                        np.finfo(np.float32).tiny))
+    y[ll == -1] = 0
     return y.reshape(l.shape)
 
 
@@ -47,7 +50,7 @@ def test_softmax_cross_entropy_forward_backward(seed, axis, ctx, func_name):
 
     inputs = [
         rng.randn(2, 3, 4).astype(np.float32) * 2,
-        rng.randint(0, n_class, size=l_shape).astype(np.int)]
+        rng.randint(-1, n_class, size=l_shape).astype(np.int)]
 
     function_tester(rng, F.softmax_cross_entropy, ref_softmax_cross_entropy,
                     inputs, func_args=[axis], backward=[True, False],
@@ -75,3 +78,29 @@ def test_softmax_cross_entropy_double_backward(seed, axis, ctx, func_name):
                              atol_accum=1e-3,
                              dstep=1e-3,
                              ctx=ctx)
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [314])
+@pytest.mark.parametrize("axis", [0, 1, 2, -1, -2, -3])
+def test_softmax_cross_entropy_backward_with_negative_label(seed, axis, ctx, func_name):
+    from nbla_test_utils import compute_analytical_and_numerical_grad_graph
+    ishape = [2, 3, 4]
+    rng = np.random.RandomState(seed)
+
+    l_shape = list(ishape)
+    l_shape[axis] = 1
+    n_class = ishape[axis]
+
+    inp0 = nn.Variable.from_numpy_array(
+        rng.randn(2, 3, 4).astype(np.float32) * 2).apply(need_grad=True)
+    inp1 = nn.Variable.from_numpy_array(
+        rng.randint(-1, n_class, size=l_shape)).apply(need_grad=False)
+    out = F.sum(F.softmax_cross_entropy(inp0, inp1, axis=axis))
+    out.g.fill(1.0)
+    inp0.g.fill(0)
+    inp1.g.fill(0)
+    analytical_grad, numerical_grad = compute_analytical_and_numerical_grad_graph(
+        out, [inp0, inp1], recompute_graph=True)
+    numerical_grad[inp0.size:] = 0
+    assert_allclose(analytical_grad, numerical_grad, rtol=0.01, atol=0.01)

--- a/src/nbla/function/generic/categorical_cross_entropy.cpp
+++ b/src/nbla/function/generic/categorical_cross_entropy.cpp
@@ -81,6 +81,11 @@ void CategoricalCrossEntropy<T, Tl>::forward_impl(const Variables &inputs,
     for (int i2 = 0; i2 < size2_; ++i2) {
       const int j = i0 * size2_ + i2;
       Tl label = l[j];
+      if (label < 0) {
+        // Ignore the lables less than 0.
+        y[j] = 0;
+        continue;
+      }
       const int k = i0 * size1_ * size2_ + label * size2_ + i2;
       y[j] = -std::log(std::max(p[k], std::numeric_limits<T>::min()));
     }
@@ -95,6 +100,10 @@ void categorical_cross_entropy_backward_cpu(int size0, int size1, int size2,
     for (int i2 = 0; i2 < size2; ++i2) {
       const int j = i0 * size2 + i2;
       Tl label = l[j];
+      if (label < 0) {
+        // Ignore the lables less than 0.
+        continue;
+      }
       const int k = i0 * size1 * size2 + label * size2 + i2;
       dx[k] += -dy[j] / std::max(p[k], std::numeric_limits<T>::min());
     }

--- a/src/nbla/function/generic/softmax_cross_entropy.cpp
+++ b/src/nbla/function/generic/softmax_cross_entropy.cpp
@@ -89,6 +89,11 @@ void SoftmaxCrossEntropy<T, Tl>::forward_impl(const Variables &inputs,
     for (int i2 = 0; i2 < size2_; ++i2) {
       const int j = i0 * size2_ + i2;
       Tl label = l[j];
+      if (label < 0) {
+        // Ignore the lables less than 0.
+        y[j] = 0;
+        continue;
+      }
       const int k = i0 * size1_ * size2_ + label * size2_ + i2;
       y[j] = -log_p[k];
     }
@@ -115,6 +120,9 @@ void SoftmaxCrossEntropy<T, Tl>::backward_impl(
       const int j = i0 * size2_ + i2;
       Tl label = l[j];
       T grad = dy[j];
+      if (label < 0) {
+        continue;
+      }
       for (int i1 = 0; i1 < size1_; ++i1) {
         const int k = i0 * size1_ * size2_ + i1 * size2_ + i2;
         // dx[k] = beta * dx[k] + grad * (std::exp(log_p[k]) -


### PR DESCRIPTION
Ignoring labels less than 0 in cross entropy loss function. This is useful in semantic segmentation for example where it has boundary pixels that are ignored during training.