### PR TITLE
Reduce create_cache log for s3 dataset

### DIFF
--- a/python/src/nnabla/utils/data_source.py
+++ b/python/src/nnabla/utils/data_source.py
@@ -320,8 +320,9 @@ class DataSourceWithFileCache(DataSource):
         while self._position < self._data_source._size:
 
             if single_or_rankzero():
-                progress('Create cache', self._position *
-                         1.0 / self._data_source._size)
+                if self._position % int(self._data_source._size/20+1) == 0:
+                    progress('Create cache', self._position *
+                             1.0 / self._data_source._size)
 
             self._store_data_to_cache_buffer(self._position)
             self._position += 1


### PR DESCRIPTION
when requesting dataset from s3, reduce to print cache long not so much frequently.
