### PR TITLE
Make inplace option in most of Function operations obsolete

### DIFF
--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -1135,7 +1135,7 @@ Neural Network Activation Functions:
         doc: N-D array
     arguments:
       inplace:
-        doc: The output array is shared with the input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -1165,7 +1165,7 @@ Neural Network Activation Functions:
         type: float
         default: '0.1'
       inplace:
-        doc: The output array is shared with the input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2583,7 +2583,7 @@ Arithmetic:
         doc: N-D array
     arguments:
       inplace:
-        doc: The output array is shared with the 1st input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2623,7 +2623,7 @@ Arithmetic:
         doc: N-D array
     arguments:
       inplace:
-        doc: The output array is shared with the 1st input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2648,7 +2648,7 @@ Arithmetic:
         doc: N-D array
     arguments:
       inplace:
-        doc: The output array is shared with the 1st input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2769,7 +2769,7 @@ Arithmetic:
         type: double
         default: '1'
       inplace:
-        doc: The output array is shared with the input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -2796,7 +2796,7 @@ Arithmetic:
         type: double
         default: '1'
       inplace:
-        doc: The output array is shared with the input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
     outputs:
@@ -5887,7 +5887,7 @@ Stochasticity:
         type: bool
         default: 'True'
       inplace:
-        doc: The output array is shared with the input array if True.
+        doc: This option is obsolete and ignored. Output is never in-placed with input.
         type: bool
         default: 'False'
       base_axis:

--- a/include/nbla/function/add2.hpp
+++ b/include/nbla/function/add2.hpp
@@ -44,14 +44,11 @@ Outputs:
  */
 template <typename T> class Add2 : public BaseFunction<bool> {
 protected:
-  bool inplace_;
-
 public:
-  Add2(const Context &ctx, bool inplace)
-      : BaseFunction(ctx, inplace), inplace_(inplace) {}
+  Add2(const Context &ctx, bool inplace) : BaseFunction(ctx, inplace) {}
   virtual ~Add2() {}
   virtual shared_ptr<Function> copy() const {
-    return create_Add2(ctx_, inplace_);
+    return create_Add2(ctx_, false /* inplace is obsoleted. */);
   }
   virtual vector<dtypes> in_types() {
     return vector<dtypes>{get_dtype<T>(), get_dtype<T>()};
@@ -62,15 +59,6 @@ public:
   virtual string name() { return "Add2"; }
   virtual vector<string> allowed_array_classes() {
     return SingletonManager::get<Cpu>()->array_classes();
-  }
-  virtual int inplace_data(int i) const {
-    if (this->fall_back_func_ || !inplace_ || i > 0)
-      return Function::NOT_INPLACE;
-    return Function::INPLACE;
-  }
-  virtual int inplace_data_with(int i) const {
-    // 0 is okay because never be called in the case of i != 0.
-    return 0;
   }
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
 

--- a/include/nbla/function/add_scalar.hpp
+++ b/include/nbla/function/add_scalar.hpp
@@ -41,6 +41,6 @@ Outputs:
 \ingroup FunctionImplGrp
  */
 NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(AddScalar, x + (T)a0, dy, false, false,
-                                      double, false);
+                                      double, true);
 }
 #endif

--- a/include/nbla/function/bc_add2.hpp
+++ b/include/nbla/function/bc_add2.hpp
@@ -32,6 +32,6 @@ broadcastable Add2. If Add2's inputs require broadcasting, it's fallback into
 BcAdd2 operation. See setup_impl of add2.cpp.
  */
 NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(BcAdd2, x0 + x1, dy, dy, false, false,
-                                     false, false, false);
+                                     false, false, true);
 }
 #endif

--- a/include/nbla/function/mul_scalar.hpp
+++ b/include/nbla/function/mul_scalar.hpp
@@ -41,6 +41,6 @@ Outputs:
 \ingroup FunctionImplGrp
 */
 NBLA_DEFINE_TRANSFORM_UNARY_1_INPLACE(MulScalar, x *(T)a0, dy *(T)a0, false,
-                                      false, double, false);
+                                      false, double, true);
 }
 #endif

--- a/include/nbla/function/random_erase.hpp
+++ b/include/nbla/function/random_erase.hpp
@@ -46,7 +46,8 @@ Outputs:
 @param n Max number of patches to be erased.
 @param share Use a same bounding box randomly picked over the feature dimension
 when being True. Default is False.
