### PR TITLE
Add computation graph active inputs handling.

### DIFF
--- a/include/nbla/computation_graph/function.hpp
+++ b/include/nbla/computation_graph/function.hpp
@@ -129,6 +129,10 @@ public:
    */
   inline size_t num_inputs() const { return inputs_.size(); }
 
+  /** Get the i-th input.
+   */
+  inline CgVariablePtr input(size_t i) { return inputs_.at(i); }
+
   /** Get number of outputs.
    */
   inline size_t num_outputs() const { return outputs_.size(); }

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -218,6 +218,10 @@ public:
    */
   inline CgFunctionPtr parent() { return parent_; }
 
+  /** Query if a parent function is set.
+   */
+  inline bool has_parent() { return parent_ != nullptr; }
+
   /** Get variable reference held in this instance.
    */
   inline VariablePtr variable() { return var_; }

--- a/include/nbla/function.hpp
+++ b/include/nbla/function.hpp
@@ -81,6 +81,7 @@ protected:
   Context ctx_;                           ///< Storing context.
   vector<shared_ptr<Shape_t>> in_shapes;  ///< Storing input shapes.
   vector<shared_ptr<Shape_t>> out_shapes; ///< Storing output shapes.
+  vector<bool> cg_input_mask;
 
   /** Fall back function. If this is set at instantiation of Function, behavior
   of the function will be replaced with the fall-back function.
@@ -150,6 +151,15 @@ public:
   @sa setup_recompute()
   */
   void recompute(const Variables &inputs, const Variables &outputs);
+
+  /** Activate or deactivate inputs.
+  */
+  void set_active_input_mask(const vector<bool> &mask);
+
+  /* A flag to indicate if an input shall be considerd as active by the graph
+   * engine during forward and backward.
+   */
+  bool is_active_input(int i) const;
 
   /** Get Context used in this function.
   */

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -42,6 +42,7 @@ cdef extern from "nbla/function.hpp" namespace "nbla":
                       const vector[cpp_bool] &accum) nogil except +
         void setup_recompute(const Variables&, const Variables&) nogil except +
         void recompute(const Variables&, const Variables&) nogil except +
+        void set_active_input_mask(const vector[cpp_bool] mask) nogil except +
         CContext context() except +
         vector[dtypes] in_types()
         vector[dtypes] out_types()

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -229,6 +229,12 @@ cdef class Function:
             list_to_vector_variable_p(inputs),
             list_to_vector_variable_p(outputs))
 
+    def set_active_input_mask(self, mask):
+        cdef vector[cpp_bool] c_mask
+        for elem in mask:
+            c_mask.push_back(bool(elem))
+        self.funp.function().get().set_active_input_mask(c_mask)
+
     @property
     def context(self):
         ccontext = self.funp.function().get().context()

--- a/python/test/function/test_add_n.py
+++ b/python/test/function/test_add_n.py
@@ -58,3 +58,32 @@ def test_add_n_double_backward(num_inputs, seed, ctx, func_name):
                              atol_accum=5e-2,
                              dstep=1e-3,
                              ctx=ctx)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("input_shape", [(2, 3, 4)])
+@pytest.mark.parametrize("n_inputs, n_active", [(3, 1), (5, 2), (10, 6)])
+def test_add_n_active_inputs(n_inputs, n_active, input_shape, seed):
+    from nnabla.testing import assert_allclose
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*input_shape).astype('f4') for _ in range(n_inputs)]
+    active = np.random.permutation(n_inputs) < n_active
+
+    y = F.add_n(*[nn.Variable.from_numpy_array(inp).apply(need_grad=True)
+                  for inp in inputs])
+    y.parent.set_active_input_mask(active)
+    y_ref = F.add_n(*[nn.Variable.from_numpy_array(inp).apply(need_grad=True)
+                      for (act, inp) in zip(active, inputs) if act])
+
+    y.forward()
+    y_ref.forward()
+    assert_allclose(y.d, y_ref.d)
+
+    for inp in y.parent.inputs + y_ref.parent.inputs:
+        inp.g = 0
+
+    y.backward()
+    y_ref.backward()
+    active_inputs = [y.parent.inputs[i] for i, act in enumerate(active) if act]
+    for inp, ref in zip(active_inputs, y_ref.parent.inputs):
+        assert_allclose(inp.g, ref.g)

--- a/python/test/function/test_mul_n.py
+++ b/python/test/function/test_mul_n.py
@@ -14,6 +14,7 @@
 
 import pytest
 import numpy as np
+import nnabla as nn
 import nnabla.functions as F
 from nbla_test_utils import list_context, function_tester
 
@@ -56,3 +57,32 @@ def test_mul_n_double_backward(num_inputs, seed, ctx, func_name):
                              atol_accum=5e-2,
                              dstep=1e-3,
                              ctx=ctx)
