### PR TITLE
Improve recomputation API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@
 /python/src/nnabla/function_bases.py
 /python/src/nnabla/nbla
 /python/src/nnabla/nnabla.lib
+/python/src/nnabla/recompute.cpp
 /python/src/nnabla/solver.cpp
 /python/src/nnabla/solver.pxd
 /python/src/nnabla/solver.pyx

--- a/include/nbla/recompute.hpp
+++ b/include/nbla/recompute.hpp
@@ -1,0 +1,50 @@
+// Copyright 2021 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_RECOMPUTE_HPP__
+#define __NBLA_RECOMPUTE_HPP__
+#include <nbla/defs.hpp>
+#include <nbla/singleton_manager.hpp>
+
+namespace nbla {
+/**
+Singleton class for storing global recompute flag.
+*/
+class NBLA_API Recompute {
+  bool current_;
+
+public:
+  ~Recompute();
+  /** Get current global recompute flag.
+   */
+  bool get_global_recompute() const;
+
+  /** Set global recompute flag.
+   */
+  void set_global_recompute(bool recompute);
+
+private:
+  friend SingletonManager;
+  // Never called by users.
+  Recompute();
+  DISABLE_COPY_AND_ASSIGN(Recompute);
+};
+
+NBLA_API bool get_global_recompute();
+
+NBLA_API void c_set_global_recompute(const bool recompute);
+
+NBLA_API bool c_get_global_recompute();
+}
+#endif

--- a/python/setup.py
+++ b/python/setup.py
@@ -183,6 +183,7 @@ if __name__ == '__main__':
         '_indexing',
         'utils/dlpack',
         'testing/clear_called_flag_recorder',
