### PR TITLE
Improve docker entrypoint set

### DIFF
--- a/docker/release/.entrypoint.sh
+++ b/docker/release/.entrypoint.sh
@@ -14,8 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-set -e
-
 if [ $# -eq 0 ]; then
     exec "/bin/bash"
 else


### PR DESCRIPTION
Docker entrypoint script should remove `set -e`, in case some script command returns non-zero value, further causes entrypoint script exit unexpectly.

Refer to: https://github.com/sony/nnabla-ext-cuda/pull/387
