### PR TITLE
 Bugfix the higher-order gradient of gather_nd

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -278,3 +278,5 @@
   BoolFill_f: 341
   BoolGather_Empty: 339
   BoolScatter_Empty: 340
+37:
+  ScatterNd_iIB: 342

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -4961,7 +4961,7 @@ Array Manipulation:
         doc: Mask with which to scatter. Non-zero/zero elements are supposed to be
           a binary mask as 1/0. No gradients are computed with respect to mask.
       output:
-        doc: Distination of output. If specified, data are inplaced.
+        doc: Destination of output. If specified, data are inplaced.
         optional: true
     outputs:
       y:

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -4872,12 +4872,17 @@ Array Manipulation:
         doc: Shape of output variable.
         type: repeated int64
         default: None
+      add:
+        doc: Add the input data to the same destination specified by the indices.
+        type: bool
+        default: 'False'
     outputs:
       y:
         doc: N-D array of given `shape`.
     c_runtime: not support
     function_ids:
       iI: 271
+      iIB: 342
   ScatterAdd:
     snake_name: scatter_add
     doc: |2

--- a/include/nbla/function/scatter_nd.hpp
+++ b/include/nbla/function/scatter_nd.hpp
@@ -22,7 +22,7 @@
 
 namespace nbla {
 
-NBLA_REGISTER_FUNCTION_HEADER(ScatterNd, const vector<int> &);
+NBLA_REGISTER_FUNCTION_HEADER(ScatterNd, const vector<int> &, bool);
 
 /** Scatter `data` into a new array of given `shape` according to `indices`.
   This operation is the inverse of :func:`~nnabla.functions.gather_nd`.
@@ -66,16 +66,17 @@ Outputs:
 \ingroup FunctionImplGrp
  */
 template <typename T>
-class ScatterNd : public BaseFunction<const vector<int> &> {
+class ScatterNd : public BaseFunction<const vector<int> &, bool> {
 protected:
   const vector<int> shape_;
+  const bool add_;
 
 public:
-  ScatterNd(const Context &ctx, const vector<int> &shape)
-      : BaseFunction(ctx, shape), shape_(shape) {}
+  ScatterNd(const Context &ctx, const vector<int> &shape, bool add)
+      : BaseFunction(ctx, shape, add), shape_(shape), add_(add) {}
   virtual ~ScatterNd() {}
   virtual shared_ptr<Function> copy() const {
-    return create_ScatterNd(ctx_, shape_);
+    return create_ScatterNd(ctx_, shape_, add_);
   }
   virtual int min_inputs() { return 2; }
   virtual int min_outputs() { return 1; }

--- a/python/src/nnabla/backward_function/gather_nd.py
+++ b/python/src/nnabla/backward_function/gather_nd.py
@@ -28,5 +28,5 @@ def gather_nd_backward(inputs):
     dy = inputs[0]
     x0 = inputs[1]
     idx = inputs[2]
-    dx0 = F.scatter_nd(dy, idx, shape=x0.shape)
+    dx0 = F.scatter_nd(dy, idx, shape=x0.shape, add=True)
     return dx0, None

--- a/python/src/nnabla/backward_function/scatter_nd.py
+++ b/python/src/nnabla/backward_function/scatter_nd.py
@@ -16,7 +16,7 @@
 import nnabla.functions as F
 
 
-def scatter_nd_backward(inputs, shape):
+def scatter_nd_backward(inputs, shape, add):
     """
     Args:
       inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -1293,7 +1293,7 @@ def gather_nd(data, indices):
     return gather_nd_base(data, indices)
 
 
-def scatter_nd(data, indices, shape=None, out=None):
+def scatter_nd(data, indices, shape=None, out=None, add=False):
     """Scatter `data` according to `indices` into a new array of given `shape`
     or an existing array provided as `out`. Exactly one of the `shape` or `out`
     argument must be given. Given output `shape`, or shape of `out` array,
@@ -1332,6 +1332,7 @@ def scatter_nd(data, indices, shape=None, out=None):
         indices(list, numpy.ndarray, ~nnabla.Variable, ~nnabla.NdArray): scatter indices
         shape(tuple, list): shape of new output array
         out(~nnabla.Variable, ~nnabla.NdArray): existing output array
+        add(tool): Add the input data to the same destination specified by the indices.
 
     Returns: ~nnabla.Variable or ~nnabla.NdArray of given `shape`.
 
@@ -1351,7 +1352,7 @@ def scatter_nd(data, indices, shape=None, out=None):
         shape = out.shape
     elif isinstance(shape, np.ndarray):
         shape = shape.tolist()
-    return scatter_nd_base(data, indices, out, shape)
+    return scatter_nd_base(data, indices, out, shape, add)
 
 
 def scatter_add(x0, indices, x1, axis=None):

--- a/python/test/function/test_gather_nd.py
+++ b/python/test/function/test_gather_nd.py
@@ -51,3 +51,29 @@ def test_forward_backward(seed, ishape, index, ctx, func_name):
     inputs = [rng.randn(*ishape).astype(np.float32), np.array(index)]
     function_tester(rng, F.gather_nd, gather_nd, inputs, func_name=func_name,
                     ctx=ctx, backward=[True, False])
+
+
+@pytest.mark.parametrize("ctx, func_name", ctxs)
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("ishape, index", [
+    ([10], [[0]]),
+    ([10], [[1, 5, 8]]),
+    ([10], [[-1, -5, -8]]),
+    ([3, 4], [[0]]),
+    ([3, 4], [[0], [0]]),
+    ([3, 4], [[0, 1], [0, 2]]),
+    ([3, 4], [[0, -1], [0, -2]]),
+    ([2, 3, 4], [[0]]),
+    ([2, 3, 4], [[0], [1]]),
+    ([2, 3, 4], [[0], [1], [2]]),
+    ([2, 3, 4], [[0, 1]]),
+    ([2, 3, 4], [[0, 1], [1, 2]]),
+    ([2, 3, 4], [[0, 1], [1, 2], [1, 0]]),
+    ([4, 4, 4, 4], [[[0, 1], [2, 3]], [[0, 1], [2, 3]]]),
+])
+def test_double_backward(seed, ishape, index, ctx, func_name):
+    from nbla_test_utils import backward_function_tester
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*ishape).astype(np.float32), np.array(index)]
+    backward_function_tester(rng, F.gather_nd, inputs,
+                             ctx=ctx, backward=[True, False])

--- a/src/nbla/function/generic/scatter_nd.cpp
+++ b/src/nbla/function/generic/scatter_nd.cpp
@@ -20,7 +20,7 @@
 
 namespace nbla {
 
-NBLA_REGISTER_FUNCTION_SOURCE(ScatterNd, const vector<int> &);
+NBLA_REGISTER_FUNCTION_SOURCE(ScatterNd, const vector<int> &, bool);
 
 template <typename T>
 void ScatterNd<T>::setup_impl(const Variables &inputs,
@@ -97,8 +97,14 @@ void ScatterNd<T>::forward_impl(const Variables &inputs,
     }
     auto slice_length = dst_strides.at(idx_rows - 1);
     auto slice_offset = ndi::nd2flat(dst_ndi, dst_strides);
-    for (int k = 0; k < slice_length; k++) {
-      dst[slice_offset + k] = src[i * slice_length + k];
+    if (add_) {
+      for (int k = 0; k < slice_length; k++) {
+        dst[slice_offset + k] += src[i * slice_length + k];
+      }
+    } else {
+      for (int k = 0; k < slice_length; k++) {
+        dst[slice_offset + k] = src[i * slice_length + k];
+      }
     }
   }
 }


### PR DESCRIPTION
The race condition happened before when we had overlapping indices of F.gather_nd (i.e., advanced indexing) used by nn.grad. This is fixed by this PR, so the interpolation by the composite function works fine now by nn.grad, too.