### PR TITLE
Skip test_warp_by_grid.py

### DIFF
--- a/python/test/function/test_warp_by_grid.py
+++ b/python/test/function/test_warp_by_grid.py
@@ -286,6 +286,9 @@ def ref_warp_by_grid(inp, grid, mode, padding_mode, align_corners, channel_last)
 @pytest.mark.parametrize("channel_last", [False, True])
 def test_warp_by_grid_forward_backward(seed, ctx, func_name, size_out, size_inp, channels, batch_size,
                                        mode, padding_mode, align_corners, channel_last):
+
+    pytest.skip("Skip. Recover it after windows Tesla T4 1GPUTest fixed.")
+
     if channel_last and func_name == "WarpByGrid":
         pytest.skip("channel_last=True is not supported in CPU.")
 


### PR DESCRIPTION
Skip test_warp_by_grid.py due to win10 Tesla T4 1GPUTest fails. Recover it once fixed.