### PR TITLE
Enable customizing std types and functions with memory allocation

### DIFF
--- a/examples/cpp/cpp_graph/main.cpp
+++ b/examples/cpp/cpp_graph/main.cpp
@@ -119,5 +119,6 @@ int main() {
     printf("%f\n", data_h[i]);
   }
 
+  SingletonManager::clear();
   return 0;
 }

--- a/examples/cpp/mnist_collection/dcgan_training.hpp
+++ b/examples/cpp/mnist_collection/dcgan_training.hpp
@@ -18,7 +18,6 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include <nbla/auto_forward.hpp>
 #include <nbla/computation_graph/computation_graph.hpp>
@@ -30,13 +29,13 @@ using namespace std;
 
 #include <nbla_utils/parameters.hpp>
 
-using namespace nbla;
+#include "mnist_data.hpp"
+
 namespace f = nbla::functions;
 namespace pf = nbla::parametric_functions;
+using namespace nbla;
 using std::make_shared;
 
-#include "mnist_data.hpp"
-using std::make_shared;
 std::random_device seed_gen;
 std::default_random_engine engine(seed_gen());
 std::normal_distribution<> normal(0.0, 1.0);
@@ -273,7 +272,7 @@ bool dcgan_training_with_static_graph(nbla::Context ctx) {
         print_array(fake);
     }
   } catch (...) {
-    cout << "Exception in dcgan_training_with_static_graph.\n";
+    std::cout << "Exception in dcgan_training_with_static_graph.\n";
     fclose(fp);
     return false;
   }
@@ -404,7 +403,7 @@ bool dcgan_training_with_dynamic_graph(nbla::Context ctx) {
         print_array(fake);
     }
   } catch (...) {
-    cout << "Exception in dcgan_training_with_dynamic_graph.\n";
+    std::cout << "Exception in dcgan_training_with_dynamic_graph.\n";
     fclose(fp);
     return false;
   }

--- a/examples/cpp/mnist_collection/lenet_training.hpp
+++ b/examples/cpp/mnist_collection/lenet_training.hpp
@@ -19,12 +19,9 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include <nbla/computation_graph/computation_graph.hpp>
 #include <nbla/solver/adam.hpp>
-using namespace nbla;
-using std::make_shared;
 
 #include <nbla/auto_forward.hpp>
 #include <nbla/functions.hpp>
@@ -32,11 +29,14 @@ using std::make_shared;
 #include <nbla/parametric_functions.hpp>
 
 #include <nbla_utils/parameters.hpp>
+
+#include "mnist_data.hpp"
+
 namespace f = nbla::functions;
 namespace pf = nbla::parametric_functions;
 namespace utl = nbla::utils;
-
-#include "mnist_data.hpp"
+using namespace nbla;
+using std::make_shared;
 
 /******************************************/
 // Example of Lenet Model Design
@@ -141,7 +141,7 @@ bool lenet_training_with_static_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in lenet_training_with_static_graph.\n";
+    std::cout << "Exception in lenet_training_with_static_graph.\n";
     fclose(fp);
     return false;
   }
@@ -234,7 +234,7 @@ bool lenet_training_with_dynamic_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in lenet_training_with_dynamic_graph.\n";
+    std::cout << "Exception in lenet_training_with_dynamic_graph.\n";
     fclose(fp);
     return false;
   }

--- a/examples/cpp/mnist_collection/mnist_data.hpp
+++ b/examples/cpp/mnist_collection/mnist_data.hpp
@@ -21,11 +21,15 @@
 #include <string>
 #include <vector>
 #include <zlib.h>
-using namespace std;
 
 #include <nbla/computation_graph/variable.hpp>
 #include <nbla/context.hpp>
+
+using std::vector;
+using std::string;
 using std::make_shared;
+using nbla::Context;
+using nbla::CgVariablePtr;
 
 /******************************************/
 // Example of data provider
@@ -37,7 +41,8 @@ vector<vector<uint8_t>> read_images(const string &train,
 
   gzFile fp = gzopen((data_root + filename).c_str(), "rb");
   if (fp == NULL) {
-    cerr << "This sample requires mnist data downloaded before." << endl;
+    std::cerr << "This sample requires mnist data downloaded before."
+              << std::endl;
     exit(0);
   }
 
@@ -71,7 +76,8 @@ vector<uint8_t> read_labels(const string &train, const string &data_root,
 
   gzFile fp = gzopen((data_root + filename).c_str(), "rb");
   if (fp == NULL) {
-    cerr << "This sample requires mnist data downloaded before." << endl;
+    std::cerr << "This sample requires mnist data downloaded before."
+              << std::endl;
     exit(0);
   }
 

--- a/examples/cpp/mnist_collection/resnet_training.hpp
+++ b/examples/cpp/mnist_collection/resnet_training.hpp
@@ -19,12 +19,9 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include <nbla/computation_graph/computation_graph.hpp>
 #include <nbla/solver/adam.hpp>
-using namespace nbla;
-using std::make_shared;
 
 #include <nbla/auto_forward.hpp>
 #include <nbla/functions.hpp>
@@ -33,11 +30,14 @@ using std::make_shared;
 
 #include <nbla_utils/parameters.hpp>
 
+#include "mnist_data.hpp"
+
 namespace f = nbla::functions;
 namespace pf = nbla::parametric_functions;
 namespace utl = nbla::utils;
 
-#include "mnist_data.hpp"
+using namespace nbla;
+using std::make_shared;
 
 /******************************************/
 // Example of ResNet Model Design
@@ -233,7 +233,7 @@ bool resnet_training_with_static_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in resnet_training_with_static_graph.\n";
+    std::cout << "Exception in resnet_training_with_static_graph.\n";
     fclose(fp);
     return false;
   }
@@ -327,7 +327,7 @@ bool resnet_training_with_dynamic_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in resnet_training_with_dynamic_graph.\n";
+    std::cout << "Exception in resnet_training_with_dynamic_graph.\n";
     fclose(fp);
     return false;
   }

--- a/examples/cpp/mnist_collection/siamese_training.hpp
+++ b/examples/cpp/mnist_collection/siamese_training.hpp
@@ -16,23 +16,24 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include <nbla/computation_graph/computation_graph.hpp>
 #include <nbla/solver/adam.hpp>
-using namespace nbla;
-using std::make_shared;
+
 #include <nbla/auto_forward.hpp>
 #include <nbla/functions.hpp>
 #include <nbla/global_context.hpp>
 #include <nbla/parametric_functions.hpp>
 #include <nbla_utils/parameters.hpp>
 
+#include "mnist_data.hpp"
+
 namespace f = nbla::functions;
 namespace pf = nbla::parametric_functions;
 namespace utl = nbla::utils;
 
-#include "mnist_data.hpp"
+using namespace nbla;
+using std::make_shared;
 
 /******************************************/
 // Example of Siamese Model Design
@@ -242,7 +243,7 @@ bool siamese_training_with_static_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in siamese_training_with_static_graph.\n";
+    std::cout << "Exception in siamese_training_with_static_graph.\n";
     fclose(fp);
     return false;
   }
@@ -355,7 +356,7 @@ bool siamese_training_with_dynamic_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in siamese_training_with_dynamic_graph.\n";
+    std::cout << "Exception in siamese_training_with_dynamic_graph.\n";
     fclose(fp);
     return false;
   }

--- a/examples/cpp/mnist_collection/train_dcgan.cpp
+++ b/examples/cpp/mnist_collection/train_dcgan.cpp
@@ -16,9 +16,10 @@
 #include <nbla/context.hpp>
 #include <stdio.h>
 #include <string.h>
-using namespace nbla;
 
 #include "dcgan_training.hpp"
+
+using namespace nbla;
 
 /******************************************/
 // Example of mnist training

--- a/examples/cpp/mnist_collection/train_lenet_classifier.cpp
+++ b/examples/cpp/mnist_collection/train_lenet_classifier.cpp
@@ -16,9 +16,10 @@
 #include <nbla/context.hpp>
 #include <stdio.h>
 #include <string.h>
-using namespace nbla;
 
 #include "lenet_training.hpp"
+
+using namespace nbla;
 
 /******************************************/
 // Example of mnist training

--- a/examples/cpp/mnist_collection/train_resnet_classifier.cpp
+++ b/examples/cpp/mnist_collection/train_resnet_classifier.cpp
@@ -13,12 +13,12 @@
 // limitations under the License.
 // Include nnabla header files
 
+#include "resnet_training.hpp"
 #include <nbla/context.hpp>
 #include <stdio.h>
 #include <string.h>
-using namespace nbla;
 
-#include "resnet_training.hpp"
+using namespace nbla;
 
 /******************************************/
 // Example of mnist training

--- a/examples/cpp/mnist_collection/train_siamese.cpp
+++ b/examples/cpp/mnist_collection/train_siamese.cpp
@@ -16,9 +16,10 @@
 #include <nbla/context.hpp>
 #include <stdio.h>
 #include <string.h>
-using namespace nbla;
 
 #include "siamese_training.hpp"
+
+using namespace nbla;
 
 /******************************************/
 // Example of mnist training

--- a/examples/cpp/mnist_collection/train_vae.cpp
+++ b/examples/cpp/mnist_collection/train_vae.cpp
@@ -16,9 +16,10 @@
 #include <nbla/context.hpp>
 #include <stdio.h>
 #include <string.h>
-using namespace nbla;
 
 #include "vae_training.hpp"
+
+using namespace nbla;
 
 /******************************************/
 // Example of mnist training

--- a/examples/cpp/mnist_collection/train_vat.cpp
+++ b/examples/cpp/mnist_collection/train_vat.cpp
@@ -16,9 +16,10 @@
 #include <nbla/context.hpp>
 #include <stdio.h>
 #include <string.h>
-using namespace nbla;
 
 #include "vat_training.hpp"
+
+using namespace nbla;
 
 /******************************************/
 // Example of mnist training

--- a/examples/cpp/mnist_collection/vae_training.hpp
+++ b/examples/cpp/mnist_collection/vae_training.hpp
@@ -20,12 +20,9 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include <nbla/computation_graph/computation_graph.hpp>
 #include <nbla/solver/adam.hpp>
-using namespace nbla;
-using std::make_shared;
 
 #include <nbla/auto_forward.hpp>
 #include <nbla/functions.hpp>
@@ -34,11 +31,14 @@ using std::make_shared;
 
 #include <nbla_utils/parameters.hpp>
 
+#include "mnist_data.hpp"
+
 namespace f = nbla::functions;
 namespace pf = nbla::parametric_functions;
 namespace utl = nbla::utils;
 
-#include "mnist_data.hpp"
+using namespace nbla;
+using std::make_shared;
 
 /******************************************/
 // Example of Lenet Model Design
@@ -200,7 +200,7 @@ bool vae_training_with_static_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in vae_training_with_static_graph.\n";
+    std::cout << "Exception in vae_training_with_static_graph.\n";
     fclose(fp);
     return false;
   }
@@ -293,7 +293,7 @@ bool vae_training_with_dynamic_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in vae_training_with_dynamic_graph.\n";
+    std::cout << "Exception in vae_training_with_dynamic_graph.\n";
     fclose(fp);
     return false;
   }

--- a/examples/cpp/mnist_collection/vat_training.hpp
+++ b/examples/cpp/mnist_collection/vat_training.hpp
@@ -16,12 +16,10 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
-using namespace std;
 
 #include <nbla/computation_graph/computation_graph.hpp>
 #include <nbla/solver/adam.hpp>
-using namespace nbla;
-using std::make_shared;
+
 #include <nbla/auto_forward.hpp>
 #include <nbla/functions.hpp>
 #include <nbla/global_context.hpp>
@@ -29,11 +27,15 @@ using std::make_shared;
 
 #include <nbla_utils/parameters.hpp>
 
+#include "mnist_data.hpp"
+
 namespace f = nbla::functions;
 namespace pf = nbla::parametric_functions;
 namespace utl = nbla::utils;
 
-#include "mnist_data.hpp"
+using namespace nbla;
+using std::make_shared;
+
 std::random_device seed_gen;
 std::default_random_engine engine(seed_gen());
 std::uniform_real_distribution<> uniform(0.0, 1.0);
@@ -253,7 +255,7 @@ bool vat_training_with_static_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in vat_training_with_static_graph.\n";
+    std::cout << "Exception in vat_training_with_static_graph.\n";
     fclose(fp);
     return false;
   }
@@ -420,7 +422,7 @@ bool vat_training_with_dynamic_graph(nbla::Context ctx) {
       }
     }
   } catch (...) {
-    cout << "Exception in vat_training_with_dynamic_graph.\n";
+    std::cout << "Exception in vat_training_with_dynamic_graph.\n";
     fclose(fp);
     return false;
   }

--- a/examples/cpp/mnist_runtime/mnist_runtime.cpp
+++ b/examples/cpp/mnist_runtime/mnist_runtime.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <nbla/singleton_manager.hpp>
 #include <nbla_utils/nnp.hpp>
 
 #ifdef WITH_CUDA
@@ -174,5 +175,7 @@ int main(int argc, char *argv[]) {
   }
   std::cout << std::endl;
   std::cout << "Prediction: " << prediction << std::endl;
+
+  nbla::SingletonManager::clear();
   return 0;
 }

--- a/examples/cpp/mnist_training/main.cpp
+++ b/examples/cpp/mnist_training/main.cpp
@@ -14,10 +14,11 @@
 
 #include <iostream>
 #include <nbla/context.hpp>
-using namespace std;
-using namespace nbla;
 
 #include "mnist_training.hpp"
+
+using namespace std;
+using namespace nbla;
 
 /******************************************/
 // Example of mnist training

--- a/examples/cpp/mnist_training/mnist_training.hpp
+++ b/examples/cpp/mnist_training/mnist_training.hpp
@@ -21,8 +21,6 @@
 #include <vector>
 #include <zlib.h>
 
-using namespace std;
-
 // Include nnabla header files
 #include <nbla/computation_graph/function.hpp>
 #include <nbla/computation_graph/variable.hpp>
@@ -32,6 +30,8 @@ using namespace std;
 using namespace nbla;
 using namespace utils;
 using namespace nnp;
+using std::vector;
+using std::string;
 
 /******************************************/
 // Example of data provider