-@param inplace The output array is shared with the input array if True.
+@param inplace This option is obsolete and ignored. Output is never in-placed
+with input.
 @param base_axis
 @param seed Random seed. When -1, seed is sampled from global random number
 generator.
@@ -69,7 +70,6 @@ protected:
   const vector<float> replacements_;
   int n_;
   bool share_;
-  bool inplace_;
   int base_axis_;
   int seed_;
   bool channel_last_;
@@ -90,13 +90,14 @@ public:
                      share, inplace, base_axis, seed, channel_last,
                      ste_fine_grained),
         prob_(prob), area_ratios_(area_ratios), aspect_ratios_(aspect_ratios),
-        replacements_(replacements), n_(n), share_(share), inplace_(inplace),
+        replacements_(replacements), n_(n), share_(share),
         base_axis_(base_axis), seed_(seed), channel_last_(channel_last),
         ste_fine_grained_(ste_fine_grained) {}
   virtual ~RandomErase() {}
   virtual shared_ptr<Function> copy() const {
     return create_RandomErase(ctx_, prob_, area_ratios_, aspect_ratios_,
-                              replacements_, n_, share_, inplace_, base_axis_,
+                              replacements_, n_, share_,
+                              false /* inplace is obsoleted. */, base_axis_,
                               seed_, channel_last_, ste_fine_grained_);
   }
   virtual int min_inputs() { return 1; }
@@ -107,10 +108,6 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual string name() { return "RandomErase"; }
-  virtual int inplace_data(int i) const {
-    return inplace_ ? Function::INPLACE : Function::NOT_INPLACE;
-  }
-  virtual int inplace_data_with(int i) const { return 0; }
   virtual bool need_setup_recompute(int o) const { return true; }
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
 

--- a/include/nbla/function/relu.hpp
+++ b/include/nbla/function/relu.hpp
@@ -43,19 +43,17 @@ Outputs:
 - N-D array.
 
 @tparam T Data type for computation.
-@param inplace The output array is will be shared with the input array if true.
+@param inplace This option is obsolete and ignored. Output is never in-placed
+with input.
 \ingroup FunctionImplGrp
  */
 template <typename T> class ReLU : public BaseFunction<bool> {
 protected:
-  bool inplace_;
-
 public:
-  ReLU(const Context &ctx, bool inplace)
-      : BaseFunction(ctx, inplace), inplace_(inplace) {}
+  ReLU(const Context &ctx, bool inplace) : BaseFunction(ctx, inplace) {}
   virtual ~ReLU() {}
   virtual shared_ptr<Function> copy() const {
-    return create_ReLU(ctx_, inplace_);
+    return create_ReLU(ctx_, false /* inplace is obsoleted. */);
   }
   virtual int min_inputs() { return 1; }
   virtual int min_outputs() { return 1; }
@@ -66,10 +64,6 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
   virtual bool grad_depends_output_data(int i, int o) const { return true; }
-  virtual int inplace_data(int i) const {
-    return inplace_ ? Function::INPLACE : Function::NOT_INPLACE;
-  }
-  virtual int inplace_data_with(int i) const { return 0; }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,

--- a/include/nbla/function/sub2.hpp
+++ b/include/nbla/function/sub2.hpp
@@ -39,6 +39,6 @@ Outputs:
 \ingroup FunctionImplGrp
  */
 NBLA_DEFINE_TRANSFORM_BINARY_INPLACE(Sub2, x0 - x1, dy, -dy, false, false,
-                                     false, false, false);
+                                     false, false, true);
 }
 #endif

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -486,17 +486,17 @@ cdef class NdArray:
     def __iadd__(self, x):
         import nnabla.functions as F
         if isinstance(x, (NdArray, Variable)):
-            F.add2(self, x, inplace=True)
+            F.add2(self, x, outputs=[self])
         else:
-            F.add_scalar(self, x, inplace=True)
+            F.add_scalar(self, x, outputs=[self])
         return self
 
     def __isub__(self, x):
         import nnabla.functions as F
         if isinstance(x, (NdArray, Variable)):
-            F.sub2(self, x, inplace=True)
+            F.sub2(self, x, outputs=[self])
         else:
-            F.add_scalar(self, -x, inplace=True)
+            F.add_scalar(self, -x, outputs=[self])
         return self
 
     def __imul__(self, x):
