### PR TITLE
fix CUDA version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,15 @@ pip install nnabla
 
 This installs the CPU version of Neural Network Libraries. GPU-acceleration can be added by installing the CUDA extension with following command.  
 ```
-pip install nnabla-ext-cuda101
+pip install nnabla-ext-cuda110
 ```  
-Above command is for version 10.1 CUDA Toolkit.  
+Above command is for version 11.0 CUDA Toolkit.  
 
 for other versions:  
+`pip install nnabla-ext-cuda102` for CUDA version 10.2.  
 `pip install nnabla-ext-cuda100` for CUDA version 10.0.  
-`pip install nnabla-ext-cuda90` for CUDA version 9.0.  
-`pip install nnabla-ext-cuda80` for CUDA version 8.0.  
   
-CUDA ver. 9.1, ver. 9.2 are not supported now.  
+CUDA ver. 10.1, ver. 9.x, ver. 8.x are not supported now.  
 
 
 For more details, see the [installation section](http://nnabla.readthedocs.io/en/latest/python/installation.html) of the documentation.


### PR DESCRIPTION
The README contained older CUDA versions which was supported before.
We now support 10.0, 10.2 and 11.0. So, update README file.