### PR TITLE
Fix global seed setter for multi-device settings

### DIFF
--- a/include/nbla/random_manager.hpp
+++ b/include/nbla/random_manager.hpp
@@ -25,7 +25,7 @@ Singleton class for storing global context.
 */
 class NBLA_API RandomManager {
   std::mt19937 rgen_;
-  unsigned int seed_;
+  unsigned seed_;
   int count_;
 
 public:

--- a/python/src/nnabla/random.pyx
+++ b/python/src/nnabla/random.pyx
@@ -20,10 +20,22 @@ from random cimport _set_seed
 pseed = 313
 prng = np.random.RandomState(pseed)
 
-def seed(seed_value):
+def seed(seed_value, set_function_seed=True, set_parameter_seed=True):
     assert isinstance(seed_value, int)
-    global pseed
-    global prng
-    pseed = seed_value
-    prng = np.random.RandomState(seed_value)
-    _set_seed(seed_value)
+    
+    if set_parameter_seed:  
+        global pseed
+        global prng
+        pseed = seed_value
+        prng = np.random.RandomState(seed_value)
+    
+    if set_function_seed:
+        _set_seed(seed_value)
+
+def set_parameter_seed(seed_value):
+    # prng should be the same across workers in the multi-device setting.
+    seed(seed_value, set_function_seed=False, set_parameter_seed=True)
+
+def set_function_seed(seed_value):
+    # rng for c++ random functions should be different across workers in the multi-device setting.
+    seed(seed_value, set_function_seed=True, set_parameter_seed=False)

--- a/src/nbla/random_manager.cpp
+++ b/src/nbla/random_manager.cpp
@@ -16,7 +16,7 @@
 #include <nbla/singleton_manager-internal.hpp>
 
 namespace nbla {
-RandomManager::RandomManager() : seed_(313), count_(0) {
+RandomManager::RandomManager() : seed_(std::random_device()()), count_(0) {
   rgen_ = std::mt19937(seed_);
 }
 


### PR DESCRIPTION
This PR changes the default seed for random_manager as random and also separates seed setter for parameter initializer and random function.

Currently, rancom_manger::seed_ is initialized by constant. This is actually undesirable because random functions produce the same sequences every time.
Especially in the setting with multi-device, the seed for random functions should be different across devices while the seed for parameter initializer should be the same. Note that the default seed for initializing parameters is unchanged (fixed as 313).