@@ -504,7 +504,7 @@ cdef class NdArray:
         if isinstance(x, (NdArray, Variable)):
             return F.mul2(self, x)
         else:
-            F.mul_scalar(self, x, inplace=True)
+            F.mul_scalar(self, x, outputs=[self])
         return self
 
     def __idiv__(self, x):
@@ -512,7 +512,7 @@ cdef class NdArray:
         if isinstance(x, (NdArray, Variable)):
             return F.div2(self, x)
         else:
-            F.mul_scalar(self, 1. / x, inplace=True)
+            F.mul_scalar(self, 1. / x, outputs=[self])
         return self
 
     def __itruediv__(self, x):
@@ -520,7 +520,7 @@ cdef class NdArray:
         if isinstance(x, (NdArray, Variable)):
             return F.div2(self, x)
         else:
-            F.mul_scalar(self, 1. / x, inplace=True)
+            F.mul_scalar(self, 1. / x, outputs=[self])
         return self
 
     def __ipow__(self, x):

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -1126,48 +1126,6 @@ cdef class Variable:
     def __matmul__(x, y):
         return AOP.matmul(x, y)
 
-    def __iadd__(self, x):
-        import nnabla.functions as F
-        if isinstance(x, (NdArray, Variable)):
-            return F.add2(self, x, inplace=False)
-        else:
-            return F.add_scalar(self, x, inplace=False)
-
-    def __isub__(self, x):
-        import nnabla.functions as F
-        if isinstance(x, (NdArray, Variable)):
-            return F.sub2(self, x, inplace=False)
-        else:
-            return F.add_scalar(self, -x, inplace=False)
-
-    def __imul__(self, x):
-        import nnabla.functions as F
-        if isinstance(x, (NdArray, Variable)):
-            return F.mul2(self, x)
-        else:
-            return F.mul_scalar(self, x)
-
-    def __idiv__(self, x):
-        import nnabla.functions as F
-        if isinstance(x, (NdArray, Variable)):
-            return F.div2(self, x, inplace=False)
-        else:
-            return F.mul_scalar(self, 1. / x)
-
-    def __itruediv__(self, x):
-        import nnabla.functions as F
-        if isinstance(x, (NdArray, Variable)):
-            return F.div2(self, x, inplace=False)
-        else:
-            return F.mul_scalar(self, 1. / x)
-
-    def __ipow__(self, x):
-        import nnabla.functions as F
-        if isinstance(x, (NdArray, Variable)):
-            return F.pow2(self, x)
-        else:
-            return F.pow_scalar(self, x)
-
     def __getitem__(self, key):
         return IDX.getitem(self, key)
 

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -40,7 +40,7 @@ def SmallResNet(x, test=False, act=F.relu, inplace=False, shared=False):
         with nn.parameter_scope("{}-shortcut".format(name)):
             s = PF.convolution(h, maps, (3, 3), (1, 1), with_bias=False)
             h = PF.batch_normalization(h, batch_stat=not test)
-        return act(h + s, inplace) if act in (F.relu, F.leaky_relu) else act(h + s)
+        return act(h + s, inplace=inplace) if act in (F.relu, F.leaky_relu) else act(h + s)
     h = conv(h, maps=4, name="conv1")
     h = F.max_pooling(h, (2, 2))
     h = conv(h, maps=4, name="conv2")

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -473,37 +473,6 @@ class TestClearInput():
 
         self.check_input_data_clear_called_flags(answer)
 
-    # Test for inplaced variable in a network of two layers.
-    def test_clear_input_if_no_need_grad_inplace0(self):
-        x1 = nn.Variable([1, 5], need_grad=True)
-
-        xx1 = F.identity(x1)
-        y1 = F.add_scalar(xx1, inplace=True)
-
-        answer = []
-        answer.append([False])
-        answer.append([False])
-
-        y1.forward(clear_no_need_grad=True)
-
-        self.check_input_data_clear_called_flags(answer)
-
-    # Test for inplaced variable in a network of three layers.
-    def test_clear_input_if_no_need_grad_inplace1(self):
-        x1 = nn.Variable([1, 5], need_grad=True)
-
-        xx1 = F.identity(x1)
-        y1 = F.add_scalar(xx1, inplace=True)
-        y2 = F.add_scalar(y1)
-
-        answer = []
-        answer.append([False])
-        answer.append([False])
-        answer.append([False])
-
-        y2.forward(clear_no_need_grad=True)
-        self.check_input_data_clear_called_flags(answer)
-
     # Test for a variable shared with two layer functions.
     # Check if it is cleared after the both functions finish to use it.
     def test_clear_input_if_no_need_grad_branch0(self):
