### PR TITLE
Fix object detector models

### DIFF
--- a/python/src/nnabla/models/object_detection/base.py
+++ b/python/src/nnabla/models/object_detection/base.py
@@ -84,8 +84,8 @@ class ObjectDetection(object):
         return input_var
 
     def get_nnp_input_size(self):
-        nnp_input_size = self.nnp.proto.network[0].variable[0].shape.dim[2:]
-        return nnp_input_size
+        inputs = self.nnp.get_network(self.nnp.get_network_names()[0]).inputs
+        return list(inputs.values())[0].shape[2:]
 
     def __call__(self, input_var=None, use_from=None, use_up_to='detection', training=False, returns_net=False, verbose=0):
         '''


### PR DESCRIPTION
The `ObjectDetection` base class has been corrupt since commit 699ce9a0d6e19852f5d6171f86265b718bc860f8 removed the `proto` attribute from the `NnpLoader` class.

This issue can be seen e.g. with
```
from nnabla.models.object_detection.yolov2 import YoloV2
import nnabla as nn

model = YoloV2()
print(model(nn.Variable((1,3,608,608))))
```

which results in
```
Traceback (most recent call last):
  File "yolo.py", line 5, in <module>
    print(model(nn.Variable((1,3,608,608))))
  File "/home/daniel/test_prg/python/nnabla/venv3/lib/python3.7/site-packages/nnabla/models/object_detection/yolov2.py", line 66, in __call__
    nnp_input_size = self.get_nnp_input_size()
  File "/home/daniel/test_prg/python/nnabla/venv3/lib/python3.7/site-packages/nnabla/models/object_detection/base.py", line 87, in get_nnp_input_size
    nnp_input_size = self.nnp.proto.network[0].variable[0].shape.dim[2:]
AttributeError: 'NnpLoader' object has no attribute 'proto
```