### PR TITLE
Fix recomputation for the function which requires output data for backward computation

### DIFF
--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -904,6 +904,25 @@ class TestRecomputation():
         self.check_recomputation(seed, graph, inputs)
 
     @pytest.mark.parametrize("seed", [313])
+    def test_grad_value_with_output_dependent_function(self, seed):
+        """
+        Gradient values are tested for the function which depends on output data.
+        Here, we test a following case that variable `h` will be recomputed and
+        its data is needed for the `F.swish` backward.
+        x -> F.swish -> h -> F.interpolate -> y
+        """
+        def graph(x0):
+            # F.swish -> F.interpolate
+            x1 = F.swish(x0)
+            x1.apply(recompute=True)
+            x2 = F.interpolate(x1, scale=(2,))
+            return x2
+
+        x = nn.Variable((2, 3), need_grad=True)
+        inputs = (x,)
+        self.check_recomputation(seed, graph, inputs)
+
+    @pytest.mark.parametrize("seed", [313])
     def test_with_persistent_flag(self, seed):
         x = nn.Variable((2, 3), need_grad=True)
 


### PR DESCRIPTION
In previous implementation of recompute, output data required by backward computation is not recomputed unintentionally, which provides wrong values in backward. This PR introduces recomputation of the outputs of each function as well as inputs if required and fixes this problem.

For example, in the code below, h1 should be recomputed during backward.
But, in previous implementation, h1 is not recomputed during backward of F.interpolate since F.interpolate doesn't require the input data for backward computation. After this PR is merged, h1 would be recomputed properly. (we also add the test case for this.)
```
h = ...
h1 = F.swish(h)
h1.apply(recompute=True)
h2 = F.interpolate(h1)

h2.forward(clear_no_need_grad=True)
h2.backward(clear_buffer=True)
```