### PR TITLE
fix status 9 error

### DIFF
--- a/python/test/utils/test_sliced_data_iterator.py
+++ b/python/test/utils/test_sliced_data_iterator.py
@@ -95,3 +95,4 @@ def test_sliced_data_iterator_race_condition(num_of_slices, size, batch_size, sh
 
         for i in range(size + 5):
             d = sliced_it.next()
+        iterator.close()


### PR DESCRIPTION
This commit tends to fix "status 0 error" in windows test. This error occurs frequently and cause CI pipeline unstable.