@@ -42,7 +42,8 @@ vector<vector<uint8_t>> read_images(const string &data_root,
 
   gzFile fp = gzopen((data_root + filename).c_str(), "rb");
   if (fp == NULL) {
-    cerr << "This sample requires mnist data downloaded before." << endl;
+    std::cerr << "This sample requires mnist data downloaded before."
+              << std::endl;
     exit(0);
   }
 
@@ -71,7 +72,8 @@ vector<uint8_t> read_labels(const string &data_root, const string &filename) {
 
   gzFile fp = gzopen((data_root + filename).c_str(), "rb");
   if (fp == NULL) {
-    cerr << "This sample requires mnist data downloaded before." << endl;
+    std::cerr << "This sample requires mnist data downloaded before."
+              << std::endl;
     exit(0);
   }
 

--- a/include/nbla/array.hpp
+++ b/include/nbla/array.hpp
@@ -39,7 +39,7 @@ namespace nbla {
 
 This is extended to implement a new array class (see CpuArray, CudaArray etc.).
 */
-class Array : public std::enable_shared_from_this<Array> {
+class Array : public enable_shared_from_this<Array> {
 protected:
   /// Size of array.
   Size_t size_;

--- a/include/nbla/array_registry.hpp
+++ b/include/nbla/array_registry.hpp
@@ -27,9 +27,6 @@
 
 namespace nbla {
 
-using std::shared_ptr;
-using std::string;
-using std::map;
 using std::pair;
 
 /** Array classes which can be get/cast without copy. */
@@ -56,8 +53,8 @@ private:
 /** ArrayCreator class this is never be instantiated. */
 class NBLA_API ArrayCreator {
 public:
-  typedef std::function<Array *(const Size_t, dtypes, const Context &)> Creator;
-  typedef std::function<Context(const Context &ctx)> FilterContext;
+  typedef function<Array *(const Size_t, dtypes, const Context &)> Creator;
+  typedef function<Context(const Context &ctx)> FilterContext;
   typedef map<string, pair<Creator, FilterContext>> Registry_t;
 
   /** Interface to create array */
@@ -85,7 +82,7 @@ private:
 */
 class NBLA_API ArraySynchronizer {
 public:
-  typedef std::function<void(Array *, Array *, const int)> Synchronizer;
+  typedef function<void(Array *, Array *, const int)> Synchronizer;
   typedef map<pair<string, string>, Synchronizer> Registry_t;
 
   /** Synchronize array
@@ -123,9 +120,9 @@ NBLA_API void synchronizer_default(Array *src, Array *dst,
 
 #define NBLA_REGISTER_ARRAY_CREATOR(CLS)                                       \
   {                                                                            \
-    std::function<Array *(const Size_t, dtypes, const Context &)> func =       \
+    function<Array *(const Size_t, dtypes, const Context &)> func =            \
         [](const Size_t size, dtypes dtype, const Context &ctx) {              \
-          return new CLS(size, dtype, ctx);                                    \
+          return new_object<CLS>(size, dtype, ctx);                            \
         };                                                                     \
     ArrayCreator::add_creator(#CLS, func, CLS::filter_context);                \
   }

--- a/include/nbla/backend_base.hpp
+++ b/include/nbla/backend_base.hpp
@@ -25,10 +25,6 @@
 
 namespace nbla {
 
-using std::vector;
-using std::string;
-using std::shared_ptr;
-
 /**
 Base class of singleton classes for storing some handles or
 configs for computation on a backend.

--- a/include/nbla/backend_registry.hpp
+++ b/include/nbla/backend_registry.hpp
@@ -28,17 +28,13 @@
 
 namespace nbla {
 
-using std::string;
-using std::unordered_map;
-using std::shared_ptr;
-
 /** BackendUtils class
 
 This class is never be instantiated.
  */
 class NBLA_API BackendUtils {
 public:
-  typedef std::function<BackendBase *(void)> BackendGetter;
+  typedef function<BackendBase *(void)> BackendGetter;
   typedef unordered_map<string, BackendGetter> Registry_t;
 
   /** Register new synchronizer

--- a/include/nbla/common.hpp
+++ b/include/nbla/common.hpp
@@ -37,10 +37,6 @@ maybe because they are uncategorized.
 
 namespace nbla {
 
-using std::vector;
-using std::ostringstream;
-using std::shared_ptr;
-
 typedef vector<int64_t> Shape_t; ///< Type of array shape and strides etc.
 typedef int64_t Size_t;          ///< Type of size of array
 
@@ -107,7 +103,7 @@ inline string byte_to_human_readable(long double byte) {
     byte /= div;
   }
 
-  std::ostringstream out;
+  ostringstream out;
   out.precision(2);
   out << std::fixed << byte;
 
@@ -117,10 +113,10 @@ inline string byte_to_human_readable(long double byte) {
 /** Scoped callback
 */
 class DestructorCallback {
-  std::function<void(void)> callback_;
+  function<void(void)> callback_;
 
 public:
-  inline DestructorCallback(std::function<void(void)> callback)
+  inline DestructorCallback(function<void(void)> callback)
       : callback_(callback) {}
   inline ~DestructorCallback() { callback_(); }
 };

--- a/include/nbla/communicator.hpp
+++ b/include/nbla/communicator.hpp
@@ -27,11 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-using std::shared_ptr;
-using std::unordered_map;
-
 /** \addtogroup NNablaCoreGrp */
 /*@{*/
 

--- a/include/nbla/communicator/data_parallel_communicator.hpp
+++ b/include/nbla/communicator/data_parallel_communicator.hpp
@@ -29,11 +29,6 @@ namespace nbla {
 
 NBLA_REGISTER_COMMUNICATOR_HEADER(DataParallelCommunicator);
 
-using std::string;
-using std::vector;
-using std::shared_ptr;
-using std::unordered_map;
-
 /** \addtogroup NNablaCoreGrp */
 /*@{*/
 

--- a/include/nbla/communicator/multi_process_data_parallel_communicator.hpp
+++ b/include/nbla/communicator/multi_process_data_parallel_communicator.hpp
@@ -29,11 +29,7 @@ namespace nbla {
 
 NBLA_REGISTER_COMMUNICATOR_HEADER(MultiProcessDataParallelCommunicator);
 
-using std::string;
-using std::vector;
 using std::pair;
-using std::shared_ptr;
-using std::unordered_map;
 
 /** \addtogroup NNablaCoreGrp */
 /*@{*/

--- a/include/nbla/communicator_registry.hpp
+++ b/include/nbla/communicator_registry.hpp
@@ -56,15 +56,15 @@ This will be used inside init method.
 */
 #define NBLA_REGISTER_COMMUNICATOR_IMPL(BASE, CLS, BACKEND, ...)               \
   {                                                                            \
-    std::function<shared_ptr<Communicator>(                                    \
+    function<shared_ptr<Communicator>(                                         \
         const Context &NBLA_VA_ARGS(__VA_ARGS__))>                             \
         func = [](NBLA_ARGDEFS(const Context &NBLA_VA_ARGS(__VA_ARGS__))) {    \
-          return shared_ptr<Communicator>(                                     \
-              new CLS(NBLA_ARGS(const Context &NBLA_VA_ARGS(__VA_ARGS__))));   \
+          return make_shared<CLS>(                                             \
+              NBLA_ARGS(const Context &NBLA_VA_ARGS(__VA_ARGS__)));            \
         };                                                                     \
     typedef FunctionDbItem<Communicator NBLA_VA_ARGS(__VA_ARGS__)> item_t;     \
     get_##BASE##CommunicatorRegistry().add(                                    \
-        shared_ptr<item_t>(new item_t{BACKEND, func}));                        \
+        make_shared<item_t>(BACKEND, func));                                   \
   }
 #else
 /**
@@ -95,14 +95,13 @@ This will be used inside init method.
 */
 #define NBLA_REGISTER_COMMUNICATOR_IMPL(BASE, CLS, BACKEND, ...)               \
   {                                                                            \
-    std::function<shared_ptr<Communicator>(const Context &, ##__VA_ARGS__)>    \
-        func = [](NBLA_ARGDEFS(const Context &, ##__VA_ARGS__)) {              \
-          return shared_ptr<Communicator>(                                     \
-              new CLS(NBLA_ARGS(const Context &, ##__VA_ARGS__)));             \
+    function<shared_ptr<Communicator>(const Context &, ##__VA_ARGS__)> func =  \
+        [](NBLA_ARGDEFS(const Context &, ##__VA_ARGS__)) {                     \
+          return make_shared<CLS>(NBLA_ARGS(const Context &, ##__VA_ARGS__));  \
         };                                                                     \
     typedef FunctionDbItem<Communicator, ##__VA_ARGS__> item_t;                \
     get_##BASE##CommunicatorRegistry().add(                                    \
-        shared_ptr<item_t>(new item_t{BACKEND, func}));                        \
+        make_shared<item_t>(BACKEND, func));                                   \
   }
 #endif
 }

--- a/include/nbla/computation_graph/computation_graph.hpp
+++ b/include/nbla/computation_graph/computation_graph.hpp
@@ -112,8 +112,7 @@ public:
       auto c = SingletonManager::get<GlobalClearBufferState>()->clear_buffer();
       @endcode
    */
-  std::unique_ptr<ScopedState> state(bool clear_buffer,
-                                     bool clear_no_need_grad);
+  unique_ptr<ScopedState> state(bool clear_buffer, bool clear_no_need_grad);
 
 private:
   friend SingletonManager;

--- a/include/nbla/computation_graph/function.hpp
+++ b/include/nbla/computation_graph/function.hpp
@@ -43,7 +43,7 @@ class CgFunction {
   /* Wrapper object of output CgVariable.
    */
   struct OutputWrapper {
-    std::weak_ptr<CgVariable> weak_reference;
+    weak_ptr<CgVariable> weak_reference;
     /*
       Output variables are weakly referenced to avoid circular dependencies,
       which means output variables may be deleted before it is used.

--- a/include/nbla/computation_graph/variable.hpp
+++ b/include/nbla/computation_graph/variable.hpp
@@ -26,10 +26,6 @@
 
 namespace nbla {
 
-using std::unordered_map;
-using std::unordered_set;
-using std::string;
-
 // Forward declaration
 class CgFunction;
 typedef shared_ptr<CgFunction> CgFunctionPtr;
@@ -43,7 +39,7 @@ struct CommunicatorBackwardCallback {
 typedef shared_ptr<CommunicatorBackwardCallback>
     CommunicatorBackwardCallbackPtr;
 
-typedef std::function<void(const CgFunctionPtr &ptr)> function_hook_type;
+typedef function<void(const CgFunctionPtr &ptr)> function_hook_type;
 
 /** Callback helper class for function callbacks during forward and backward
 class.
@@ -52,9 +48,9 @@ This is used from Python frontend.
  */
 class FunctionHookWithObject {
 public:
-  typedef std::function<void(void *)> setup_callback_type;
-  typedef std::function<void(void *)> cleanup_callback_type;
-  typedef std::function<void(void *, const CgFunctionPtr &f)> callback_type;
+  typedef function<void(void *)> setup_callback_type;
+  typedef function<void(void *)> cleanup_callback_type;
+  typedef function<void(void *, const CgFunctionPtr &f)> callback_type;
 
 private:
   void *obj_{nullptr};
@@ -99,8 +95,7 @@ class CgVariable {
   CgFunctionPtr parent_{nullptr}; ///< Function created this variable.
   int rank_{0};                   ///< Longest path from root variable.
   ///< Holds weak function references. <https://stackoverflow.com/a/22110715>
-  unordered_map<CgFunction *,
-                pair<std::weak_ptr<CgFunction>, FunctionReferenceInfo>>
+  unordered_map<CgFunction *, pair<weak_ptr<CgFunction>, FunctionReferenceInfo>>
       function_references_;
   size_t function_reference_count_{0}; ///< Number of function references
   bool allow_modify_data_{true};       ///< Whether the data can be in-placed.
@@ -356,16 +351,15 @@ public:
 
   /** Execute callback at functions in forward order in a graph.
    */
-  void
-  visit_function_recursive(CgFunctionPtr func,
-                           unordered_set<CgFunctionPtr> &fclosed,
-                           const bool recomputation,
-                           std::function<void(CgFunctionPtr)> forward_callback);
+  void visit_function_recursive(CgFunctionPtr func,
+                                unordered_set<CgFunctionPtr> &fclosed,
+                                const bool recomputation,
+                                function<void(CgFunctionPtr)> forward_callback);
 
   /** Execute callback at functions in backward order in a graph.
    */
   void visit_function_backward(
-      CgFunctionPtr func, std::function<void(CgFunctionPtr)> backward_callback,
+      CgFunctionPtr func, function<void(CgFunctionPtr)> backward_callback,
       vector<CommunicatorBackwardCallbackPtr> communicator_callbacks);
 };
 
@@ -382,8 +376,8 @@ class ClearCalledFlagRecorder {
 
   bool is_activated_{false};
 
-  std::vector<std::vector<std::pair<bool, bool>>> recorded_input_clear_flags_;
-  std::vector<std::vector<std::pair<bool, bool>>> recorded_output_clear_flags_;
+  vector<vector<std::pair<bool, bool>>> recorded_input_clear_flags_;
+  vector<vector<std::pair<bool, bool>>> recorded_output_clear_flags_;
 
 public:
   ~ClearCalledFlagRecorder();
@@ -401,20 +395,18 @@ public:
   void record(const CgFunctionPtr func);
 
   /** Get recorded clear flags. */
-  std::vector<std::vector<std::pair<bool, bool>>>
-  get_recorded_input_clear_flags() const;
+  vector<vector<std::pair<bool, bool>>> get_recorded_input_clear_flags() const;
 
   /** Get recorded clear flags. */
-  std::vector<std::vector<std::pair<bool, bool>>>
-  get_recorded_output_clear_flags() const;
+  vector<vector<std::pair<bool, bool>>> get_recorded_output_clear_flags() const;
 
 private:
   friend SingletonManager; // needs forward declaration
                            // Never called by users.
   ClearCalledFlagRecorder();
 
-  std::vector<std::pair<bool, bool>>
-  get_variable_clear_called_flag(const std::vector<CgVariablePtr> &vars);
+  vector<std::pair<bool, bool>>
+  get_variable_clear_called_flag(const vector<CgVariablePtr> &vars);
 
   DISABLE_COPY_AND_ASSIGN(ClearCalledFlagRecorder);
 };
@@ -423,10 +415,9 @@ NBLA_API void c_activate_clear_called_flag_recorder();
 
 NBLA_API void c_deactivate_clear_called_flag_recorder();
 
-NBLA_API std::vector<std::vector<std::pair<bool, bool>>>
-c_get_input_clear_called_flags();
+NBLA_API vector<vector<std::pair<bool, bool>>> c_get_input_clear_called_flags();
 
-NBLA_API std::vector<std::vector<std::pair<bool, bool>>>
+NBLA_API vector<vector<std::pair<bool, bool>>>
 c_get_output_clear_called_flags();
 }
 #endif

--- a/include/nbla/context.hpp
+++ b/include/nbla/context.hpp
@@ -23,9 +23,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-
 /** Context structure
 
 It will be used specifying device and array class etc.

--- a/include/nbla/cpu.hpp
+++ b/include/nbla/cpu.hpp
@@ -24,10 +24,6 @@
 
 namespace nbla {
 
-using std::vector;
-using std::string;
-using std::unique_ptr;
-
 /**
 Singleton class for storing some handles or configs for CPU Computation.
 */

--- a/include/nbla/defs.hpp
+++ b/include/nbla/defs.hpp
@@ -34,4 +34,6 @@
 // Helper macro to get this class type
 // To use this, <type_traits> must be included before using it.
 #define NBLA_THIS_TYPE std::remove_pointer<decltype(this)>::type
+
+#include <nbla/std.hpp>
 #endif

--- a/include/nbla/event.hpp
+++ b/include/nbla/event.hpp
@@ -23,8 +23,6 @@
 
 namespace nbla {
 
-using std::shared_ptr;
-
 class NBLA_API Event {
 public:
   Event() {}

--- a/include/nbla/exception.hpp
+++ b/include/nbla/exception.hpp
@@ -32,9 +32,7 @@
 #include <vector>
 
 namespace nbla {
-using std::string;
 using std::snprintf;
-using std::vector;
 
 /** In NNabla, exceptions are thrown through this macro. Error codes are
     defined in enum class nbla::error_code. See also NBLA_CHECK.

--- a/include/nbla/function.hpp
+++ b/include/nbla/function.hpp
@@ -27,10 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-using std::shared_ptr;
-using std::make_shared;
 using std::tuple;
 using std::get;
 

--- a/include/nbla/function/affine.hpp
+++ b/include/nbla/function/affine.hpp
@@ -27,8 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-
 NBLA_REGISTER_FUNCTION_HEADER(Affine, int);
 
 /** Affine also called as fully connected layer defined as

--- a/include/nbla/function/batch_normalization.hpp
+++ b/include/nbla/function/batch_normalization.hpp
@@ -33,8 +33,6 @@
 #include <nbla/imperative.hpp>
 #include <vector>
 
-using std::vector;
-
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_HEADER(BatchNormalization, const vector<int> &, float,

--- a/include/nbla/function/binary_connect_affine.hpp
+++ b/include/nbla/function/binary_connect_affine.hpp
@@ -28,8 +28,6 @@
 
 namespace nbla {
 
-using std::string;
-
 NBLA_REGISTER_FUNCTION_HEADER(BinaryConnectAffine, int, float);
 
 /** BinaryConnectAffine

--- a/include/nbla/function/binary_connect_convolution.hpp
+++ b/include/nbla/function/binary_connect_convolution.hpp
@@ -28,9 +28,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-
 NBLA_REGISTER_FUNCTION_HEADER(BinaryConnectConvolution,
                               int,                 // base_axis
                               const vector<int> &, // pad

--- a/include/nbla/function/callback.hpp
+++ b/include/nbla/function/callback.hpp
@@ -25,8 +25,6 @@
 
 namespace nbla {
 
-using std::string;
-
 /** A callback Function.
 
 The callback functions of setup_impl, forward_impl and backward_mpl registered
@@ -36,21 +34,21 @@ at initialization are called.
 class Callback : public BaseFunction<> {
 
 public:
-  typedef std::function<void(void *, const Variables &inputs,
-                             const Variables &outputs)>
+  typedef function<void(void *, const Variables &inputs,
+                        const Variables &outputs)>
       setup_callback_type;
-  typedef std::function<void(void *, const Variables &inputs,
-                             const Variables &outputs)>
+  typedef function<void(void *, const Variables &inputs,
+                        const Variables &outputs)>
       forward_callback_type;
-  typedef std::function<void(
+  typedef function<void(
       void *, const Variables &inputs, const Variables &outputs,
       const vector<bool> &propagate_down, const vector<bool> &accum)>
       backward_callback_type;
-  typedef std::function<void(void *)> cleanup_callback_type;
+  typedef function<void(void *)> cleanup_callback_type;
 
-  typedef std::function<bool(void *, int, int)>
+  typedef function<bool(void *, int, int)>
       grad_depends_output_data_callback_type;
-  typedef std::function<bool(void *, int, int)>
+  typedef function<bool(void *, int, int)>
       grad_depends_input_data_callback_type;
 
 private:
@@ -83,7 +81,7 @@ public:
         grad_depends_input_data_callback_(gi) {}
   virtual ~Callback() { cleanup_callback_(obj_); }
   virtual shared_ptr<Function> copy() const {
-    return std::make_shared<Callback>(
+    return make_shared<Callback>(
         ctx_, obj_, min_outputs_, setup_callback_, forward_callback_,
         backward_callback_, cleanup_callback_,
         grad_depends_output_data_callback_, grad_depends_input_data_callback_);
@@ -97,9 +95,7 @@ public:
     return vector<dtypes>{get_dtype<float>()};
   }
   virtual string name() { return "Callback"; }
-  virtual vector<string> allowed_array_classes() {
-    return SingletonManager::get<Cpu>()->array_classes();
-  }
+  NBLA_API virtual vector<string> allowed_array_classes();
   virtual bool grad_depends_output_data(int i, int o) const {
     if (!grad_depends_output_data_callback_)
       return true;

--- a/include/nbla/function/categorical_cross_entropy.hpp
+++ b/include/nbla/function/categorical_cross_entropy.hpp
@@ -27,9 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::make_shared;
-
 NBLA_REGISTER_FUNCTION_HEADER(CategoricalCrossEntropy, int);
 
 /** CategoricalCrossEntropy calculate the element-wise cross entropy between the

--- a/include/nbla/function/convolution.hpp
+++ b/include/nbla/function/convolution.hpp
@@ -27,9 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-
 NBLA_REGISTER_FUNCTION_HEADER(Convolution, int,    // base_axis
                               const vector<int> &, // pad
                               const vector<int> &, // stride

--- a/include/nbla/function/crelu.hpp
+++ b/include/nbla/function/crelu.hpp
@@ -27,8 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-
 NBLA_REGISTER_FUNCTION_HEADER(CReLU, int);
 
 /** Concatenated Rectified Linear Unit (CReLU) concatenates ReLU outputs of

--- a/include/nbla/function/deconvolution.hpp
+++ b/include/nbla/function/deconvolution.hpp
@@ -27,9 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-
 NBLA_REGISTER_FUNCTION_HEADER(Deconvolution, int,   // base_axis
                               const vector<int> &,  // pad
                               const vector<int> &,  // stride

--- a/include/nbla/function/deformable_convolution.hpp
+++ b/include/nbla/function/deformable_convolution.hpp
@@ -25,9 +25,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-
 NBLA_REGISTER_FUNCTION_HEADER(DeformableConvolution, int, // base_axis
                               const vector<int> &,        // pad
                               const vector<int> &,        // stride

--- a/include/nbla/function/dropout.hpp
+++ b/include/nbla/function/dropout.hpp
@@ -28,8 +28,6 @@
 
 namespace nbla {
 
-using std::string;
-
 NBLA_REGISTER_FUNCTION_HEADER(Dropout, double, int);
 
 /** Dropout defined as

--- a/include/nbla/function/flip.hpp
+++ b/include/nbla/function/flip.hpp
@@ -66,7 +66,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
 
-  std::vector<int> &axes() { return axes_; }
+  vector<int> &axes() { return axes_; }
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:
@@ -83,9 +83,8 @@ protected:
   }
 
 private:
-  void flip_recursive(Variable *inp, const T *x, T *y,
-                      const std::vector<bool> &flip, bool add, int x_offset,
-                      int y_offset, int dim);
+  void flip_recursive(Variable *inp, const T *x, T *y, const vector<bool> &flip,
+                      bool add, int x_offset, int y_offset, int dim);
 };
 }
 #endif

--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -26,8 +26,6 @@
 
 namespace nbla {
 
-using std::vector;
-
 NBLA_REGISTER_FUNCTION_HEADER(FusedBatchNormalization, const vector<int> &,
                               float, float, bool, const string &);
 

--- a/include/nbla/function/fused_convolution.hpp
+++ b/include/nbla/function/fused_convolution.hpp
@@ -130,7 +130,7 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
 
-  std::unordered_map<InName, std::pair<int, Variable *>> input_variables_;
+  unordered_map<InName, std::pair<int, Variable *>> input_variables_;
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     if (input_variables_.find(GAMMA) != input_variables_.end())
       return true;
@@ -152,7 +152,7 @@ protected:
 
 private:
   // Members only used in a naive implementation with composite
-  std::unordered_map<InName, CgVariablePtr> input_cg_variables_;
+  unordered_map<InName, CgVariablePtr> input_cg_variables_;
   CgVariablePtr last_output_cg_variable_;
   bool reset_cg_variables(const Variables &inputs, const Variables &outputs);
 };

--- a/include/nbla/function/identity.hpp
+++ b/include/nbla/function/identity.hpp
@@ -27,8 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-
 NBLA_REGISTER_FUNCTION_HEADER(Identity);
 
 /** Identify outputs the input as-is. There is no need to use this layer

--- a/include/nbla/function/leaky_relu.hpp
+++ b/include/nbla/function/leaky_relu.hpp
@@ -27,8 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-
 NBLA_REGISTER_FUNCTION_HEADER(LeakyReLU, float, bool);
 
 /** Leaky Rectified Linear Unit (LeakyReLU) defined as

--- a/include/nbla/function/mean_subtraction.hpp
+++ b/include/nbla/function/mean_subtraction.hpp
@@ -24,8 +24,6 @@
 
 #include <vector>
 
-using std::vector;
-
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_HEADER(MeanSubtraction, int, bool);

--- a/include/nbla/function/pad.hpp
+++ b/include/nbla/function/pad.hpp
@@ -52,7 +52,7 @@ Outputs:
  */
 
 typedef struct { int first, second; } PadItem;
-typedef std::vector<PadItem> PadList;
+typedef vector<PadItem> PadList;
 
 template <typename T>
 class Pad : public BaseFunction<const vector<int> &, const string &, float> {

--- a/include/nbla/function/quantize_linear.hpp
+++ b/include/nbla/function/quantize_linear.hpp
@@ -88,7 +88,7 @@ protected:
     // future.
     return true;
   }
-  NBLA_API virtual void round(Variable *inp, std::string round_mode);
+  NBLA_API virtual void round(Variable *inp, string round_mode);
   NBLA_API virtual void saturate(Variable *inp, int min_range, int max_range);
 };
 }

--- a/include/nbla/function/relu.hpp
+++ b/include/nbla/function/relu.hpp
@@ -27,8 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-
 NBLA_REGISTER_FUNCTION_HEADER(ReLU, bool);
 
 /** Rectified Linear Unit (ReLU) defined as

--- a/include/nbla/function/shift.hpp
+++ b/include/nbla/function/shift.hpp
@@ -67,7 +67,7 @@ public:
     return SingletonManager::get<Cpu>()->array_classes();
   }
 
-  std::vector<int> &shifts() { return shifts_; }
+  vector<int> &shifts() { return shifts_; }
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
 
 protected:

--- a/include/nbla/function/softmax.hpp
+++ b/include/nbla/function/softmax.hpp
@@ -27,9 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::make_shared;
-
 NBLA_REGISTER_FUNCTION_HEADER(Softmax, int);
 
 /** Softmax normalization defined as

--- a/include/nbla/function/softmax_cross_entropy.hpp
+++ b/include/nbla/function/softmax_cross_entropy.hpp
@@ -27,9 +27,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::make_shared;
-
 NBLA_REGISTER_FUNCTION_HEADER(SoftmaxCrossEntropy, int);
 
 /** SoftmaxCrossEntropy calculate the element-wise cross entropy between the

--- a/include/nbla/function/sync_batch_normalization.hpp
+++ b/include/nbla/function/sync_batch_normalization.hpp
@@ -26,14 +26,11 @@
 
 #include <vector>
 
-using std::vector;
-
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_HEADER(SyncBatchNormalization,
-                              const std::shared_ptr<Communicator> &,
-                              const std::string &, const vector<int> &, float,
-                              float, bool);
+                              const shared_ptr<Communicator> &, const string &,
+                              const vector<int> &, float, float, bool);
 
 /** Batch normalization with sync between other processes at training time
 defined as
@@ -74,14 +71,14 @@ https://hangzhang.org/PyTorch-Encoding/notes/syncbn.html
 template <typename T>
 class SyncBatchNormalization : public BatchNormalization<T> {
 protected:
-  std::shared_ptr<Communicator> comm_;
-  std::string group_;
+  shared_ptr<Communicator> comm_;
+  string group_;
   size_t num_processes_;
 
 public:
   SyncBatchNormalization(const Context &ctx,
-                         const std::shared_ptr<Communicator> &comm,
-                         const std::string &group, const vector<int> axes,
+                         const shared_ptr<Communicator> &comm,
+                         const string &group, const vector<int> axes,
                          float decay_rate, float eps, bool batch_stat)
       : BatchNormalization<T>(ctx, axes, decay_rate, eps, batch_stat,
                               false /* no_scale */, false /* no_bias */),

--- a/include/nbla/function/tensor_normalization.hpp
+++ b/include/nbla/function/tensor_normalization.hpp
@@ -144,8 +144,7 @@ protected:
   bool output_stat_;
   bool need_adapter_;
   Shape_t bn_param_shape_;
-  std::unique_ptr<BatchNormalizationInOutAdapter> bn_in_adapter_,
-      bn_param_adapter_;
+  unique_ptr<BatchNormalizationInOutAdapter> bn_in_adapter_, bn_param_adapter_;
   shared_ptr<Function> f_batch_norm_;
 
 public:

--- a/include/nbla/function/utils/base_pooling.hpp
+++ b/include/nbla/function/utils/base_pooling.hpp
@@ -30,8 +30,6 @@ namespace nbla {
 
 using std::ceil;
 
-using std::vector;
-
 /**
    Get output shape of pooling from input configuration.
  */

--- a/include/nbla/function/utils/channel_first_adaptor.hpp
+++ b/include/nbla/function/utils/channel_first_adaptor.hpp
@@ -21,7 +21,6 @@
 #include <nbla/function/transpose.hpp>
 
 namespace nbla {
-using std::vector;
 
 /**
  * @brief This class can be used to transform a variable memory format to
@@ -150,7 +149,7 @@ public:
                                                     const bool accum);
 };
 
-using ChannelFirstAdaptorPtr = std::shared_ptr<ChannelFirstAdaptor>;
+using ChannelFirstAdaptorPtr = shared_ptr<ChannelFirstAdaptor>;
 }
 
 #endif

--- a/include/nbla/function/utils/rnn.hpp
+++ b/include/nbla/function/utils/rnn.hpp
@@ -20,7 +20,6 @@
 #include <nbla/function_registry.hpp>
 
 namespace nbla {
-namespace function {
 namespace utils {
 namespace rnn {
 
@@ -237,7 +236,6 @@ inline void unpack_batch_first(const U *packed_sequence, const int *batch_sizes,
 
 } // rnn
 } // utils
-} // function
 } // nbla
 
 #endif

--- a/include/nbla/garbage_collector.hpp
+++ b/include/nbla/garbage_collector.hpp
@@ -22,7 +22,6 @@
 #include <vector>
 
 namespace nbla {
-using std::vector;
 
 /** Singleton for garbage collector registry.
 
@@ -34,7 +33,7 @@ using std::vector;
  */
 class NBLA_API GarbageCollector {
 public:
-  typedef std::function<void()> collector_type;
+  typedef function<void()> collector_type;
 
   /** Register a GC function with a form `void ()`.
    */

--- a/include/nbla/global_function_callback.hpp
+++ b/include/nbla/global_function_callback.hpp
@@ -25,7 +25,7 @@ using std::pair;
 // Forward declaration
 class CgFunction;
 typedef shared_ptr<CgFunction> CgFunctionPtr;
-typedef std::function<void(const CgFunctionPtr &ptr)> function_hook_type;
+typedef function<void(const CgFunctionPtr &ptr)> function_hook_type;
 
 /**
 Singleton class for storing global function callbacks.

--- a/include/nbla/global_solver_callback.hpp
+++ b/include/nbla/global_solver_callback.hpp
@@ -20,7 +20,7 @@
 
 namespace nbla {
 
-typedef std::function<void(void)> update_hook_type;
+typedef function<void(void)> update_hook_type;
 
 /**
 Singleton class for storing global function callbacks.

--- a/include/nbla/init.hpp
+++ b/include/nbla/init.hpp
@@ -22,9 +22,6 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-
 /**
 Initialize NNabla CPU features.
 

--- a/include/nbla/lms/swap_in_out_scheduler.hpp
+++ b/include/nbla/lms/swap_in_out_scheduler.hpp
@@ -41,14 +41,9 @@ template <> struct hash<nbla::dtypes> {
 
 namespace nbla {
 
-using std::vector;
-using std::unordered_map;
-using std::string;
 using std::accumulate;
-using std::weak_ptr;
 using std::reference_wrapper;
 using std::pair;
-using std::set;
 
 /** A class which manages GPU memory usage and schedules swap in/out
     throughout network computation.

--- a/include/nbla/memory/allocator.hpp
+++ b/include/nbla/memory/allocator.hpp
@@ -26,9 +26,6 @@
 
 namespace nbla {
 
-using std::unordered_map;
-using std::unique_ptr;
-
 // Forward declaration
 class Allocator;
 
@@ -121,7 +118,7 @@ public:
     @note A Allocator instance must be instantiated as a shared_ptr.
     @todo Support streams or events.
  */
-class NBLA_API Allocator : public std::enable_shared_from_this<Allocator> {
+class NBLA_API Allocator : public enable_shared_from_this<Allocator> {
 protected:
   unique_ptr<AllocatorCallback>
       callback_; ///< Callback could be set in a derived class.
@@ -132,7 +129,7 @@ protected:
 public:
   typedef unordered_map<string, int> MemCountMap;
 
-  std::function<void(void)> callback_tmp_ = nullptr;
+  function<void(void)> callback_tmp_ = nullptr;
 
   /** Constructor does nothing.
    */

--- a/include/nbla/memory/caching_allocator_with_buckets.hpp
+++ b/include/nbla/memory/caching_allocator_with_buckets.hpp
@@ -23,10 +23,7 @@
 
 namespace nbla {
 
-using std::map;
-using std::unordered_map;
 using std::tuple;
-using std::make_shared;
 
 /** A base class of CachingAllocatorWithBuckets.
 
@@ -142,7 +139,7 @@ class CachingAllocatorWithBuckets : public CachingAllocatorWithBucketsBase {
 public:
   CachingAllocatorWithBuckets() : CachingAllocatorWithBucketsBase() {
 #if 0
-    this->callback_.reset(new PrintingAllocatorCallback(
+    this->callback_.reset(new_object<PrintingAllocatorCallback>(
         typeid(CachingAllocatorWithBuckets<memory_type>).name()));
 #endif
   }

--- a/include/nbla/memory/memory.hpp
+++ b/include/nbla/memory/memory.hpp
@@ -22,9 +22,7 @@
 
 namespace nbla {
 
-using std::string;
 using std::size_t;
-using std::shared_ptr;
 
 /** Memory status on the device.
  */
@@ -63,7 +61,7 @@ public:
 };
 
 typedef shared_ptr<PhysicalMemory> PhysicalMemoryPtr;
-typedef std::vector<PhysicalMemoryPtr> VecPhysicalMemoryPtr;
+typedef vector<PhysicalMemoryPtr> VecPhysicalMemoryPtr;
 
 /** \addtogroup NNablaCoreGrp */
 /*@{*/

--- a/include/nbla/memory/naive_allocator.hpp
+++ b/include/nbla/memory/naive_allocator.hpp
@@ -36,7 +36,7 @@ public:
   typedef MemoryType memory_type;
   NaiveAllocator() {
 #if 0
-    callback_.reset(new PrintingAllocatorCallback(typeid(*this).name()));
+    callback_.reset(new_object<PrintingAllocatorCallback>(typeid(*this).name()));
 #endif
   }
 

--- a/include/nbla/memory/virtual_caching_allocator.hpp
+++ b/include/nbla/memory/virtual_caching_allocator.hpp
@@ -24,9 +24,6 @@
 #include <nbla/memory/allocator.hpp>
 
 namespace nbla {
-using std::queue;
-using std::make_shared;
-using std::multimap;
 
 typedef std::chrono::time_point<std::chrono::high_resolution_clock> Tp;
 
@@ -98,8 +95,8 @@ public:
 
   typedef pair<Tp, shared_ptr<Memory>> MemPtrWithTime;
   typedef multimap<size_t, MemPtrWithTime> MappedCache;
-  typedef std::priority_queue<MemPtrWithTime, vector<MemPtrWithTime>,
-                              std::greater<MemPtrWithTime>>
+  typedef priority_queue<MemPtrWithTime, vector<MemPtrWithTime>,
+                         std::greater<MemPtrWithTime>>
       Wlist;
 
   void set_chunk_size(size_t size);

--- a/include/nbla/nd_array.hpp
+++ b/include/nbla/nd_array.hpp
@@ -21,8 +21,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 /** Dtype and backend agnostic multi-dimensional array.
  */
 class NdArray {

--- a/include/nbla/parametric_functions.hpp
+++ b/include/nbla/parametric_functions.hpp
@@ -35,7 +35,6 @@
 #include <nbla/function/deconvolution.hpp>
 #include <nbla/functions.hpp>
 #include <nbla/initializer.hpp>
-using std::make_shared;
 namespace f = nbla::functions;
 
 namespace nbla {

--- a/include/nbla/singleton_manager-internal.hpp
+++ b/include/nbla/singleton_manager-internal.hpp
@@ -32,14 +32,14 @@ template <typename SINGLETON> SINGLETON *SingletonManager::get() {
   // TODO: Enable debug print
   // std::cout << "Creating a singleton \"" << typeid(SINGLETON).name() << "\""
   //           << std::endl;
-  r = new SINGLETON{};
+  r = NBLA_NEW_OBJECT(SINGLETON);
 
   auto deleter = []() -> void {
     // TODO: Enable debug print
     // std::cout << "Deleting a singleton \"" << typeid(SINGLETON).name() <<
     // "\""
     //          << std::endl;
-    delete r; // Static variable doesn't require capturing.
+    NBLA_DELETE_OBJECT(r); // Static variable doesn't require capturing.
     r = nullptr;
   };
   int id = s.count_;

--- a/include/nbla/singleton_manager.hpp
+++ b/include/nbla/singleton_manager.hpp
@@ -27,8 +27,6 @@
 #include <nbla/synced_array.hpp>
 
 namespace nbla {
-using std::unique_ptr;
-using std::unordered_map;
 
 /** API for getting or creating and deleting any singleton classes.
 
@@ -72,7 +70,7 @@ public:
 private:
   int count_; ///< How many singletons in this registry.
   ///< Hash map from ID to a pair of address and deleter function.
-  unordered_map<int, pair<uintptr_t, std::function<void()>>> singletons_;
+  unordered_map<int, pair<uintptr_t, function<void()>>> singletons_;
   unordered_map<uintptr_t, int> adr2id_; ///< Hash map from address to ID.
 
   static SingletonManager

--- a/include/nbla/solver.hpp
+++ b/include/nbla/solver.hpp
@@ -26,12 +26,7 @@
 
 namespace nbla {
 
-using std::string;
-using std::vector;
-using std::shared_ptr;
-using std::unordered_map;
-
-typedef std::function<void(void)> update_hook_type;
+typedef function<void(void)> update_hook_type;
 
 /** Callback helper class for update callbacks
 
@@ -39,9 +34,9 @@ This is used from Python frontend.
 */
 class UpdateHookWithObject {
 public:
-  typedef std::function<void(void *)> setup_callback_type;
-  typedef std::function<void(void *)> cleanup_callback_type;
-  typedef std::function<void(void *)> callback_type;
+  typedef function<void(void *)> setup_callback_type;
+  typedef function<void(void *)> cleanup_callback_type;
+  typedef function<void(void *)> callback_type;
 
 private:
   void *obj_{nullptr};

--- a/include/nbla/std.hpp
+++ b/include/nbla/std.hpp
@@ -1,0 +1,110 @@
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef __NBLA_STD_HPP__
+#define __NBLA_STD_HPP__
+
+#include <deque>
+#include <list>
+#include <map>
+#include <queue>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <functional>
+#include <memory>
+#include <type_traits>
+
+#include <cstdlib>
+
+namespace nbla {
+
+inline void *malloc(size_t size) { return std::malloc(size); }
+
+inline void free(void *p) { return std::free(p); }
+
+using std::deque;
+using std::function;
+using std::hash;
+using std::list;
+using std::map;
+using std::multimap;
+using std::ostringstream;
+using std::priority_queue;
+using std::queue;
+using std::set;
+using std::stack;
+using std::string;
+using std::stringstream;
+using std::unordered_map;
+using std::unordered_set;
+using std::vector;
+
+using std::shared_ptr;
+using std::weak_ptr;
+using std::unique_ptr;
+
+using std::enable_shared_from_this;
+using std::make_shared;
+using std::make_unique;
+
+using std::to_string;
+
+/** Allocate memory and call constructor of a new object.
+
+   This macro enables us to create a object with private constructor.
+ */
+#define NBLA_NEW_OBJECT(TYPE, ...) (new TYPE(__VA_ARGS__))
+
+/** Call destructor and deallocate memory of a object.
+
+   This macro enables us to delete a object with private destructor.
+ */
+#define NBLA_DELETE_OBJECT(p)                                                  \
+  do {                                                                         \
+    delete (p);                                                                \
+  } while (false)
+
+/** Allocate memory and call constructor of a new object.
+ */
+template <typename T, typename... Args> T *new_object(Args &&... args) {
+  static_assert(std::is_constructible<T, Args...>::value,
+                "Unable to call constructor.");
+  return new T(std::forward<Args>(args)...);
+}
+
+/** Call destructor and deallocate memory of a object.
+ */
+template <typename T> void delete_object(T *p) {
+  static_assert(std::is_destructible<T>::value, "Unable to call destructor.");
+  delete p;
+}
+
+/** Allocate memory and call constructor of a new array.
+ */
+template <typename T> T *new_array(size_t n) {
+  static_assert(std::is_default_constructible<T>::value,
+                "Unable to call constructor.");
+  return new T[n];
+}
+
+/** Call destructor and deallocate memory of an array.
+ */
+template <typename T> void delete_array(T *p) {
+  static_assert(std::is_destructible<T>::value, "Unable to call destructor.");
+  delete[] p;
+}
+}
+
+#endif

--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -26,15 +26,13 @@
 
 namespace nbla {
 
-using std::map;
-using std::shared_ptr;
 using std::pair;
 
 /** Synchronized array interface that implicitly transfers and cast arrays
 over devices and data types.
 \ingroup NNablaCoreGrp
 */
-class NBLA_API SyncedArray : public std::enable_shared_from_this<SyncedArray> {
+class NBLA_API SyncedArray : public enable_shared_from_this<SyncedArray> {
   struct ArrayDesc {
     string key;
     string array_class;
@@ -139,7 +137,7 @@ public:
   /** Get the array class of the head.
    *
    */
-  inline std::string head_array_class() { return head_.array_class; }
+  inline string head_array_class() { return head_.array_class; }
 
   /** Get the number of arrays
   */
@@ -207,10 +205,10 @@ class SingletonManager; // Forward declaration for friend
 enum SyncedArrayCallbackTag { GET, CAST, CLEAR };
 
 /// Type of callback function for get, cast, and clear of SyncedArray.
-using synced_array_callback_func_type = std::function<void(
-    SyncedArrayPtr saptr, const SyncedArrayCallbackTag func_name,
-    const dtypes dtype, const Context &ctx, const bool write_only,
-    const bool first_creation, const bool off_recording)>;
+using synced_array_callback_func_type =
+    function<void(SyncedArrayPtr saptr, const SyncedArrayCallbackTag func_name,
+                  const dtypes dtype, const Context &ctx, const bool write_only,
+                  const bool first_creation, const bool off_recording)>;
 
 /**
 Singleton class to store a callback function for get, cast, and clear of

--- a/include/nbla/utils/deformable-im2col-internal.hpp
+++ b/include/nbla/utils/deformable-im2col-internal.hpp
@@ -15,9 +15,7 @@
 #ifndef __NBLA_UTILS_DEFORMABLE_IM2COL_INTERNAL_HPP__
 #define __NBLA_UTILS_DEFORMABLE_IM2COL_INTERNAL_HPP__
 
-#include <vector>
-
-using std::vector;
+#include <nbla/common.hpp>
 
 namespace nbla {
 

--- a/include/nbla/utils/dlpack_array_registry.hpp
+++ b/include/nbla/utils/dlpack_array_registry.hpp
@@ -17,26 +17,17 @@
 
 #include <dlpack/dlpack.h> // third-party
 #include <nbla/context.hpp>
+#include <nbla/singleton_manager-internal.hpp>
 
 #include <map>
 
 namespace nbla {
-
-using std::map;
 
 /** DlpackArrayCreator class this is never be instantiated.
 
     This creator class is used only for DlpackArray.
 */
 class NBLA_API DlpackArrayRegistry {
-  using ArrayToDLDeviceType = map<string, DLDeviceType>;
-  using DLDeviceTypeToArray = map<DLDeviceType, string>;
-  using DLDeviceTypeToBackend = map<DLDeviceType, string>;
-
-  static DLDeviceTypeToArray device_type_to_array_;
-  static DLDeviceTypeToBackend device_type_to_backend_;
-  static ArrayToDLDeviceType array_to_device_type_;
-
 public:
   /** Interface to create a context for DlpackArray */
   static Context create_context(const DLTensor &dlp);

--- a/include/nbla/utils/fold_from_patches.hpp
+++ b/include/nbla/utils/fold_from_patches.hpp
@@ -15,8 +15,7 @@
 #ifndef __NBLA_UTILS_FOLD_FROM_PATCHES_HPP__
 #define __NBLA_UTILS_FOLD_FROM_PATCHES_HPP__
 
-#include <vector>
-using std::vector;
+#include <nbla/common.hpp>
 
 namespace nbla {
 template <typename T>

--- a/include/nbla/utils/nd_index.hpp
+++ b/include/nbla/utils/nd_index.hpp
@@ -15,20 +15,18 @@
 #ifndef __NBLA_UTILS_ND_INDEX_HPP__
 #define __NBLA_UTILS_ND_INDEX_HPP__
 
+#include <nbla/common.hpp>
+
 #include <algorithm>
-#include <array>
 #include <cassert>
-#include <functional>
 #include <limits>
 #include <numeric>
-#include <sstream>
-#include <vector>
 
 namespace nbla {
 namespace ndi {
 
-template <typename T> std::string str(const std::vector<T> &index) {
-  std::ostringstream os;
+template <typename T> string str(const vector<T> &index) {
+  ostringstream os;
   os << "[";
   auto print = [&os](size_t i) { os << i << ", "; };
   std::for_each(index.begin(), index.end() - 1, print);
@@ -37,9 +35,8 @@ template <typename T> std::string str(const std::vector<T> &index) {
 }
 
 // Calculate strides from `shape` and return as a new allocated vector.
-template <typename T>
-inline std::vector<T> strides(const std::vector<T> &shape) {
-  std::vector<T> v(shape.size(), 1);
+template <typename T> inline vector<T> strides(const vector<T> &shape) {
+  vector<T> v(shape.size(), 1);
   std::copy(shape.begin() + 1, shape.end(), v.begin());
   std::partial_sum(v.rbegin(), v.rend(), v.rbegin(), std::multiplies<T>());
   return v;
@@ -48,7 +45,7 @@ inline std::vector<T> strides(const std::vector<T> &shape) {
 // Compute the flat offset for the multidimensional `index` within the shape
 // determined by `strides`.
 template <typename T>
-inline T nd2flat(const std::vector<T> &index, const std::vector<T> &stride) {
+inline T nd2flat(const vector<T> &index, const vector<T> &stride) {
   assert(index.size() <= stride.size());
   return std::inner_product(index.begin(), index.end(), stride.begin(), 0);
 }
@@ -57,8 +54,7 @@ inline T nd2flat(const std::vector<T> &index, const std::vector<T> &stride) {
 // determined by `strides` restricted to the outer dimensions until and not
 // including `axis`.
 template <typename T>
-inline T nd2flat(const std::vector<T> &index, const std::vector<T> &stride,
-                 int axis) {
+inline T nd2flat(const vector<T> &index, const vector<T> &stride, int axis) {
   using std::inner_product;
   assert(stride.size() <= std::numeric_limits<int>::max());
   assert(index.size() <= stride.size());
@@ -72,7 +68,7 @@ inline T nd2flat(const std::vector<T> &index, const std::vector<T> &stride,
 // determined by `strides` restricted to the dimensions from and including
 // `axis.first` until and excluding `axis.second`.
 template <typename T>
-inline T nd2flat(const std::vector<T> &index, const std::vector<T> &stride,
+inline T nd2flat(const vector<T> &index, const vector<T> &stride,
                  std::pair<int, int> axis) {
   assert(stride.size() <= std::numeric_limits<int>::max());
   assert(index.size() <= stride.size());
@@ -91,9 +87,9 @@ inline T nd2flat(const std::vector<T> &index, const std::vector<T> &stride,
 
 // Convert a flat `index` to a multidimensional index according to `stride`.
 template <typename T>
-inline std::vector<T> flat2nd(T index, const std::vector<T> &stride) {
+inline vector<T> flat2nd(T index, const vector<T> &stride) {
   assert(stride.size() <= std::numeric_limits<int>::max());
-  std::vector<T> nd_index(stride.size());
+  vector<T> nd_index(stride.size());
   for (int axis = 0; axis < static_cast<int>(nd_index.size()); ++axis) {
     nd_index[axis] = index / stride[axis];
     index -= nd_index[axis] * stride[axis];
@@ -103,11 +99,10 @@ inline std::vector<T> flat2nd(T index, const std::vector<T> &stride) {
 
 // Calculate the size of the subspace of `shape` that goes from axis to last.
 //
-// std::vector<int> shape = {2, 3, 4, 5, 6};
+// vector<int> shape = {2, 3, 4, 5, 6};
 // ndi::inner_size(shape, 3) => 30
 //
-template <typename T>
-inline T inner_size(const std::vector<T> &shape, int axis) {
+template <typename T> inline T inner_size(const vector<T> &shape, int axis) {
   using std::accumulate;
   using std::multiplies;
   assert(shape.size() <= std::numeric_limits<int>::max());
@@ -119,11 +114,10 @@ inline T inner_size(const std::vector<T> &shape, int axis) {
 
 // Calculate the size of the subspace of `shape` that goes from 0 to axis - 1.
 //
-// std::vector<int> shape = {2, 3, 4, 5, 6};
+// vector<int> shape = {2, 3, 4, 5, 6};
 // ndi::outer_size(shape, 3) => 24
 //
-template <typename T>
-inline T outer_size(const std::vector<T> &shape, int axis) {
+template <typename T> inline T outer_size(const vector<T> &shape, int axis) {
   using std::accumulate;
   using std::multiplies;
   assert(shape.size() <= std::numeric_limits<int>::max());
@@ -137,7 +131,7 @@ inline T outer_size(const std::vector<T> &shape, int axis) {
 // axes as needed. The return value is true for all increments except when all
 // axes wrap to zero at once. Example:
 //
-// std::vector<int> index = {0, 0}, shape = {2, 2};
+// vector<int> index = {0, 0}, shape = {2, 2};
 // do {
 //   std::cout << ndi::str(index) << " ";
 // } while (ndi::increment(index, shape));
@@ -145,7 +139,7 @@ inline T outer_size(const std::vector<T> &shape, int axis) {
 // produces "[0, 0] [0 1] [1, 0] [1, 1]"
 //
 template <typename T>
-inline bool increment(std::vector<T> &index, const std::vector<T> &shape) {
+inline bool increment(vector<T> &index, const vector<T> &shape) {
   assert(shape.size() <= std::numeric_limits<int>::max());
   assert(index.size() == shape.size());
   for (int axis = static_cast<int>(index.size()) - 1; axis >= 0; axis--) {
@@ -163,7 +157,7 @@ inline bool increment(std::vector<T> &index, const std::vector<T> &shape) {
 // ranges from 0 to `axis`. The return value is true for all increments except
 // when all axes of the subspace of `shape` wrap to zero at once. Example:
 //
-// std::vector<int> index = {0, 0, 0}, shape = {2, 2, 2};
+// vector<int> index = {0, 0, 0}, shape = {2, 2, 2};
 // do {
 //   std::cout << ndi::str(index) << " ";
 // } while (ndi::increment(index, shape, 1));
@@ -171,8 +165,7 @@ inline bool increment(std::vector<T> &index, const std::vector<T> &shape) {
 // produces "[0, 0, 0] [0, 1, 0] [1, 0, 0] [1, 1, 0]"
 //
 template <typename T>
-inline bool increment(std::vector<T> &index, const std::vector<T> &shape,
-                      int axis) {
+inline bool increment(vector<T> &index, const vector<T> &shape, int axis) {
   assert(shape.size() <= std::numeric_limits<int>::max());
   assert(index.size() == shape.size());
   if (axis < 0)
@@ -193,16 +186,15 @@ inline bool increment(std::vector<T> &index, const std::vector<T> &shape,
 // the size of the larger input vector. The missing elements from the shorter
 // input vector are interpreted as 1.
 template <typename Ta, typename Tb>
-inline std::vector<Ta> multiply(const std::vector<Ta> &a,
-                                const std::vector<Tb> &b) {
-  std::vector<Ta> r(std::max(a.size(), b.size()), 1);
+inline vector<Ta> multiply(const vector<Ta> &a, const vector<Tb> &b) {
+  vector<Ta> r(std::max(a.size(), b.size()), 1);
   if (a.size() < b.size()) {
     std::copy_backward(a.begin(), a.end(), r.end());
-    for (typename std::vector<Ta>::size_type i = 0; i < r.size(); i++)
+    for (typename vector<Ta>::size_type i = 0; i < r.size(); i++)
       r.at(i) *= b.at(i);
   } else {
     std::copy_backward(b.begin(), b.end(), r.end());
-    for (typename std::vector<Ta>::size_type i = 0; i < r.size(); i++)
+    for (typename vector<Ta>::size_type i = 0; i < r.size(); i++)
       r.at(i) *= a.at(i);
   }
   return r;
@@ -212,22 +204,21 @@ inline std::vector<Ta> multiply(const std::vector<Ta> &a,
 // elements with value `v`. If `a` is intended as a multidimensional index or a
 // shape then this function is expanding into outer dimensions.
 template <typename T>
-inline std::vector<T> expand(const std::vector<T> &a, size_t n, const T &v) {
-  std::vector<T> r(std::max(a.size(), n), v);
+inline vector<T> expand(const vector<T> &a, size_t n, const T &v) {
+  vector<T> r(std::max(a.size(), n), v);
   std::copy_backward(a.begin(), a.end(), r.end());
   return r;
 }
 
 template <typename T>
-inline std::vector<T> make_index(size_t ndim, const T &init = T()) {
-  return std::vector<T>(ndim, init);
+inline vector<T> make_index(size_t ndim, const T &init = T()) {
+  return vector<T>(ndim, init);
 }
 
 template <typename T>
-inline std::vector<T> batch_reduced_shape(std::vector<T> &shape,
-                                          int reduce_axis_up_to) {
+inline vector<T> batch_reduced_shape(vector<T> &shape, int reduce_axis_up_to) {
   assert(reduce_axis_up_to < shape.size());
-  std::vector<T> ret(shape.size() - reduce_axis_up_to + 1);
+  vector<T> ret(shape.size() - reduce_axis_up_to + 1);
   ret[0] = outer_size(shape, reduce_axis_up_to);
   std::copy(shape.cbegin() + reduce_axis_up_to, shape.cend(), ret.begin() + 1);
   return ret;

--- a/include/nbla/utils/top_k.hpp
+++ b/include/nbla/utils/top_k.hpp
@@ -15,9 +15,10 @@
 #ifndef __NBLA_UTILS_TOPK_HPP__
 #define __NBLA_UTILS_TOPK_HPP__
 
+#include <nbla/common.hpp>
+
 #include <algorithm>
 #include <utility>
-#include <vector>
 
 namespace nbla {
 
@@ -36,7 +37,7 @@ inline void top_k(const T *x, const size_t n, const size_t k, size_t *out) {
     }
   };
 
-  std::vector<std::pair<T, size_t>> heap(k);
+  vector<std::pair<T, size_t>> heap(k);
   for (size_t i = 0; i < k; ++i) {
     heap[i] = std::make_pair(x[i], i);
   }
@@ -71,7 +72,7 @@ inline void top_k_abs(const T *x, const size_t n, const size_t k, size_t *out) {
     }
   };
 
-  std::vector<std::pair<T, size_t>> heap(k);
+  vector<std::pair<T, size_t>> heap(k);
   for (size_t i = 0; i < k; ++i) {
     heap[i] = std::make_pair(x[i] < 0 ? -x[i] : x[i], i);
   }

--- a/include/nbla/utils/unfold_to_patches.hpp
+++ b/include/nbla/utils/unfold_to_patches.hpp
@@ -15,8 +15,7 @@
 #ifndef __NBLA_UTILS_UNFOLD_TO_PATCHES_HPP__
 #define __NBLA_UTILS_UNFOLD_TO_PATCHES_HPP__
 
-#include <vector>
-using std::vector;
+#include <nbla/common.hpp>
 
 namespace nbla {
 template <typename T>

--- a/include/nbla/variable.hpp
+++ b/include/nbla/variable.hpp
@@ -21,8 +21,6 @@
 
 #include <memory>
 
-using std::shared_ptr;
-
 namespace nbla {
 
 /** User interface for Array and passed to Function.

--- a/include/nbla/version.hpp
+++ b/include/nbla/version.hpp
@@ -17,8 +17,6 @@
 
 namespace nbla {
 
-using std::string;
-
 const string nbla_version(void);
 const string nbla_author(void);
 const string nbla_author_email(void);

--- a/include/nbla_utils/nnp.hpp
+++ b/include/nbla_utils/nnp.hpp
@@ -95,7 +95,7 @@ class TrainingConfigImpl;
  */
 class Network {
   friend NnpImpl;
-  std::unique_ptr<NetworkImpl> impl_;
+  unique_ptr<NetworkImpl> impl_;
   Network(NetworkImpl *impl);
 
 public:
@@ -149,7 +149,7 @@ public:
  */
 class Executor {
   friend NnpImpl;
-  std::unique_ptr<ExecutorImpl> impl_;
+  unique_ptr<ExecutorImpl> impl_;
   Executor(ExecutorImpl *impl);
 
 public:
@@ -225,7 +225,7 @@ public:
 // ----------------------------------------------------------------------
 class Optimizer {
   friend NnpImpl;
-  std::unique_ptr<OptimizerImpl> impl_;
+  unique_ptr<OptimizerImpl> impl_;
   Optimizer(OptimizerImpl *impl);
 
 public:
@@ -297,7 +297,7 @@ public:
 // ----------------------------------------------------------------------
 class Monitor {
   friend NnpImpl;
-  std::unique_ptr<MonitorImpl> impl_;
+  unique_ptr<MonitorImpl> impl_;
   Monitor(MonitorImpl *impl);
 
 public:
@@ -346,7 +346,7 @@ public:
 // ----------------------------------------------------------------------
 class TrainingConfig {
   friend NnpImpl;
-  std::unique_ptr<TrainingConfigImpl> impl_;
+  unique_ptr<TrainingConfigImpl> impl_;
   TrainingConfig(TrainingConfigImpl *impl);
 
 public:
@@ -407,7 +407,7 @@ public:
     @endcode
  */
 class Nnp {
-  std::unique_ptr<NnpImpl> impl_;
+  unique_ptr<NnpImpl> impl_;
 
 public:
   /** Constructor which sets default context.

--- a/src/nbla/array/array.cpp
+++ b/src/nbla/array/array.cpp
@@ -21,8 +21,6 @@
 
 namespace nbla {
 
-using std::vector;
-
 Array::Array(const Size_t size, dtypes dtype, const Context &ctx,
              AllocatorMemory &&mem)
     : size_(size), dtype_(dtype), ctx_(ctx), mem_(std::move(mem)) {}

--- a/src/nbla/array/cpu_array.cpp
+++ b/src/nbla/array/cpu_array.cpp
@@ -23,10 +23,6 @@
 
 namespace nbla {
 
-using std::vector;
-using std::shared_ptr;
-using std::make_shared;
-
 CpuArray::CpuArray(const Size_t size, dtypes dtype, const Context &ctx)
     : Array::Array(size, dtype, ctx,
                    SingletonManager::get<Cpu>()->naive_allocator()->alloc(

--- a/src/nbla/array_registry.cpp
+++ b/src/nbla/array_registry.cpp
@@ -14,6 +14,7 @@
 
 #include <nbla/array_registry.hpp>
 #include <nbla/common.hpp>
+#include <nbla/singleton_manager-internal.hpp>
 
 #include <memory>
 #include <string>
@@ -21,14 +22,9 @@
 
 namespace nbla {
 
-using std::shared_ptr;
-using std::string;
-using std::vector;
-
 // Array group
 ArrayGroup::Registry_t &ArrayGroup::get_registry() {
-  static Registry_t registry_;
-  return registry_;
+  return *SingletonManager::get<Registry_t>();
 }
 
 void ArrayGroup::add_group(const string &array_class,
@@ -54,8 +50,7 @@ string ArrayGroup::get_group(const string &array_class) {
 
 // Array Factory
 ArrayCreator::Registry_t &ArrayCreator::get_registry() {
-  static Registry_t registry_;
-  return registry_;
+  return *SingletonManager::get<Registry_t>();
 }
 
 static void
@@ -97,8 +92,7 @@ void ArrayCreator::add_creator(const string &name, Creator creator,
 
 // Array Synchronizer
 ArraySynchronizer::Registry_t &ArraySynchronizer::get_registry() {
-  static Registry_t registry_;
-  return registry_;
+  return *SingletonManager::get<Registry_t>();
 }
 
 void ArraySynchronizer::synchronize(const string &src_class, Array *src_array,
@@ -109,7 +103,7 @@ void ArraySynchronizer::synchronize(const string &src_class, Array *src_array,
   pair<string, string> key{src_class, dst_class};
   NBLA_CHECK(registry.count(key) == 1, error_code::unclassified,
              [registry, key]() {
-               std::ostringstream ss;
+               ostringstream ss;
                ss << key.first << "-" << key.second << " is not in (";
                for (auto &kv : registry) {
                  ss << kv.first.first << "-" << kv.first.second << ", ";

--- a/src/nbla/backend_registry.cpp
+++ b/src/nbla/backend_registry.cpp
@@ -14,10 +14,10 @@
 
 #include <nbla/backend_registry.hpp>
 #include <nbla/common.hpp>
+#include <nbla/singleton_manager-internal.hpp>
 
 namespace nbla {
 
-using std::stringstream;
 using std::getline;
 
 void BackendUtils::add_backend(const string &backend_name,
@@ -28,8 +28,7 @@ void BackendUtils::add_backend(const string &backend_name,
 }
 
 BackendUtils::Registry_t &BackendUtils::get_registry() {
-  static Registry_t registry_;
-  return registry_;
+  return *SingletonManager::get<Registry_t>();
 }
 
 string get_key(const Context ctx) {

--- a/src/nbla/communicator.cpp
+++ b/src/nbla/communicator.cpp
@@ -20,8 +20,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 Communicator::Communicator(const Context &ctx) : ctx_(ctx) {}
 
 Communicator::~Communicator() {}

--- a/src/nbla/communicator/data_parallel_communicator.cpp
+++ b/src/nbla/communicator/data_parallel_communicator.cpp
@@ -23,8 +23,6 @@ namespace nbla {
 // like solver does.
 NBLA_REGISTER_COMMUNICATOR_SOURCE(DataParallelCommunicator);
 
-using std::make_shared;
-
 template <typename T>
 DataParallelCommunicator<T>::DataParallelCommunicator(const Context &ctx)
     : Communicator(ctx) {}

--- a/src/nbla/communicator/multi_process_data_parallel_communicator.cpp
+++ b/src/nbla/communicator/multi_process_data_parallel_communicator.cpp
@@ -23,8 +23,6 @@ namespace nbla {
 // like solver does.
 NBLA_REGISTER_COMMUNICATOR_SOURCE(MultiProcessDataParallelCommunicator);
 
-using std::make_shared;
-
 template <typename T>
 MultiProcessDataParallelCommunicator<T>::MultiProcessDataParallelCommunicator(
     const Context &ctx)

--- a/src/nbla/computation_graph/computation_graph.cpp
+++ b/src/nbla/computation_graph/computation_graph.cpp
@@ -21,8 +21,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 static void set_function_inputs(CgFunctionPtr func,
                                 const vector<CgVariablePtr> &inputs) {
   // Check need_grad
@@ -210,11 +208,10 @@ void GlobalClearBufferState::set(bool clear_buffer, bool clear_no_need_grad) {
   clear_buffer_[tid] = clear_buffer;
   clear_no_need_grad_[tid] = clear_no_need_grad;
 }
-std::unique_ptr<GlobalClearBufferState::ScopedState>
+unique_ptr<GlobalClearBufferState::ScopedState>
 GlobalClearBufferState::state(bool clear_buffer, bool clear_no_need_grad) {
-  return std::unique_ptr<GlobalClearBufferState::ScopedState>(
-      new GlobalClearBufferState::ScopedState(this, clear_buffer,
-                                              clear_no_need_grad));
+  return make_unique<GlobalClearBufferState::ScopedState>(this, clear_buffer,
+                                                          clear_no_need_grad);
 }
 GlobalClearBufferState::ScopedState::ScopedState(GlobalClearBufferState *self,
                                                  bool clear_buffer,

--- a/src/nbla/computation_graph/function.cpp
+++ b/src/nbla/computation_graph/function.cpp
@@ -19,8 +19,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 // Just a helper function.
 static inline const char *b2str(bool b) { return b ? "true" : "false"; }
 

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -38,15 +38,9 @@
 
 namespace nbla {
 
-using std::make_shared;
-using std::set;
-using std::unordered_map;
-using std::unordered_set;
 using std::tuple;
 using std::make_tuple;
 using std::get;
-using std::unique_ptr;
-using std::vector;
 
 /** FunctionHookWithObject Implementation **/
 FunctionHookWithObject::FunctionHookWithObject() {}
@@ -653,7 +647,7 @@ public:
 void CgVariable::visit_function_recursive(
     CgFunctionPtr func, unordered_set<CgFunctionPtr> &fclosed,
     const bool as_recomputation,
-    std::function<void(CgFunctionPtr)> forward_callback) {
+    function<void(CgFunctionPtr)> forward_callback) {
 
   // A. Push the function to the closed list.
   fclosed.insert(func);
@@ -833,7 +827,7 @@ bool need_recompute_output(const CgFunctionPtr &f, const int output_idx) {
 }
 
 void CgVariable::visit_function_backward(
-    CgFunctionPtr p, std::function<void(CgFunctionPtr)> backward_callback,
+    CgFunctionPtr p, function<void(CgFunctionPtr)> backward_callback,
     vector<CommunicatorBackwardCallbackPtr> communicator_callbacks) {
   // Open list of next search candidate.
   unordered_map<CgFunctionPtr, uint64_t> ids;
@@ -958,8 +952,8 @@ void CgVariable::backward(
   // Scoped context.
   // Set flags used during backward of this variable to avoid clearing
   // buffer. Also, set the grad array passed as an argument.
-  std::vector<NdArrayPtr> bak_grads;
-  std::vector<NdArrayPtr> dummy_zero_grads;
+  vector<NdArrayPtr> bak_grads;
+  vector<NdArrayPtr> dummy_zero_grads;
   for (auto var : parent_->outputs()) {
     bak_grads.push_back(var->variable()->grad());
     NdArrayPtr dummpy_grad = NdArray::create(var->variable()->shape());
@@ -1011,7 +1005,7 @@ size_t CgVariable::function_reference_count() const {
 }
 
 void CgVariable::insert_function_reference(CgFunctionPtr func) {
-  std::weak_ptr<CgFunction> wp(func);
+  weak_ptr<CgFunction> wp(func);
   function_reference_count_++;
   auto it = function_references_.find(func.get());
   if (it != function_references_.end()) {
@@ -1052,8 +1046,8 @@ bool CgVariable::check_and_unmark_need_setup(CgFunctionPtr func) {
 }
 
 CgVariablePtr CgVariable::create_deep_copy(Context ctx, bool copy_grad) {
-  auto ret = std::make_shared<CgVariable>(this->variable()->shape(),
-                                          this->need_grad());
+  auto ret =
+      make_shared<CgVariable>(this->variable()->shape(), this->need_grad());
 
   dtypes dtype = this->variable()->data()->array()->dtype();
 
@@ -1084,10 +1078,10 @@ void ClearCalledFlagRecorder::deactivate() {
   recorded_output_clear_flags_.clear();
 }
 
-std::vector<std::pair<bool, bool>>
+vector<std::pair<bool, bool>>
 ClearCalledFlagRecorder::get_variable_clear_called_flag(
-    const std::vector<CgVariablePtr> &vars) {
-  std::vector<std::pair<bool, bool>> clear_called_flags;
+    const vector<CgVariablePtr> &vars) {
+  vector<std::pair<bool, bool>> clear_called_flags;
 
   for (const auto &var : vars) {
     bool data_flag = var->variable()->data()->array()->clear_called();
@@ -1109,12 +1103,12 @@ void ClearCalledFlagRecorder::record(const CgFunctionPtr func) {
       get_variable_clear_called_flag(func->outputs()));
 }
 
-std::vector<std::vector<std::pair<bool, bool>>>
+vector<vector<std::pair<bool, bool>>>
 ClearCalledFlagRecorder::get_recorded_input_clear_flags() const {
   return recorded_input_clear_flags_;
 }
 
-std::vector<std::vector<std::pair<bool, bool>>>
+vector<vector<std::pair<bool, bool>>>
 ClearCalledFlagRecorder::get_recorded_output_clear_flags() const {
   return recorded_output_clear_flags_;
 }

--- a/src/nbla/context.cpp
+++ b/src/nbla/context.cpp
@@ -28,7 +28,7 @@ Context &Context::set_backend(const vector<string> &backend) {
   for (auto it = this->backend.begin(); it != this->backend.end(); it++) {
     if (it->find(':') == string::npos) {
       // The default type config is float.
-      *it = *it + std::string(":float");
+      *it = *it + string(":float");
     }
   }
   return *this;

--- a/src/nbla/exception.cpp
+++ b/src/nbla/exception.cpp
@@ -37,7 +37,7 @@ string get_error_string(error_code code) {
     CASE_ERROR_STRING(runtime);
 #undef CASE_ERROR_STRING
   }
-  return std::string();
+  return string();
 }
 
 // -------------------------------------------------------------------------
@@ -46,7 +46,7 @@ string get_error_string(error_code code) {
 Exception::Exception(error_code code, const string &msg, const string &func,
                      const string &file, int line)
     : code_(code), msg_(msg), func_(func), file_(file), line_(line) {
-  std::ostringstream ss;
+  ostringstream ss;
   ss << get_error_string(code_) << " error in " << func_ << std::endl
      << file_ << ":" << line_ << std::endl
      << msg_ << std::endl;

--- a/src/nbla/function.cpp
+++ b/src/nbla/function.cpp
@@ -20,8 +20,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 Function::Function(const Context &ctx) : ctx_(ctx), fall_back_func_(nullptr) {}
 
 Function::~Function() {}

--- a/src/nbla/function/generic/average_pooling.cpp
+++ b/src/nbla/function/generic/average_pooling.cpp
@@ -34,8 +34,7 @@ using std::max;
 namespace avg_pooling_impl {
 
 template <typename TI, typename TO, int NDIM>
-inline const std::array<TO, NDIM> v2a(const std::vector<TI> &v,
-                                      const int skip = 0) {
+inline const std::array<TO, NDIM> v2a(const vector<TI> &v, const int skip = 0) {
   std::array<TO, NDIM> a;
   for (int i = 0; i < NDIM; i++)
     a[i] = v.at(skip + i);

--- a/src/nbla/function/generic/batch_normalization.cpp
+++ b/src/nbla/function/generic/batch_normalization.cpp
@@ -123,7 +123,7 @@ void BatchNormalization<T>::setup_impl(const Variables &inputs,
     mul2_ = create_Mul2(this->ctx_, false);
     add_epsilon_ = create_AddScalar(this->ctx_, (T)this->eps_, false);
     square_root_ = create_PowScalar(this->ctx_, (T)-0.5, false);
-    std::vector<int> raxes;
+    vector<int> raxes;
     for (int i = 0; i < inputs[0]->ndim(); ++i) {
       if (i != axes_[0])
         raxes.push_back(i);

--- a/src/nbla/function/generic/convolution.cpp
+++ b/src/nbla/function/generic/convolution.cpp
@@ -218,7 +218,7 @@ void Convolution<T>::backward_impl(const Variables &inputs,
   T *dw = nullptr;
   T *db = nullptr;
   T *col = nullptr;
-  std::unique_ptr<ColVectorMap<T>> mdb;
+  unique_ptr<ColVectorMap<T>> mdb;
 
   if (propagate_down[0] || propagate_down[1]) {
     col = col_.cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -239,7 +239,7 @@ void Convolution<T>::backward_impl(const Variables &inputs,
     if (!accum[2])
       inputs[2]->grad()->zero();
     db = inputs[2]->cast_grad_and_get_pointer<T>(this->ctx_, false);
-    mdb.reset(new ColVectorMap<T>(db, channels_o_));
+    mdb = make_unique<ColVectorMap<T>>(db, channels_o_);
   }
   // Sample loop
   for (int n = 0; n < outer_size_; ++n) {

--- a/src/nbla/function/generic/deconvolution.cpp
+++ b/src/nbla/function/generic/deconvolution.cpp
@@ -246,7 +246,7 @@ void Deconvolution<T>::backward_impl(const Variables &inputs,
   T *dw = nullptr;
   T *db = nullptr;
   T *col = nullptr;
-  std::unique_ptr<ColVectorMap<T>> mdb;
+  unique_ptr<ColVectorMap<T>> mdb;
 
   if (propagate_down[0] || propagate_down[1]) {
     col = col_.cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -265,7 +265,7 @@ void Deconvolution<T>::backward_impl(const Variables &inputs,
     if (!accum[2])
       inputs[2]->grad()->zero();
     db = inputs[2]->cast_grad_and_get_pointer<T>(this->ctx_, false);
-    mdb.reset(new ColVectorMap<T>(db, channels_i_));
+    mdb = make_unique<ColVectorMap<T>>(db, channels_i_);
   }
 
   // Sample loop

--- a/src/nbla/function/generic/deformable_convolution.cpp
+++ b/src/nbla/function/generic/deformable_convolution.cpp
@@ -314,7 +314,7 @@ void DeformableConvolution<T>::backward_impl(const Variables &inputs,
   T *dmask = nullptr;
   T *col = nullptr;
 
-  std::unique_ptr<ColVectorMap<T>> mdb;
+  unique_ptr<ColVectorMap<T>> mdb;
 
   if (propagate_down[0] || propagate_down[1] || propagate_down[2]) {
     col = col_.cast_data_and_get_pointer<T>(this->ctx_, true);
@@ -350,13 +350,13 @@ void DeformableConvolution<T>::backward_impl(const Variables &inputs,
     if (!accum[4])
       inputs[4]->grad()->zero();
     db = inputs[4]->cast_grad_and_get_pointer<T>(this->ctx_, false);
-    mdb.reset(new ColVectorMap<T>(db, channels_o_));
+    mdb = make_unique<ColVectorMap<T>>(db, channels_o_);
   } else if ((inputs.size() == 4 && inputs[3]->ndim() == 1) &&
              propagate_down[3]) {
     if (!accum[3])
       inputs[3]->grad()->zero();
     db = inputs[3]->cast_grad_and_get_pointer<T>(this->ctx_, false);
-    mdb.reset(new ColVectorMap<T>(db, channels_o_));
+    mdb = make_unique<ColVectorMap<T>>(db, channels_o_);
   }
   // Sample loop
   for (int n = 0; n < outer_size_; ++n) {

--- a/src/nbla/function/generic/flip.cpp
+++ b/src/nbla/function/generic/flip.cpp
@@ -37,8 +37,8 @@ void Flip<T>::setup_impl(const Variables &inputs, const Variables &outputs) {
 
 template <typename T>
 void Flip<T>::flip_recursive(Variable *inp, const T *x, T *y,
-                             const std::vector<bool> &flip, bool add,
-                             int x_offset, int y_offset, int dim) {
+                             const vector<bool> &flip, bool add, int x_offset,
+                             int y_offset, int dim) {
   int current_x_offset = x_offset, current_y_offset = y_offset;
   const int y_stride = inp->strides()[dim];
   int x_stride = y_stride;

--- a/src/nbla/function/generic/fused_convolution.cpp
+++ b/src/nbla/function/generic/fused_convolution.cpp
@@ -250,7 +250,7 @@ void FusedConvolution<T>::setup_impl(const Variables &inputs,
   last_out->variable()->set_grad(outputs[0]->grad());
   // Call all setup again to ensure inplaced variable is refer to the correct
   // array.
-  std::unordered_set<CgFunctionPtr> fclosed;
+  unordered_set<CgFunctionPtr> fclosed;
   last_out->visit_function_recursive(last_out->parent(), fclosed,
                                      false /* as_recomputation */,
                                      [](CgFunctionPtr fn) { fn->setup(); });
@@ -315,7 +315,7 @@ void FusedConvolution<T>::backward_impl(const Variables &inputs,
   }
 
   // Propagate need_grad states
-  std::unordered_set<CgFunctionPtr> fclosed;
+  unordered_set<CgFunctionPtr> fclosed;
   last_output_cg_variable_->visit_function_recursive(
       last_output_cg_variable_->parent(), fclosed, false /* recomputation */,
       [](CgFunctionPtr fn) {});

--- a/src/nbla/function/generic/image_augmentation.cpp
+++ b/src/nbla/function/generic/image_augmentation.cpp
@@ -104,8 +104,8 @@ void ImageAugmentation<T>::image_augmentation(const Variables &inputs,
   const float i_w_out_half = 1.0f / w_out_half;
   const float i_h_out_half = 1.0f / h_out_half;
 
-  T *channel_brightness_buf = new T[num_ch * num_image];
-  T *channel_contrast_buf = new T[num_ch * num_image];
+  const auto channel_brightness_buf = make_unique<T[]>(num_ch * num_image);
+  const auto channel_contrast_buf = make_unique<T[]>(num_ch * num_image);
 #ifdef _OPENMP
 #pragma omp parallel for schedule(static)
 #endif
@@ -164,8 +164,8 @@ void ImageAugmentation<T>::image_augmentation(const Variables &inputs,
         contrast_;
     // std::cout << "global_contrast : " << global_contrast << "\n";
 
-    T *channel_brightness = channel_brightness_buf + iim * num_ch;
-    T *channel_contrast = channel_contrast_buf + iim * num_ch;
+    T *channel_brightness = channel_brightness_buf.get() + iim * num_ch;
+    T *channel_contrast = channel_contrast_buf.get() + iim * num_ch;
     for (int ic = 0; ic < num_ch; ++ic) {
       const float ch_brightness =
           brightness_each_
@@ -286,8 +286,6 @@ void ImageAugmentation<T>::image_augmentation(const Variables &inputs,
       }
     }
   }
-  delete[] channel_brightness_buf;
-  delete[] channel_contrast_buf;
 }
 
 template <typename T>

--- a/src/nbla/function/generic/inq_affine.cpp
+++ b/src/nbla/function/generic/inq_affine.cpp
@@ -115,7 +115,7 @@ void INQAffine<T, T1>::forward_impl(const Variables &inputs,
       // weights
       if (selection_algorithm_ == "largest_abs") {
         // fix weights with largest absolute value
-        std::vector<size_t> indices(inputs[1]->size());
+        vector<size_t> indices(inputs[1]->size());
         std::iota(begin(indices), end(indices), 0);
         std::sort(begin(indices), end(indices), [&](size_t a, size_t b) {
           return std::abs(weights[a]) > std::abs(weights[b]);

--- a/src/nbla/function/generic/inq_convolution.cpp
+++ b/src/nbla/function/generic/inq_convolution.cpp
@@ -114,7 +114,7 @@ void INQConvolution<T, T1>::forward_impl(const Variables &inputs,
       // weights
       if (selection_algorithm_ == "largest_abs") {
         // fix weights with largest absolute value
-        std::vector<size_t> indices(inputs[1]->size());
+        vector<size_t> indices(inputs[1]->size());
         std::iota(begin(indices), end(indices), 0);
         std::sort(begin(indices), end(indices), [&](size_t a, size_t b) {
           return std::abs(weights[a]) > std::abs(weights[b]);

--- a/src/nbla/function/generic/max_pooling.cpp
+++ b/src/nbla/function/generic/max_pooling.cpp
@@ -35,8 +35,7 @@ NBLA_REGISTER_FUNCTION_SOURCE(MaxPooling, const vector<int> &,
 namespace max_pooling_impl {
 
 template <typename TI, typename TO, int NDIM>
-inline const std::array<TO, NDIM> v2a(const std::vector<TI> &v,
-                                      const int skip = 0) {
+inline const std::array<TO, NDIM> v2a(const vector<TI> &v, const int skip = 0) {
   std::array<TO, NDIM> a;
   for (int i = 0; i < NDIM; i++)
     a[i] = v.at(skip + i);

--- a/src/nbla/function/generic/min_max_quantize.cpp
+++ b/src/nbla/function/generic/min_max_quantize.cpp
@@ -87,7 +87,7 @@ void MinMaxQuantize<T>::setup_impl(const Variables &inputs,
       axes.push_back(i);
   }
   // Compute broadcast shape
-  std::vector<int> bshape(x->shape().size());
+  vector<int> bshape(x->shape().size());
   for (Shape_t::size_type i = 0; i < x->shape().size(); i++) {
     bshape[i] = x->shape()[i];
   }

--- a/src/nbla/function/generic/pack_padded_sequence.cpp
+++ b/src/nbla/function/generic/pack_padded_sequence.cpp
@@ -78,7 +78,7 @@ void PackPaddedSequence<U>::forward_impl(const Variables &inputs,
   auto data_packed_sequence =
       packed_sequence->cast_data_and_get_pointer<U>(ctx_);
   auto data_batch_sizes = batch_sizes->cast_data_and_get_pointer<int>(cpu_ctx);
-  namespace rnn = function::utils::rnn;
+  namespace rnn = ::nbla::utils::rnn;
   // Compute batch_sizes
   rnn::compute_batch_sizes(data_lengths, lengths->size(), data_batch_sizes);
   // Pack
@@ -118,7 +118,7 @@ void PackPaddedSequence<U>::backward_impl(const Variables &inputs,
   auto grad_packed_sequence = packed_sequence->get_grad_pointer<U>(ctx_);
   auto data_batch_sizes = batch_sizes->get_data_pointer<int>(cpu_ctx);
   // Unpack
-  namespace rnn = function::utils::rnn;
+  namespace rnn = ::nbla::utils::rnn;
   if (accum[0]) {
     if (batch_first_) {
       rnn::unpack_batch_first<U, true>(grad_packed_sequence, data_batch_sizes,

--- a/src/nbla/function/generic/pad_packed_sequence.cpp
+++ b/src/nbla/function/generic/pad_packed_sequence.cpp
@@ -83,7 +83,7 @@ void PadPackedSequence<U>::forward_impl(const Variables &inputs,
       padded_sequence->cast_data_and_get_pointer<U>(ctx_);
   auto data_lengths = lengths->cast_data_and_get_pointer<int>(cpu_ctx);
 
-  namespace rnn = function::utils::rnn;
+  namespace rnn = ::nbla::utils::rnn;
   // Compute lengths
   rnn::compute_lengths(data_batch_sizes, batch_sizes->size(), data_lengths);
   // Unpack
@@ -132,7 +132,7 @@ void PadPackedSequence<U>::backward_impl(const Variables &inputs,
   auto grad_padded_sequence = padded_sequence->get_grad_pointer<U>(ctx_);
 
   // Pack
-  namespace rnn = function::utils::rnn;
+  namespace rnn = ::nbla::utils::rnn;
   if (accum[0]) {
     if (batch_first_) {
       if (TL > T)

--- a/src/nbla/function/generic/quantize_linear.cpp
+++ b/src/nbla/function/generic/quantize_linear.cpp
@@ -75,7 +75,7 @@ void QuantizeLinear<T>::saturate(Variable *inp, int min_range, int max_range) {
 }
 
 template <typename T>
-void QuantizeLinear<T>::round(Variable *inp, std::string round_mode) {
+void QuantizeLinear<T>::round(Variable *inp, string round_mode) {
   auto size = inp->size();
   auto x = inp->cast_data_and_get_pointer<T>(this->ctx_, false);
   if (round_mode == "HALF_AWAY_FROM_ZERO") {

--- a/src/nbla/function/generic/random_choice.cpp
+++ b/src/nbla/function/generic/random_choice.cpp
@@ -71,7 +71,6 @@ void RandomChoice<T>::random_choice(const Variables &inputs,
   using std::uniform_real_distribution;
   using std::partial_sum;
   using std::count_if;
-  using std::vector;
 
   auto x_data = inputs[0]->get_data_pointer<T>(this->ctx_);
   auto w_data = inputs[1]->get_data_pointer<T>(this->ctx_);

--- a/src/nbla/function/generic/random_erase.cpp
+++ b/src/nbla/function/generic/random_erase.cpp
@@ -242,9 +242,9 @@ void RandomErase<T>::random_erase(const Variables &inputs,
   T *y = outputs[0]->cast_data_and_get_pointer<T>(this->ctx_, true);
 
   // Generate N x B (x C) x 5, 5 is {prob, Se, re, xe, ye}
-  this->random_coordinates_ =
-      this->share_ ? std::make_shared<NdArray>(Shape_t{N, B, 5})
-                   : std::make_shared<NdArray>(Shape_t{N, B, C, 5});
+  this->random_coordinates_ = this->share_
+                                  ? make_shared<NdArray>(Shape_t{N, B, 5})
+                                  : make_shared<NdArray>(Shape_t{N, B, C, 5});
   float *random_coords =
       this->random_coordinates_->cast(get_dtype<float>(), this->ctx_)
           ->template pointer<float>();

--- a/src/nbla/function/generic/random_shift.cpp
+++ b/src/nbla/function/generic/random_shift.cpp
@@ -50,7 +50,7 @@ RandomShift<T>::prepare_addr_table(const Variables &inputs,
   addr_table.resize(in_dim);
   for (int id = 0; id < in_dim; ++id) {
     const int stride = inputs[0]->strides()[id];
-    std::vector<int> &table = addr_table[id];
+    vector<int> &table = addr_table[id];
     const int size = inputs[0]->shape()[id];
     table.resize(size);
     const int shift_index = shifts.size() - in_dim + id;
@@ -85,7 +85,7 @@ void RandomShift<T>::shift_recursive(const Variable *inp, const T *x, T *y,
   int current_y_offset = y_offset;
   const int stride = inp->strides()[dim];
   const int size = inp->shape()[dim];
-  const std::vector<int> &table = addr_table_[shift_index][dim];
+  const vector<int> &table = addr_table_[shift_index][dim];
   if (static_cast<Shape_t::size_type>(dim) == inp->shape().size() - 1) {
     for (int i = 0; i < size; ++i) {
       if (x_offset == CVAL_INDEX || table[i] == CVAL_INDEX)
@@ -118,7 +118,7 @@ void RandomShift<T>::shift_backward_recursive(const Variable *inp, const T *dy,
   int current_y_offset = y_offset;
   const int stride = inp->strides()[dim];
   const int size = inp->shape()[dim];
-  const std::vector<int> &table = addr_table_[shift_index][dim];
+  const vector<int> &table = addr_table_[shift_index][dim];
   if (static_cast<Shape_t::size_type>(dim) == inp->shape().size() - 1) {
     for (int i = 0; i < size; ++i) {
       if ((x_offset != CVAL_INDEX) && (table[i] != CVAL_INDEX)) {

--- a/src/nbla/function/generic/rnn.cpp
+++ b/src/nbla/function/generic/rnn.cpp
@@ -14,7 +14,6 @@
 
 #include <nbla/function/rnn.hpp>
 
-using std::make_shared;
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_SOURCE(RNN, int, const string &, float, bool, bool);

--- a/src/nbla/function/generic/spectral_norm.cpp
+++ b/src/nbla/function/generic/spectral_norm.cpp
@@ -231,7 +231,7 @@ void SpectralNorm<T>::setup_impl(const Variables &inputs,
 
   // Call all setup again to ensure inplaced variables refer to the correct
   // array.
-  std::unordered_set<CgFunctionPtr> fclosed;
+  unordered_set<CgFunctionPtr> fclosed;
   last_out->visit_function_recursive(last_out->parent(), fclosed,
                                      false /* as_recomputation */,
                                      [](CgFunctionPtr fn) { fn->setup(); });

--- a/src/nbla/function/generic/sum_pooling.cpp
+++ b/src/nbla/function/generic/sum_pooling.cpp
@@ -34,8 +34,7 @@ using std::max;
 namespace sum_pooling_impl {
 
 template <typename TI, typename TO, int NDIM>
-inline const std::array<TO, NDIM> v2a(const std::vector<TI> &v,
-                                      const int skip = 0) {
+inline const std::array<TO, NDIM> v2a(const vector<TI> &v, const int skip = 0) {
   std::array<TO, NDIM> a;
   for (int i = 0; i < NDIM; i++)
     a[i] = v.at(skip + i);

--- a/src/nbla/function/generic/sync_batch_normalization.cpp
+++ b/src/nbla/function/generic/sync_batch_normalization.cpp
@@ -24,9 +24,8 @@
 namespace nbla {
 
 NBLA_REGISTER_FUNCTION_SOURCE(SyncBatchNormalization,
-                              const std::shared_ptr<Communicator> &,
-                              const std::string &, const vector<int> &, float,
-                              float, bool);
+                              const shared_ptr<Communicator> &, const string &,
+                              const vector<int> &, float, float, bool);
 
 template <typename T>
 void SyncBatchNormalization<T>::setup_impl(const Variables &inputs,

--- a/src/nbla/function/generic/tensor_normalization.cpp
+++ b/src/nbla/function/generic/tensor_normalization.cpp
@@ -75,10 +75,10 @@ void TensorNormalization<T>::setup_impl(const Variables &inputs,
   // batch_norm adapter
   need_adapter_ = this->axes_.size() != 1;
   if (need_adapter_) {
-    bn_in_adapter_.reset(
-        new BatchNormalizationInOutAdapter(ctx_, ndim, x_shape, axes_));
-    bn_param_adapter_.reset(
-        new BatchNormalizationInOutAdapter(ctx_, ndim, bn_param_shape_, axes_));
+    bn_in_adapter_ =
+        make_unique<BatchNormalizationInOutAdapter>(ctx_, ndim, x_shape, axes_);
+    bn_param_adapter_ = make_unique<BatchNormalizationInOutAdapter>(
+        ctx_, ndim, bn_param_shape_, axes_);
 
     const int bn_axis = ndim - axes_.size();
     // ndim of batch_norm input x will be 1 when ndim - axes_.size() == 0. In

--- a/src/nbla/function/generic/top_k_data.cpp
+++ b/src/nbla/function/generic/top_k_data.cpp
@@ -72,8 +72,8 @@ void TopKData<T>::forward_impl(const Variables &inputs,
   auto y_data = y->cast_data_and_get_pointer<T>(this->ctx_);
   auto tk_idx = top_k_idx_.cast_data_and_get_pointer<size_t>(this->ctx_);
 
-  std::function<void(const T *, const size_t, const size_t, size_t *)>
-      top_k_func = this->abs_ ? top_k_abs<T> : top_k<T>;
+  function<void(const T *, const size_t, const size_t, size_t *)> top_k_func =
+      this->abs_ ? top_k_abs<T> : top_k<T>;
 
   for (int s = 0; s < this->ns_; s++) {
     top_k_func(x_data, this->ss_, this->k_, tk_idx);

--- a/src/nbla/function/generic/top_k_grad.cpp
+++ b/src/nbla/function/generic/top_k_grad.cpp
@@ -77,8 +77,8 @@ void TopKGrad<T>::backward_impl(const Variables &inputs,
   auto x_grad = x->cast_grad_and_get_pointer<T>(this->ctx_);
   auto tk_idx = top_k_idx_.cast_data_and_get_pointer<size_t>(this->ctx_);
 
-  std::function<void(const T *, const size_t, const size_t, size_t *)>
-      top_k_func = this->abs_ ? top_k_abs<T> : top_k<T>;
+  function<void(const T *, const size_t, const size_t, size_t *)> top_k_func =
+      this->abs_ ? top_k_abs<T> : top_k<T>;
 
   auto inner_size = y->size(this->base_axis_);
   auto outer_size = y->size() / inner_size;

--- a/src/nbla/function/nontemplate/callback.cpp
+++ b/src/nbla/function/nontemplate/callback.cpp
@@ -29,4 +29,8 @@ void Callback::backward_impl(const Variables &inputs, const Variables &outputs,
                              const vector<bool> &accum) {
   backward_callback_(obj_, inputs, outputs, propagate_down, accum);
 }
+
+vector<string> Callback::allowed_array_classes() {
+  return SingletonManager::get<Cpu>()->array_classes();
+}
 }

--- a/src/nbla/functions.cpp.tmpl
+++ b/src/nbla/functions.cpp.tmpl
@@ -29,7 +29,6 @@
 #include <nbla/functions.hpp>
 #include <nbla/auto_forward.hpp>
 
-using std::make_shared;
 % for name, snake_name, _ in function_list:
 #include <nbla/function/${snake_name}.hpp>
 % endfor

--- a/src/nbla/imperative.cpp
+++ b/src/nbla/imperative.cpp
@@ -19,8 +19,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 vector<NdArrayPtr> execute(FunctionPtr func, const vector<NdArrayPtr> &inputs,
                            int n_outputs, vector<NdArrayPtr> outputs) {
   // Check inplace outputs size.

--- a/src/nbla/initializer.cpp
+++ b/src/nbla/initializer.cpp
@@ -20,7 +20,6 @@
 #include <nbla/exception.hpp>
 #include <nbla/initializer.hpp>
 #include <nbla/random_manager.hpp>
-using std::make_shared;
 
 namespace nbla {
 

--- a/src/nbla/memory/allocator_callback.cpp
+++ b/src/nbla/memory/allocator_callback.cpp
@@ -26,23 +26,21 @@ void PrintingAllocatorCallback::on_alloc(size_t bytes,
                                          const string &device_id) {
   std::cout << format_string(
                    "PrintingAllocatorCallback::on_alloc(%s, %s) in %s.",
-                   std::to_string(bytes).c_str(), device_id.c_str(),
-                   name_.c_str())
+                   to_string(bytes).c_str(), device_id.c_str(), name_.c_str())
             << std::endl;
 }
 void PrintingAllocatorCallback::on_free(size_t bytes, const string &device_id) {
   std::cout << format_string(
                    "PrintingAllocatorCallback::on_free(%s, %s) in %s.",
-                   std::to_string(bytes).c_str(), device_id.c_str(),
-                   name_.c_str())
+                   to_string(bytes).c_str(), device_id.c_str(), name_.c_str())
             << std::endl;
 }
 void PrintingAllocatorCallback::on_free_unused_device_caches(
     const string &device_id, size_t freed_bytes) {
   std::cout << format_string("PrintingAllocatorCallback::on_free_unused_device_"
                              "caches(%s, %s) in %s.",
-                             device_id.c_str(),
-                             std::to_string(freed_bytes).c_str(), name_.c_str())
+                             device_id.c_str(), to_string(freed_bytes).c_str(),
+                             name_.c_str())
             << std::endl;
 }
 void PrintingAllocatorCallback::on_allocation_failure() {

--- a/src/nbla/memory/caching_allocator_with_buckets.cpp
+++ b/src/nbla/memory/caching_allocator_with_buckets.cpp
@@ -22,7 +22,7 @@
 #include <thread>
 
 static std::mutex m;
-static std::map<std::thread::id, int> thread_ids;
+static map<std::thread::id, int> thread_ids;
 static int thread_id = 0;
 inline int get_thread_id() {
   std::lock_guard<std::mutex> lock(m);
@@ -120,7 +120,7 @@ static void
 print_device_cache_map(const char *prefix, void *self,
                        const CachingAllocatorWithBucketsBase::DeviceCacheMap &m,
                        bool small) {
-  std::vector<size_t> sizes;
+  vector<size_t> sizes;
   for (auto &i : m) {
     sizes.push_back(i.second->bytes());
   }
@@ -280,7 +280,7 @@ CachingAllocatorWithBucketsBase::get_max_cache_bytes(const string &device_id) {
 }
 
 size_t CachingAllocatorWithBucketsBase::get_total_cache_bytes(
-    const std::string &device_id) {
+    const string &device_id) {
   size_t total_bytes = 0;
 
   // small
@@ -297,7 +297,7 @@ size_t CachingAllocatorWithBucketsBase::get_total_cache_bytes(
 }
 
 size_t CachingAllocatorWithBucketsBase::get_fragmentation_bytes(
-    const std::string &device_id) {
+    const string &device_id) {
   return get_total_cache_bytes(device_id) - get_max_cache_bytes(device_id);
 }
 
@@ -306,8 +306,8 @@ size_t CachingAllocatorWithBucketsBase::get_max_available_bytes(
   return get_max_cache_bytes(device_id);
 }
 
-std::vector<int> CachingAllocatorWithBucketsBase::get_used_memory_counts(
-    const std::string &device_id) {
+vector<int> CachingAllocatorWithBucketsBase::get_used_memory_counts(
+    const string &device_id) {
   // small
   auto small_cnt = small_memory_counter_[device_id];
 

--- a/src/nbla/memory/cpu_memory.cpp
+++ b/src/nbla/memory/cpu_memory.cpp
@@ -25,7 +25,6 @@
 #endif
 
 namespace nbla {
-using std::make_shared;
 // ----------------------------------------------------------------------
 // CpuMemory implementation
 // ----------------------------------------------------------------------
@@ -44,11 +43,11 @@ CpuMemory::~CpuMemory() {
                     "Trying to free memory which has a prev (allocated "
                     "by another memory and split previously).");
   DEBUG_LOG("%s: %zu at %p\n", __func__, this->bytes(), ptr_);
-  ::free(ptr_);
+  ::nbla::free(ptr_);
 }
 
 bool CpuMemory::alloc_impl() {
-  ptr_ = ::malloc(this->bytes());
+  ptr_ = ::nbla::malloc(this->bytes());
   DEBUG_LOG("%s: %zu at %p\n", __func__, this->bytes(), ptr_);
   return bool(ptr_);
 }
@@ -62,7 +61,7 @@ shared_ptr<Memory> CpuMemory::divide_impl(size_t second_start) {
   size_t out_bytes = this->bytes() - second_start;
   void *out_ptr = (void *)((uint8_t *)ptr_ + second_start);
   return shared_ptr<Memory>(
-      new CpuMemory(out_bytes, this->device_id(), out_ptr));
+      NBLA_NEW_OBJECT(CpuMemory, out_bytes, this->device_id(), out_ptr));
 }
 
 void CpuMemory::merge_next_impl(Memory *from) {

--- a/src/nbla/memory/virtual_caching_allocator.cpp
+++ b/src/nbla/memory/virtual_caching_allocator.cpp
@@ -88,7 +88,7 @@ void VirtualCachingAllocatorBase::alloc_physical_memory(
 
 void VirtualCachingAllocatorBase::alloc_physical_memory_with_retry(
     size_t alloc_bytes, const string &device_id, size_t &p_mem_bytes,
-    std::vector<PhysicalMemoryPtr> &p_mems) {
+    vector<PhysicalMemoryPtr> &p_mems) {
   // Retry allocation logic.
   try {
     // Additionally allocate physical memory if needed.

--- a/src/nbla/nd_array.cpp
+++ b/src/nbla/nd_array.cpp
@@ -18,8 +18,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 void NdArray::update_shape_info() {
   size_ = compute_size_by_shape(shape_);
   strides_ = get_c_contiguous_strides(shape_);
@@ -28,7 +26,7 @@ void NdArray::update_shape_info() {
 
 NdArray::NdArray(const Shape_t &shape) : shape_(shape) {
   update_shape_info();
-  array_.reset(new SyncedArray(size_));
+  array_ = make_shared<SyncedArray>(size_);
 }
 
 NdArray::NdArray(SyncedArrayPtr array, const Shape_t &shape) : shape_(shape) {
@@ -54,7 +52,7 @@ void NdArray::reshape(const Shape_t &shape, bool force) {
                                        "(clearing data).");
   shape_ = shape;
   update_shape_info();
-  array_.reset(new SyncedArray(size_));
+  array_ = make_shared<SyncedArray>(size_);
 }
 
 NdArrayPtr NdArray::view(const Shape_t &shape) {

--- a/src/nbla/parametric_functions.cpp
+++ b/src/nbla/parametric_functions.cpp
@@ -32,7 +32,6 @@
 #include <nbla/function/deconvolution.hpp>
 #include <nbla/global_context.hpp>
 #include <nbla/parametric_functions.hpp>
-using std::make_shared;
 
 namespace nbla {
 

--- a/src/nbla/solver.cpp
+++ b/src/nbla/solver.cpp
@@ -36,7 +36,6 @@ void clear_param(pair<string, Params> &kv) {
 }
 #endif
 
-using std::make_shared;
 using std::make_pair;
 
 /** UpdateHookWithObject Implementation **/

--- a/src/nbla/solver/generic/adabelief.cpp
+++ b/src/nbla/solver/generic/adabelief.cpp
@@ -21,8 +21,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::make_shared;
-using std::shared_ptr;
 
 NBLA_REGISTER_SOLVER_SOURCE(AdaBelief, float, float, float, float, float, bool,
                             bool, bool, bool);

--- a/src/nbla/solver/generic/adabound.cpp
+++ b/src/nbla/solver/generic/adabound.cpp
@@ -21,8 +21,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(AdaBound, float, float, float, float, float, float);
 

--- a/src/nbla/solver/generic/adadelta.cpp
+++ b/src/nbla/solver/generic/adadelta.cpp
@@ -20,8 +20,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Adadelta, float, float, float);
 

--- a/src/nbla/solver/generic/adagrad.cpp
+++ b/src/nbla/solver/generic/adagrad.cpp
@@ -20,8 +20,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Adagrad, float, float);
 

--- a/src/nbla/solver/generic/adam.cpp
+++ b/src/nbla/solver/generic/adam.cpp
@@ -21,8 +21,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Adam, float, float, float, float);
 

--- a/src/nbla/solver/generic/adamax.cpp
+++ b/src/nbla/solver/generic/adamax.cpp
@@ -21,8 +21,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Adamax, float, float, float, float);
 

--- a/src/nbla/solver/generic/adamw.cpp
+++ b/src/nbla/solver/generic/adamw.cpp
@@ -21,8 +21,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(AdamW, float, float, float, float, float);
 

--- a/src/nbla/solver/generic/amsbound.cpp
+++ b/src/nbla/solver/generic/amsbound.cpp
@@ -21,8 +21,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(AMSBound, float, float, float, float, float, float,
                             bool);

--- a/src/nbla/solver/generic/amsgrad.cpp
+++ b/src/nbla/solver/generic/amsgrad.cpp
@@ -21,8 +21,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(AMSGRAD, float, float, float, float, bool);
 

--- a/src/nbla/solver/generic/lars.cpp
+++ b/src/nbla/solver/generic/lars.cpp
@@ -21,8 +21,6 @@
 #include <numeric>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Lars, float, float, float, float);
 

--- a/src/nbla/solver/generic/momentum.cpp
+++ b/src/nbla/solver/generic/momentum.cpp
@@ -19,8 +19,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Momentum, float, float);
 

--- a/src/nbla/solver/generic/nesterov.cpp
+++ b/src/nbla/solver/generic/nesterov.cpp
@@ -19,8 +19,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Nesterov, float, float);
 

--- a/src/nbla/solver/generic/rmsprop.cpp
+++ b/src/nbla/solver/generic/rmsprop.cpp
@@ -20,8 +20,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(RMSprop, float, float, float);
 

--- a/src/nbla/solver/generic/rmsprop_graves.cpp
+++ b/src/nbla/solver/generic/rmsprop_graves.cpp
@@ -20,8 +20,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::make_shared;
-using std::shared_ptr;
 
 NBLA_REGISTER_SOLVER_SOURCE(RMSpropGraves, float, float, float, float);
 

--- a/src/nbla/solver/generic/sgd.cpp
+++ b/src/nbla/solver/generic/sgd.cpp
@@ -19,8 +19,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(Sgd, float);
 

--- a/src/nbla/solver/generic/sgdw.cpp
+++ b/src/nbla/solver/generic/sgdw.cpp
@@ -19,8 +19,6 @@
 #include <nbla/solver/weight_decay.hpp>
 
 namespace nbla {
-using std::shared_ptr;
-using std::make_shared;
 
 NBLA_REGISTER_SOLVER_SOURCE(SgdW, float, float, float);
 

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -29,7 +29,7 @@ static bool sync_debug_enabled() {
   if (env_c == nullptr) {
     return true;
   }
-  std::string env = std::string(env_c);
+  string env = string(env_c);
   try {
     if (std::stoi(env) == 0) {
       return false;

--- a/src/nbla/utils/dlpack_utils.cpp
+++ b/src/nbla/utils/dlpack_utils.cpp
@@ -153,12 +153,12 @@ public:
 
 void deleter(struct DLManagedTensor *self) {
   // Delete the members
-  delete[] self->dl_tensor.shape;
-  delete[] self->dl_tensor.strides;
-  delete static_cast<manager_ctx *>(self->manager_ctx);
+  delete_array(self->dl_tensor.shape);
+  delete_array(self->dl_tensor.strides);
+  delete_object(static_cast<manager_ctx *>(self->manager_ctx));
 
   // Finally delete itself.
-  delete self;
+  delete_object(self);
 }
 
 DLManagedTensor *to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
@@ -204,13 +204,15 @@ DLManagedTensor *to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
   dl_tensor.dtype.lanes = 1;
 
   // shape
-  dl_tensor.shape = new int64_t[dl_tensor.ndim]; // will deleted in deleter.
+  dl_tensor.shape =
+      new_array<int64_t>(dl_tensor.ndim); // will deleted in deleter.
   for (int i = 0; i < dl_tensor.ndim; i++) {
     dl_tensor.shape[i] = shape[i];
   }
 
   // strides
-  dl_tensor.strides = new int64_t[dl_tensor.ndim]; // will deleted in deleter.
+  dl_tensor.strides =
+      new_array<int64_t>(dl_tensor.ndim); // will deleted in deleter.
   for (int i = 0; i < dl_tensor.ndim; i++) {
     dl_tensor.strides[i] = strides[i];
   }
@@ -219,14 +221,14 @@ DLManagedTensor *to_dlpack_impl(const shared_ptr<Array> &arr_ptr,
   dl_tensor.byte_offset = 0;
 
   // Create a DLManagedTensor
-  auto dl_managed_tensor = new DLManagedTensor();
+  auto dl_managed_tensor = new_object<DLManagedTensor>();
 
   // dl_tensor
   dl_managed_tensor->dl_tensor = dl_tensor;
 
   // manager_ctx
   dl_managed_tensor->manager_ctx =
-      static_cast<void *>(new manager_ctx(arr_ptr));
+      static_cast<void *>(new_object<manager_ctx>(arr_ptr));
 
   // deleter
   dl_managed_tensor->deleter = deleter;

--- a/src/nbla/variable.cpp
+++ b/src/nbla/variable.cpp
@@ -21,8 +21,6 @@
 
 namespace nbla {
 
-using std::make_shared;
-
 void Variable::update_shape_info() {
   size_ = compute_size_by_shape(shape_);
   strides_ = get_c_contiguous_strides(shape_);
@@ -31,15 +29,15 @@ void Variable::update_shape_info() {
 
 Variable::Variable(const Shape_t &shape) : shape_(shape) {
   update_shape_info();
-  data_.reset(new NdArray(shape_));
-  grad_.reset(new NdArray(shape_));
+  data_ = make_shared<NdArray>(shape_);
+  grad_ = make_shared<NdArray>(shape_);
 }
 
 Variable::Variable(NdArrayPtr data) {
   shape_ = data->shape();
   update_shape_info();
   data_ = data;
-  grad_.reset(new NdArray(shape_));
+  grad_ = make_shared<NdArray>(shape_);
 }
 
 void Variable::reshape(const vector<int64_t> &shape, bool force) {

--- a/src/nbla_cli/nbla_dump.cpp
+++ b/src/nbla_cli/nbla_dump.cpp
@@ -46,7 +46,7 @@ bool nbla_dump(int argc, char *argv[]) {
   int i = 0, j = 0;
   for (auto it = names.begin(); it != names.end(); it++, i++) {
     std::cout << "  Executor No." << i << " Name [" << *it << "]" << std::endl;
-    shared_ptr<nbla::utils::nnp::Executor> exec = nnp.get_executor(*it);
+    std::shared_ptr<nbla::utils::nnp::Executor> exec = nnp.get_executor(*it);
     if (p.get<int>("batch_size") < 0) {
       std::cout << "    Using default batch size " << exec->batch_size() << " ."
                 << std::endl;

--- a/src/nbla_utils/nnp.cpp
+++ b/src/nbla_utils/nnp.cpp
@@ -34,8 +34,7 @@ namespace nnp {
 // ----------------------------------------------------------------------
 // Network
 // ----------------------------------------------------------------------
-Network::Network(NetworkImpl *impl)
-    : impl_(std::unique_ptr<NetworkImpl>(impl)) {}
+Network::Network(NetworkImpl *impl) : impl_(unique_ptr<NetworkImpl>(impl)) {}
 
 void Network::replace_variable(const string &name, CgVariablePtr variable) {
   impl_->replace_variable(name, variable);
@@ -57,7 +56,7 @@ int Network::batch_size() const { return impl_->batch_size(); }
 // Executor
 // ----------------------------------------------------------------------
 Executor::Executor(ExecutorImpl *impl)
-    : impl_(std::unique_ptr<ExecutorImpl>(impl)) {}
+    : impl_(unique_ptr<ExecutorImpl>(impl)) {}
 string Executor::name() const { return impl_->name(); }
 string Executor::network_name() const { return impl_->network_name(); }
 void Executor::set_batch_size(int batch_size) {
@@ -77,7 +76,7 @@ void Executor::execute() { impl_->execute(); }
 // Optimizer
 // ----------------------------------------------------------------------
 Optimizer::Optimizer(OptimizerImpl *impl)
-    : impl_(std::unique_ptr<OptimizerImpl>(impl)) {}
+    : impl_(unique_ptr<OptimizerImpl>(impl)) {}
 
 string Optimizer::name() const { return impl_->name(); }
 string Optimizer::network_name() const { return impl_->network_name(); }
@@ -90,8 +89,7 @@ const float Optimizer::update(const int iter) { return impl_->update(iter); }
 // ----------------------------------------------------------------------
 // Monitor
 // ----------------------------------------------------------------------
-Monitor::Monitor(MonitorImpl *impl)
-    : impl_(std::unique_ptr<MonitorImpl>(impl)) {}
+Monitor::Monitor(MonitorImpl *impl) : impl_(unique_ptr<MonitorImpl>(impl)) {}
 
 string Monitor::name() const { return impl_->name(); }
 string Monitor::network_name() const { return impl_->network_name(); }
@@ -102,7 +100,7 @@ const float Monitor::monitor_epoch() { return impl_->monitor_epoch(); }
 // TrainingConfig
 // ----------------------------------------------------------------------
 TrainingConfig::TrainingConfig(TrainingConfigImpl *impl)
-    : impl_(std::unique_ptr<TrainingConfigImpl>(impl)) {}
+    : impl_(unique_ptr<TrainingConfigImpl>(impl)) {}
 
 const long long int TrainingConfig::max_epoch() const {
   return impl_->max_epoch();
@@ -117,7 +115,7 @@ const bool TrainingConfig::save_best() const { return impl_->save_best(); }
 // ----------------------------------------------------------------------
 // Nnp
 // ----------------------------------------------------------------------
-Nnp::Nnp(const nbla::Context &ctx) : impl_(new NnpImpl(ctx)) {
+Nnp::Nnp(const nbla::Context &ctx) : impl_(NBLA_NEW_OBJECT(NnpImpl, ctx)) {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 }
 
@@ -125,7 +123,7 @@ Nnp::~Nnp() {}
 
 bool Nnp::add(const string &filename) {
   int ep = filename.find_last_of(".");
-  std::string extname = filename.substr(ep, filename.size() - ep);
+  string extname = filename.substr(ep, filename.size() - ep);
 
   if (extname == ".prototxt" || extname == ".nntxt") {
     return impl_->add_prototxt(filename);
@@ -135,7 +133,7 @@ bool Nnp::add(const string &filename) {
     std::ifstream file(filename.c_str(), std::ios::binary | std::ios::ate);
     std::streamsize size = file.tellg();
     file.seekg(0, std::ios::beg);
-    std::vector<char> buffer(size);
+    vector<char> buffer(size);
     if (file.read(buffer.data(), size)) {
       return impl_->add_hdf5(buffer.data(), size);
     }

--- a/src/nbla_utils/nnp_impl.hpp
+++ b/src/nbla_utils/nnp_impl.hpp
@@ -49,11 +49,6 @@ namespace nbla {
 namespace utils {
 namespace nnp {
 
-using std::unordered_map;
-using std::shared_ptr;
-using std::unique_ptr;
-using std::string;
-
 // Forward dec
 class NnpImpl;
 
@@ -253,7 +248,7 @@ private:
   VariableBuffer(const VariableBuffer &) = delete;
   VariableBuffer &operator=(const VariableBuffer &) = delete;
 
-  char *buffer_;
+  unique_ptr<char[]> buffer_;
   dtypes data_type_;
   int block_size_;
   Shape_t shape_;
@@ -308,7 +303,7 @@ private:
   vector<shared_ptr<std::thread>> workers_;
   uint32_t iter_;
   bool req_exit_;
-  std::queue<queue_data_type> queue_;
+  queue<queue_data_type> queue_;
   mutable std::mutex mutex_;
   std::condition_variable full_cond_;
   std::condition_variable empty_cond_;
@@ -476,15 +471,14 @@ class NnpImpl {
 
   void update_parameters();
   int get_network_repeat_nest_depth(const ::Network &orig);
-  std::vector<std::string> create_suffixes(std::string prefix,
-                                           std::vector<std::string> ids,
-                                           std::vector<int> times);
-  std::vector<std::string>
-  create_var_suffixes(std::map<std::string, int> repeat_info, ::Variable var);
-  std::vector<std::string>
-  create_func_suffixes(std::map<std::string, int> repeat_info, ::Function func);
+  vector<string> create_suffixes(string prefix, vector<string> ids,
+                                 vector<int> times);
+  vector<string> create_var_suffixes(map<string, int> repeat_info,
+                                     ::Variable var);
+  vector<string> create_func_suffixes(map<string, int> repeat_info,
+                                      ::Function func);
   ::Network expand_network(const ::Network &orig);
-  const ::Network &search_network(std::string name);
+  const ::Network &search_network(string name);
 
   NnpImpl(const nbla::Context &ctx);
 
@@ -492,9 +486,9 @@ public:
   ~NnpImpl() {}
 
   bool add_archive(void *archive);
-  bool add_prototxt(std::string filename);
+  bool add_prototxt(string filename);
   bool add_prototxt(char *buffer, int size);
-  bool add_protobuf(std::string filename);
+  bool add_protobuf(string filename);
   bool add_protobuf(char *buffer, int size);
   bool add_hdf5(char *buffer, int size);
   vector<string> get_network_names();

--- a/src/nbla_utils/nnp_impl_configs.cpp
+++ b/src/nbla_utils/nnp_impl_configs.cpp
@@ -38,8 +38,8 @@ GlobalConfigImpl::create_context(const ::Context &ctx) {
   vector<string> backends;
   backends.insert(backends.begin(), ctx.backends().begin(),
                   ctx.backends().end());
-  return shared_ptr<nbla::Context>(
-      new Context(backends, ctx.array_class(), ctx.device_id()));
+  return make_shared<nbla::Context>(backends, ctx.array_class(),
+                                    ctx.device_id());
 }
 
 shared_ptr<nbla::Context> GlobalConfigImpl::default_context() {

--- a/src/nbla_utils/nnp_impl_create_function.cpp.tmpl
+++ b/src/nbla_utils/nnp_impl_create_function.cpp.tmpl
@@ -37,11 +37,11 @@ from utils.type_conv import type_from_proto
 
 def proto_to_ctype(name, arg):
     if arg['type'] == 'Shape':
-        return 'std::vector<int> arg_{0}(param.{0}().dim().begin(), param.{0}().dim().end())'.format(name)
+        return 'vector<int> arg_{0}(param.{0}().dim().begin(), param.{0}().dim().end())'.format(name)
     if arg['type'] == 'repeated int64':
-        return 'std::vector<int> arg_{0}(param.{0}().begin(), param.{0}().end())'.format(name)
+        return 'vector<int> arg_{0}(param.{0}().begin(), param.{0}().end())'.format(name)
     if arg['type'] == 'repeated float':
-        return 'std::vector<float> arg_{0}(param.{0}().begin(), param.{0}().end())'.format(name)
+        return 'vector<float> arg_{0}(param.{0}().begin(), param.{0}().end())'.format(name)
     return '{0} arg_{1} = param.{1}()'.format(type_from_proto[arg['type']]['cpp_var'], name)
     
 %>
@@ -109,7 +109,7 @@ shared_ptr<nbla::CgFunction> NetworkImpl::create_cgfunction(const ::Function& fu
 % endfor
 % endif
     nbla::FunctionPtr fp = create_${name}(ctx_${''.join([', arg_' + argname for argname in func.get('arguments', {}).keys()])});
-    return std::make_shared<nbla::CgFunction>(fp);
+    return make_shared<nbla::CgFunction>(fp);
   }
 % endfor
   return nullptr;

--- a/src/nbla_utils/nnp_impl_dataset_hdf5.cpp
+++ b/src/nbla_utils/nnp_impl_dataset_hdf5.cpp
@@ -153,7 +153,7 @@ bool parse_hdf5_group(hid_t gid, vector<string> &data_names,
   return true;
 }
 
-bool read_file_to_str(const std::string &filename, std::string &data) {
+bool read_file_to_str(const string &filename, string &data) {
 
   std::ifstream file(filename.c_str(), std::ios::binary | std::ios::ate);
   if (!file) {

--- a/src/nbla_utils/nnp_impl_dataset_npy.hpp
+++ b/src/nbla_utils/nnp_impl_dataset_npy.hpp
@@ -36,7 +36,7 @@ namespace nnp {
 */
 struct FileResource {
   FILE *fp_;
-  FileResource(const std::string &filename);
+  FileResource(const string &filename);
   ~FileResource();
   bool read(char *buffer, size_t size);
   bool gets(char *buffer, size_t size);
@@ -118,9 +118,9 @@ private:
   int cache_file_data_size_;
   int data_size_;
   int batch_data_size_;
-  char *buffer_;
-  char *shuffle_buffer_;
-  std::queue<CacheFile *> file_queue_;
+  unique_ptr<char[]> buffer_;
+  unique_ptr<char[]> shuffle_buffer_;
+  queue<CacheFile *> file_queue_;
   dtypes data_type_;
   Shape_t shape_;
   string variable_name_;

--- a/src/nbla_utils/nnp_impl_monitor.cpp
+++ b/src/nbla_utils/nnp_impl_monitor.cpp
@@ -39,8 +39,7 @@ MonitorImpl::MonitorImpl(const nbla::Context &ctx, const ::Monitor &monitor,
                          shared_ptr<Network> network,
                          shared_ptr<DatasetImpl> dataset)
     : ctx_(ctx), monitor_proto_(monitor), network_(network), dataset_(dataset) {
-  data_iterator_ = shared_ptr<DataIteratorFromCacheFiles>(
-      new DataIteratorFromCacheFiles(dataset));
+  data_iterator_ = make_shared<DataIteratorFromCacheFiles>(dataset);
   network_->set_batch_size(data_iterator_->get_batch_size());
 }
 

--- a/src/nbla_utils/nnp_impl_optimizer.cpp
+++ b/src/nbla_utils/nnp_impl_optimizer.cpp
@@ -61,8 +61,7 @@ OptimizerImpl::OptimizerImpl(const nbla::Context &ctx,
     std::cout << "Update interval is forced to 1." << std::endl;
   }
 
-  data_iterator_ = shared_ptr<DataIteratorFromCacheFiles>(
-      new DataIteratorFromCacheFiles(dataset));
+  data_iterator_ = make_shared<DataIteratorFromCacheFiles>(dataset);
   network_->set_batch_size(data_iterator_->get_batch_size());
 }
 

--- a/src/nbla_utils/nnp_network_expander.cpp
+++ b/src/nbla_utils/nnp_network_expander.cpp
@@ -56,10 +56,10 @@ const int MAX_NAME_LEN = 512;
 #ifdef DEBUG_NETWORK_EXPANDER
 void dump_proto_network(const ::Network &network) {
   static int c = 0;
-  std::string output;
+  string output;
   google::protobuf::TextFormat::PrintToString(network, &output);
   std::ofstream network_proto_file;
-  std::string network_pb_txt = "network_nntxt_" + std::to_string(c++) + ".txt";
+  string network_pb_txt = "network_nntxt_" + to_string(c++) + ".txt";
   network_proto_file.open(network_pb_txt, std::ios::out);
   network_proto_file << output;
   network_proto_file.close();

--- a/src/nbla_utils/nnp_network_expander.hpp
+++ b/src/nbla_utils/nnp_network_expander.hpp
@@ -43,16 +43,16 @@ private:
 private:
   ::Network expand_;
   const ::Network &network_;
-  std::list<::Function> sorted_;
-  std::unordered_map<std::string, VisitState> visitor_state_;
+  list<::Function> sorted_;
+  unordered_map<string, VisitState> visitor_state_;
   bool old_naming_;
-  std::map<std::string, vector<std::string>> param_original_names_;
-  std::map<std::string, vector<std::string>> delay_var_;
-  std::map<std::string, vector<std::string>> repeat_end_var_;
-  std::map<std::string, vector<std::string>> repeat_start_var_;
+  map<string, vector<string>> param_original_names_;
+  map<string, vector<string>> delay_var_;
+  map<string, vector<string>> repeat_end_var_;
+  map<string, vector<string>> repeat_start_var_;
 };
 
-template <typename T> bool is_in(std::string k, const T &m) {
+template <typename T> bool is_in(string k, const T &m) {
   return (m.find(k) != m.end());
 };
 


### PR DESCRIPTION
This PR puts C++ standard library types and functions with memory allocation in a new header `include/nbla/std.hpp`.
This modification is intended to make it easier to replace C++ allocator for embedded systems.

* Add `include/nbla/std.hpp` includes the following definitions:
    * Memory allocation functions to replace `malloc`, `free`, `new` and `delete`
        * `nbla::malloc`, `nbla::free`, `nbla::aligned_alloc`, `nbla::realloc`
        * `new_object`, `delete_object`
        * `new_array`, `delete_array`
    * STL containers and memory management types
        * `string`, `stringstream`, `to_string`
        * `vector`, `list`, `stack`, `queue`, `priority_queue`, `deque`,
          `map`, `multimap`, `set`, `unordered_map`, `unordered_set`
        * `function`
        * `shared_ptr`, `weak_ptr`, `enable_shared_from_this`, `unique_ptr`
        * `make_shared`, `make_unique`
* Replace `std::` with `nbla::` at the uses of the above types and functions in nnabla.

**Note**
* So far, it doesn't force users not to use std types and functions directly. Need to check in our CI/CD pipeline later.
* Duplicate instances in singletons are found in this development on Windows platform, and resolved by properly setting dll specifiers [here](https://github.com/sony/nnabla/pull/1037/files?show-viewed-files=true&file-filters%5B%5D=#diff-6f2c2376eaddc0da83457011190116ccbbb9ce7c059b8ae334d66c6ece29450aR98) and [here](https://github.com/sony/nnabla/pull/1037/files#diff-0fa94c671f8caf6ab99f3123d2fbdea9deeb1914eb6b9e1ccd8c9155862b4bbbR32-R35).
