### PR TITLE
Fix FusedBN not to fall back to cpu implementation always

### DIFF
--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -161,5 +161,12 @@ protected:
     }
     return false;
   }
+
+  NBLA_API virtual void relu_add2_backward(const Variables &inputs,
+                                           const Variables &outputs,
+                                           const vector<bool> &propagate_down,
+                                           const vector<bool> &accum,
+                                           Variable &relu_buf);
 };
+
 } // namespace nbla


### PR DESCRIPTION
Previously, FusedBatachNormalizationCudaCudnn always fall back to cpu implementation except in the case with channel_last & channel_size % 4 == 0. The detail of this is as follows:

* When we call FusedBatchNormCudaCudnn, it is fallen back to FusedBatchNorm except in the case with channel_last && C % 4 == 0 (C is a channel size).
* Before d059fbd, we used F.Relu and F.Add2 in FusedBatchNorm. In this case, when we use cudnn backend, ReluCudaCudnn and Add2CudaCudnn are automatically used as an implementation of them. So these component functions were executed on GPU properly.
* After d059fbd, relu_backward and add2_backward were introduced for FusedBatchNorm. They must always be evaluated on CPU, no matter what backend we use.
This PR introduce FusedBatchNormalizationCuda to avoid this.

ext-cuda: https://github.com/sony/nnabla-ext-cuda/pull/372