### PR TITLE
Fix pillow save image with wrong array shape in grayscale mode.

### DIFF
--- a/python/src/nnabla/utils/image_utils/backend_events/common.py
+++ b/python/src/nnabla/utils/image_utils/backend_events/common.py
@@ -134,6 +134,10 @@ def _imsave_before(img, channel_first, auto_scale):
     if channel_first and len(img.shape) == 3:
         img = img.transpose((1, 2, 0))
 
+    if len(img.shape) == 3 and img.shape[-1] not in [1, 2, 3, 4]:
+        raise ValueError(
+            f"Invalid channel size of input image. (channel size: {img.shape[-1]})")
+
     return img
 
 

--- a/python/src/nnabla/utils/image_utils/backend_events/pil_backend.py
+++ b/python/src/nnabla/utils/image_utils/backend_events/pil_backend.py
@@ -184,6 +184,9 @@ class PilBackend(ImageUtilsBackend):
         if auto_scale and img.dtype != np.uint8:
             img = (img * 255).astype(np.uint8)
 
+        if len(img.shape) == 3 and img.shape[-1] == 1:
+            img = np.squeeze(img, axis=-1)
+
         Image.fromarray(img).save(path)
 
     def imresize(self, img, size, interpolate="bilinear", channel_first=False):


### PR DESCRIPTION
fix image_utils pillow backend throw error when saving image in grayscale mode with mismatched array shape.