+        'recompute',
         'lms']
 
     ext_modules = [Extension('nnabla.{}'.format(mname.replace('/', '.')),

--- a/python/src/nnabla/__init__.py
+++ b/python/src/nnabla/__init__.py
@@ -39,6 +39,7 @@ from .parameter import (
 from .context import (
     context_scope, set_default_context, get_current_context)
 from .auto_forward import auto_forward, set_auto_forward, get_auto_forward
+from .recompute import recompute, recompute_fn, set_global_recompute
 from ._computation_graph import forward_all
 from .grad import grad
 from .callback import (

--- a/python/src/nnabla/recompute.pxd
+++ b/python/src/nnabla/recompute.pxd
@@ -1,0 +1,19 @@
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libcpp cimport bool as cpp_bool
+
+cdef extern from "nbla/recompute.hpp" namespace "nbla":
+    void c_set_global_recompute(const cpp_bool recompute) except +
+    cpp_bool c_get_global_recompute() except +

--- a/python/src/nnabla/recompute.pyx
+++ b/python/src/nnabla/recompute.pyx
@@ -1,0 +1,99 @@
+# Copyright 2021 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from contextlib import contextmanager
+from recompute cimport *
+
+def set_global_recompute(recompute):
+    c_set_global_recompute(recompute)
+
+def get_global_recompute():
+    return c_get_global_recompute()
+
+
+@contextmanager
+def recompute(recompute_=True):
+    """Recompute all variables inside of code block.
+
+    Variables inside `with nn.recompute():` block will be recomputed during backward propagation if possible.
+    You can also specify boolean value switching recompute flag by `with nn.recompute(True):` or `with nn.recompute(False):`.
+    `with` statement can be nested, so disabling recomputation part of the network is done by enclosing the partial network with `with nn.recompute(False):`.
+
+    There is also function scope version of syntax for switching recompute flags. See `nn.recompute_fn()` documentation for more details.
+
+    Args:
+
+        recompute_ (bool): Re-computation flag. Default is True.
+
+    Example:
+
+    .. code-block:: python
+
+        with nn.recompute():
+            output0 = <Network0>(<input0>)
+
+        output1 = <Network1>(<input1>, output0)
+        loss = <Loss>(output1, <ground_truth>)
+        loss.forward(clear_no_need_grad=True)
+        loss.backward(clear_buffer=True)
+
+        # All re-computable variables defined inside `with nn.recompute()` are recomputed during backward propagation.
+        # In this case, variables defined inside `<Network0>` and `output0` are recomputed when possible.
+        # Notice that the variable's `data` to be re-computed might have uninitialized values even after forward propagation since the `data` will be cleared during forward execution. Thus, you should not access the `data` of variables to be re-computed.
+    """
+
+    prev_recompute = get_global_recompute()
+    set_global_recompute(recompute_)
+    try:
+        yield
+    finally:
+        set_global_recompute(prev_recompute)
+
+
+def recompute_fn(recompute_=True):
+    """Recompute all variables inside of function.
+
+    Variables inside decorated functions with `@nn.recompute_fn()` will be recomputed during backward propagation if possible.
+    You can also specify boolean value switching recompute flag by `@nn.recompute_fn(True)` or `@nn.recompute_fn(False)`.
+
+    There is also block scope version of syntax for switching recompute flags. See `nn.recompute()` documentation for more ditails.
+
+    Args:
+
+        recompute_ (bool): Re-computation flag. Default is True.
+
+    Example:
+
+    .. code-block:: python
+
+        @nn.recompute_fn()
+        def network(x):
+            y = <Functions>(x)
+            return y
+
+        output1 = network(<input1>, output0)
+        loss = <Loss>(output1, <ground_truth>)
+        loss.forward(clear_no_need_grad=True)
+        loss.backward(clear_buffer=True)
+
+        # All re-computable variables defined inside `network()` are recomputed during backward propagation.
+        # Notice that the variable's `data` to be re-computed might have uninitialized values even after forward propagation since the `data` will be cleared during forward execution. Thus, you should not access the `data` of variables to be re-computed.
+    """
+    def decorator(func):
+        def wrapper(*args, **kwargs):
+            with recompute(recompute_):
+                return func(*args, **kwargs)
+        return wrapper
+    return decorator

--- a/python/test/conftest.py
+++ b/python/test/conftest.py
@@ -46,6 +46,9 @@ def scope_function():
     # use cached array
     nn.prefer_cached_array(True)
 
+    # turn off re-computation
+    nn.set_global_recompute(False)
+
     yield
 
     # restore context

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -1163,6 +1163,277 @@ class TestRecomputation():
         y.forward(clear_no_need_grad=True)
         y.backward(function_pre_hook=fail_with_not_cleared_data)
 
+    @pytest.mark.parametrize("recompute_flag", [False, True])
+    def test_with_statement_variable_creation(self, recompute_flag):
+        """
+        Test for setting recompute flags with Python `with` statement.
+        """
+
+        # Create a new Variable
+        x1 = nn.Variable((2, 3))
+        assert x1.recompute == False
+
+        with nn.recompute(recompute_flag):
+            # Create Variable by `__cinit__()`
+            y1 = nn.Variable((2, 3))
+            assert y1.recompute == recompute_flag
+
+            # Create Variable by `create_from_cvariable()`
+            y2 = x1.reshape((3, 2), unlink=True)
+            assert y2.recompute == recompute_flag
+
+            # Create Variable by `create_from_cg_variable()`
+            y3 = F.relu(x1)
+            assert y3.recompute == recompute_flag
+
+            # Create Variable by `from_numpy_array()`
+            data = np.array((2, 3))
+            y4 = nn.Variable.from_numpy_array(data)
+            assert y4.recompute == recompute_flag
+
+            # Create Variable by `get_unlinked_variable()`
+            y5 = x1.get_unlinked_variable()
+            assert y5.recompute == recompute_flag
+
+            # Recompute flag for referenced Variable must not be overwritten.
+            # More detail tests are performed by `test_nested_with_statement`
+            y6 = x1
+            assert y6.recompute == False
+
+            # Direct function connection
+            y7 = F.relu(F.relu(x1))
+
+        # Create a new Variable after with statement
+        x2 = nn.Variable((2, 3))
+        assert x2.recompute == False
+
+        # Check recompute flag of forcibly got Pyhon Variable.
+        assert y7.parent.inputs[0].recompute == recompute_flag
+
+        # Check default recompute flag for nn.recompute()
+        with nn.recompute():
+            x = nn.Variable((2, 3))
+            assert x.recompute == True
+
+    # Recompute flag for first nest
+    @pytest.mark.parametrize("f1", [False, True])
+    # Recompute flag for second nest
+    @pytest.mark.parametrize("f2", [False, True])
+    # Recompute flag for third nest
+    @pytest.mark.parametrize("f3", [False, True])
+    def test_nested_with_statement(self, f1, f2, f3):
+        """
+        Test for nested Pyhon `with` statement of recomputation.
+        """
+
+        x0 = nn.Variable((2, 3))
+        assert x0.recompute == False
+
+        # Nest 1
+        with nn.recompute(f1):
+            x1 = nn.Variable((2, 3))
+            x0_1 = x0
+            assert x1.recompute == f1
+            assert x0_1.recompute == False
+
+            # Nest 2
+            with nn.recompute(f2):
+                x2 = nn.Variable((2, 3))
+                x0_2 = x0
+                x1_2 = x1
+                assert x2.recompute == f2
+                assert x0_2.recompute == False
+                assert x1_2.recompute == f1
+
+                # Nest 3
+                with nn.recompute(f3):
+                    x3 = nn.Variable((2, 3))
+                    x0_3 = x0
+                    x1_3 = x1
+                    x2_3 = x2
+                    assert x3.recompute == f3
+                    assert x0_3.recompute == False
+                    assert x1_3.recompute == f1
+                    assert x2_3.recompute == f2
+
+                x2 = nn.Variable((2, 3))
+                x0_2 = x0
+                x1_2 = x1
+                assert x2.recompute == f2
+                assert x0_2.recompute == False
+                assert x1_2.recompute == f1
+
+            x1 = nn.Variable((2, 3))
+            x0_1 = x0
+            assert x1.recompute == f1
+            assert x0_1.recompute == False
+
+        x0 = nn.Variable((2, 3))
+        assert x0.recompute == False
+
+    # Recompute flag for first `with` block
+    @pytest.mark.parametrize("f1", [False, True])
+    # Recompute flag for second `with` block
+    @pytest.mark.parametrize("f2", [False, True])
+    def test_sequential_with_statement(self, f1, f2):
+        """
+        Test for sequential use of with statement.
+        """
+        x = nn.Variable((2, 3))
+        assert x.recompute == False
+
+        # First `with` block
+        with nn.recompute(f1):
+            y = F.relu(x)
+            assert y.recompute == f1
+            y = F.sin(y)
+            assert y.recompute == f1
+
+        assert y.recompute == f1
+
+        y = F.relu(y)
+        assert y.recompute == False
+
+        # Second `with` block
+        with nn.recompute(f2):
+            y = F.relu(x)
+            assert y.recompute == f2
+            y = F.sin(y)
+            assert y.recompute == f2
+
+        assert y.recompute == f2
+
+        y = F.relu(y)
+        assert y.recompute == False
+
+    @pytest.mark.parametrize("recompute_flag", [False, True])
+    def test_recompute_fn_decorator(self, recompute_flag):
+        """
+        Test for setting recompute flags with function decorator `nn.recompute_fn()`.
+        """
+
+        # Specifying recompute flag
+        @nn.recompute_fn(recompute_flag)
+        def func2(x):
+            assert x.recompute == False
+            y = F.relu(x)
+            assert y.recompute == recompute_flag
+            return y
+
+        # Check recompute flags
+        x2 = nn.Variable((2, 3))
+        assert x2.recompute == False
+        y2 = func2(x2)
+        assert y2.recompute == recompute_flag
+
+    def test_recompute_fn_decorator_default_use(self):
+        """
+        Test for setting recompute flags with function decorator `nn.recompute_fn()` without specifying recompute flag.
+        """
+
+        # Default usage
+        @nn.recompute_fn()
+        def func1(x):
+            assert x.recompute == False
+            y = F.relu(x)
+            assert y.recompute == True
+            return y
+
+        # Check recompute flags
+        x1 = nn.Variable((2, 3))
+        assert x1.recompute == False
+        y1 = func1(x1)
+        assert y1.recompute == True
+
+    @pytest.mark.parametrize("recompute_flag", [False, True])
+    def test_recompute_fn_decorator_multiple_inputs_outputs(self, recompute_flag):
+        """
+        Test for the use of `nn.recompute_fn()` with a function which have multiple inputs, outpus, args and kwargs.
+        """
+
+        # Define sample function with multiple inputs and outputs
+        @nn.recompute_fn(recompute_flag)
+        def func(x1, x2, val, axis, reverse=False, alpha=0.2):
+            # Check args and kwargs passed correctly
+            assert val == 3.14
+            assert axis == 0
+            assert reverse == True
+            assert alpha == 0.3
+
+            y1 = F.cumsum(x1, axis, reverse=reverse)
+            y2 = x2 * val
+
+            y3 = y1 + y2
+            y3 = F.leaky_relu(y3, alpha=alpha)
+
+            # Check recompute flags for variables defined inside this function
+            assert y1.recompute == recompute_flag
+            assert y2.recompute == recompute_flag
+            assert y3.recompute == recompute_flag
+
+            return y2, y3
+
+        x1 = nn.Variable((2, 3))
+        x2 = nn.Variable((2, 3))
+
+        y1, y2 = func(x1, x2, 3.14, 0, alpha=0.3, reverse=True)
+        assert y1.recompute == recompute_flag
+        assert y2.recompute == recompute_flag
+
+    # Recompute flag for outer function
+    @pytest.mark.parametrize("f0", [False, True])
+    # Recompute flag for first inner function
+    @pytest.mark.parametrize("f1", [False, True])
+    # Recompute flag for second inner function
+    @pytest.mark.parametrize("f2", [False, True])
+    def test_nested_recompute_fn_decorator(self, f0, f1, f2):
+        """
+        Test for setting recompute flags with nested function decorator `nn.recompute_fn()`.
+        """
+
+        # First sub function
+        @nn.recompute_fn(f1)
+        def func1(x):
+            assert x.recompute == f0
+            y = F.relu(x)
+            assert y.recompute == f1
+            return y
+
+        # Second sub function
+        @nn.recompute_fn(f2)
+        def func2(x):
+            assert x.recompute == f0
+            y = F.sin(x)
+            assert y.recompute == f2
+            return y
+
+        # Main function
+        @nn.recompute_fn(f0)
+        def func0(x):
+            assert x.recompute == False
+            y = F.identity(x)
+            assert y.recompute == f0
+
+            # First inner function call
+            y = func1(y)
+            assert y.recompute == f1
+
+            y = F.relu(y)
+            assert y.recompute == f0
+
+            # Second inner function call
+            y = func2(y)
+            assert y.recompute == f2
+
+            y = F.identity(y)
+            assert y.recompute == f0
+            return y
+
+        # Call main function
+        x = nn.Variable((2, 3))
+        y = func0(x)
+        assert y.recompute == f0
+
 
 @pytest.mark.parametrize("inplace", [True, False])
 @pytest.mark.parametrize("func, num_inputs", [

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -17,6 +17,7 @@
 #include <nbla/computation_graph/function.hpp>
 #include <nbla/computation_graph/variable.hpp>
 #include <nbla/global_function_callback.hpp>
+#include <nbla/recompute.hpp>
 #include <nbla/singleton_manager-internal.hpp>
 
 #include <cstdint>
@@ -89,19 +90,31 @@ void FunctionHookWithObject::operator()(const CgFunctionPtr &f) {
 }
 
 /** CgVariable Implementation **/
-CgVariable::CgVariable() { var_ = make_shared<Variable>(Shape_t{}); }
+CgVariable::CgVariable() {
+  var_ = make_shared<Variable>(Shape_t{});
+  set_recompute(get_global_recompute());
+}
 CgVariable::CgVariable(bool need_grad) : CgVariable() {
   set_need_grad(need_grad);
+  set_recompute(get_global_recompute());
 }
 
-CgVariable::CgVariable(Shape_t shape) { var_ = make_shared<Variable>(shape); }
+CgVariable::CgVariable(Shape_t shape) {
+  var_ = make_shared<Variable>(shape);
+  set_recompute(get_global_recompute());
+}
 CgVariable::CgVariable(Shape_t shape, bool need_grad) : CgVariable(shape) {
   set_need_grad(need_grad);
+  set_recompute(get_global_recompute());
 }
 
-CgVariable::CgVariable(VariablePtr var) { var_ = var; }
+CgVariable::CgVariable(VariablePtr var) {
+  var_ = var;
+  set_recompute(get_global_recompute());
+}
 CgVariable::CgVariable(VariablePtr var, bool need_grad) : CgVariable(var) {
   set_need_grad(need_grad);
+  set_recompute(get_global_recompute());
 }
 
 class ForwardCallback {

--- a/src/nbla/recompute.cpp
+++ b/src/nbla/recompute.cpp
@@ -1,0 +1,40 @@
+// Copyright 2021 Sony Group Corporation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <nbla/recompute.hpp>
+#include <nbla/singleton_manager-internal.hpp>
+
+namespace nbla {
+Recompute::Recompute() : current_(false) {}
+
+Recompute::~Recompute() {}
+
+bool Recompute::get_global_recompute() const { return current_; }
+
+void Recompute::set_global_recompute(bool recompute) { current_ = recompute; }
+
+NBLA_INSTANTIATE_SINGLETON(NBLA_API, Recompute);
+
+// Wrapper function for Recompute::get_global_recompute.
+bool get_global_recompute() {
+  return SingletonManager::get<Recompute>()->get_global_recompute();
+}
+
+// Wrapper functions for Python interface.
+void c_set_global_recompute(const bool recompute) {
+  SingletonManager::get<Recompute>()->set_global_recompute(recompute);
+}
+
+bool c_get_global_recompute() { return get_global_recompute(); }
+}


### PR DESCRIPTION
Support with statement to set recompute flags.
Using `with nn.recompute():`, you can set recompute flag to all variables in the block.

For example, all intermediate variables in `net1` in the below script will be discarded during `forward()` and recomputed during `backward()`.
```python
x = nn.Variable(...)

with nn.recompute():
    h = net1(x)  # all intermediate variables will be set as recompute=True

y = net2(h)

y.forward()  # variables in net1 will be cleared from memory
y.backward()   # variables in net1 will be recomputed when required. 
```