+
+
+@pytest.mark.parametrize("seed", [313])
+@pytest.mark.parametrize("input_shape", [(2, 3, 4)])
+@pytest.mark.parametrize("n_inputs, n_active", [(3, 1), (5, 2), (10, 6)])
+def test_mul(n_inputs, n_active, input_shape, seed):
+    from nnabla.testing import assert_allclose
+    rng = np.random.RandomState(seed)
+    inputs = [rng.randn(*input_shape).astype('f4') for _ in range(n_inputs)]
+    active = np.random.permutation(n_inputs) < n_active
+
+    y = F.mul_n(*[nn.Variable.from_numpy_array(inp).apply(need_grad=True)
+                  for inp in inputs])
+    y.parent.set_active_input_mask(active)
+    y_ref = F.mul_n(*[nn.Variable.from_numpy_array(inp).apply(need_grad=True)
+                      for (act, inp) in zip(active, inputs) if act])
+
+    y.forward()
+    y_ref.forward()
+    assert_allclose(y.d, y_ref.d)
+
+    for inp in y.parent.inputs + y_ref.parent.inputs:
+        inp.g = 0
+
+    y.backward()
+    y_ref.backward()
+    active_inputs = [y.parent.inputs[i] for i, act in enumerate(active) if act]
+    for inp, ref in zip(active_inputs, y_ref.parent.inputs):
+        assert_allclose(inp.g, ref.g)

--- a/src/nbla/function/generic/add_n.cpp
+++ b/src/nbla/function/generic/add_n.cpp
@@ -24,38 +24,44 @@ NBLA_REGISTER_FUNCTION_SOURCE(AddN);
 
 template <typename T>
 void AddN<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
-  NBLA_CHECK(inputs.size() >= 2, error_code::value,
-             "minimum 2 inputs must be given");
+  NBLA_CHECK(inputs.size() >= 1, error_code::value,
+             "at least one input should be given");
   for (Variables::size_type i = 1; i < inputs.size(); i++) {
     NBLA_CHECK(inputs[0]->shape() == inputs[i]->shape(), error_code::value,
-               "shape of all inputs must be shame");
+               "shape of all inputs must be identical");
   }
-  outputs[0]->reshape(inputs[0]->shape(), true);
+  //
+  // Set all inputs initially active. This function allows configuration of
+  // inputs as active/inactive via Python set_active_input_mask() function.
+  //
+  cg_input_mask.assign(inputs.size(), true);
+
+  outputs.at(0)->reshape(inputs[0]->shape(), true);
 }
 
 template <typename T>
 void AddN<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
-  T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
-  std::unique_ptr<const T *[]> xs(new const T *[inputs.size()]);
-  for (Variables::size_type i = 0; i < inputs.size(); i++) {
-    xs[i] = inputs[i]->get_data_pointer<T>(this->ctx_);
-  }
-  for (int j = 0; j < inputs[0]->size(); j++) {
-    T val = (T)(0);
-    for (Variables::size_type i = 0; i < inputs.size(); ++i) {
-      val += xs[i][j];
-    }
-    y[j] = val;
-  }
-}
+  auto y = outputs.at(0)->cast_data_and_get_pointer<T>(ctx_, false);
+  Variables::size_type i = 0;
 
-template <typename T, bool accum>
-void addn_backward_cpu(int size, T *dx, const T *dy) {
-  for (int s = 0; s < size; ++s) {
-    if (accum)
-      dx[s] += dy[s];
-    else
-      dx[s] = dy[s];
+  // Copy from first active input.
+  for (; i < inputs.size(); i++) {
+    if (is_active_input(i)) {
+      auto x = inputs[i]->get_data_pointer<T>(ctx_);
+      for (Size_t k = 0; k < outputs[0]->size(); k++) {
+        y[k] = x[k];
+      }
+      break;
+    }
+  }
+  // Add remaining active inputs.
+  for (i++; i < inputs.size(); i++) {
+    if (is_active_input(i)) {
+      auto x = inputs[i]->get_data_pointer<T>(ctx_);
+      for (Size_t k = 0; k < outputs[0]->size(); k++) {
+        y[k] += x[k];
+      }
+    }
   }
 }
 
@@ -63,18 +69,20 @@ template <typename T>
 void AddN<T>::backward_impl(const Variables &inputs, const Variables &outputs,
                             const vector<bool> &propagate_down,
                             const vector<bool> &accum) {
-  if (!(propagate_down[0] || propagate_down[1])) {
-    return;
-  }
-  const T *dy = outputs[0]->get_grad_pointer<T>(this->ctx_);
-  Size_t size = inputs[0]->size();
-  for (Variables::size_type i = 0; i < inputs.size(); ++i) {
-    if (propagate_down[i]) {
-      T *dx = inputs[i]->cast_grad_and_get_pointer<T>(this->ctx_, !(accum[i]));
-      if (accum[i])
-        addn_backward_cpu<T, true>(size, dx, dy);
-      else
-        addn_backward_cpu<T, false>(size, dx, dy);
+  auto dy = outputs.at(0)->get_grad_pointer<T>(ctx_);
+
+  for (Variables::size_type i = 0; i < inputs.size(); i++) {
+    if (is_active_input(i) && propagate_down.at(i)) {
+      auto dx = inputs[i]->cast_grad_and_get_pointer<T>(ctx_, !(accum.at(i)));
+      if (accum.at(i)) {
+        for (Size_t k = 0; k < outputs[0]->size(); k++) {
+          dx[k] += dy[k];
+        }
+      } else {
+        for (Size_t k = 0; k < outputs[0]->size(); k++) {
+          dx[k] = dy[k];
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Add the concept of (in)active inputs to computation graph processing. In an existing computation graph this allows to conditionally exclude selected function inputs from graph processing, effectively disabling computation for the sub-graph leading to the inactive input. Functions supporting this feature can be configured with `set_active_input_mask(List[bool])`, the functions  currently supporting this are `F.add_n` and `F.mul_n`.