@@ -545,28 +514,6 @@ class TestClearInput():
         answer.append([False])
         answer.append([False, True])  # (2) use xx2 in backward
         answer.append([True, True])  # (3)
-
-        y3.forward(clear_no_need_grad=True)
-        self.check_input_data_clear_called_flags(answer)
-
-    # Test for inplace after branching.
-    def test_clear_input_if_no_need_grad_branch2(self):
-        x1 = nn.Variable([1, 5], need_grad=True)
-
-        xx1 = F.identity(x1)
-        y1 = F.add_scalar(xx1)
-        y2 = F.add_scalar(y1, inplace=True)
-        z1 = F.add_scalar(xx1)
-        z2 = F.add_scalar(z1)
-        y3 = F.add2(y2, z2)
-
-        answer = []
-        answer.append([False])
-        answer.append([False])
-        answer.append([False])
-        answer.append([True])
-        answer.append([True])
-        answer.append([False, True])
 
         y3.forward(clear_no_need_grad=True)
         self.check_input_data_clear_called_flags(answer)

--- a/src/nbla/function/generic/add2.cpp
+++ b/src/nbla/function/generic/add2.cpp
@@ -27,13 +27,10 @@ template <typename T>
 void Add2<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   if (inputs[0]->shape() == inputs[1]->shape()) {
     outputs[0]->reshape(inputs[0]->shape(), true);
-    if (inplace_) {
-      outputs[0]->data()->set_array(inputs[0]->data()->array());
-    }
     return;
   }
   // Trying to fallback to broadcastable Add2.
-  this->fall_back_func_ = create_BcAdd2(this->ctx_, inplace_);
+  this->fall_back_func_ = create_BcAdd2(this->ctx_, false);
   this->fall_back_func_->setup(inputs, outputs);
 }
 
@@ -41,7 +38,7 @@ template <class T>
 void Add2<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   const T *x0 = inputs[0]->get_data_pointer<T>(this->ctx_);
   const T *x1 = inputs[1]->get_data_pointer<T>(this->ctx_);
-  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, !inplace_);
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < inputs[0]->size(); s++) {
     y[s] = x0[s] + x1[s];
   }

--- a/src/nbla/function/generic/random_erase.cpp
+++ b/src/nbla/function/generic/random_erase.cpp
@@ -212,9 +212,6 @@ void RandomErase<T>::setup_impl(const Variables &inputs,
       "Image (the number of the spatial dimensions is 2) is only supported.");
 
   outputs[0]->reshape(inputs[0]->shape(), true);
-  if (inplace_) {
-    outputs[0]->data()->set_array(inputs[0]->data()->array());
-  }
 
   rgen_ = std::mt19937((seed_ == -1 ? std::random_device()() : seed_));
 }
@@ -242,7 +239,7 @@ void RandomErase<T>::random_erase(const Variables &inputs,
   auto Bs = C * H * W;
 
   const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
-  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, !inplace_);
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
 
   // Generate N x B (x C) x 5, 5 is {prob, Se, re, xe, ye}
   this->random_coordinates_ =

--- a/src/nbla/function/generic/relu.cpp
+++ b/src/nbla/function/generic/relu.cpp
@@ -28,15 +28,12 @@ NBLA_REGISTER_FUNCTION_SOURCE(ReLU, bool);
 template <typename T>
 void ReLU<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
   outputs[0]->reshape(inputs[0]->shape(), true);
-  if (inplace_) {
-    outputs[0]->data()->set_array(inputs[0]->data()->array());
-  }
 }
 
 template <class T>
 void ReLU<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
   const T *x = inputs[0]->get_data_pointer<T>(this->ctx_);
-  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, !inplace_);
+  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
   for (int s = 0; s < inputs[0]->size(); s++) {
     y[s] = std::max(T(0), x[s]);
   }


### PR DESCRIPTION
In-place operations such as `F.add_scalar(x, y, inplace=True)` don't actually perform computation in-place now. The option `inplace=True` will be just ignored by this change.