### PR TITLE
Fix scatter_add for recompute

### DIFF
--- a/include/nbla/function/scatter_add.hpp
+++ b/include/nbla/function/scatter_add.hpp
@@ -117,7 +117,7 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
-    if (i == 0 && j == 1) {
+    if (i == 2 && j == 1) {
       return true;
     }
     return false;


### PR DESCRIPTION
Fix grad_depends_input_data_impl in ScatterAdd.

In backward of ScatterAdd,
* For inputs[0], no data is required,
* We don't support backward for inputs[1],
* For inputs[2], the data of input[1] is required.

Therefore, returning i == 2 && j == 1 is correct (the gradient of i = 2 requires the data of j = 1).

ref: https://nnabla.readthedocs.io/en/latest/python/api/function.html#nnabla.functions.scatter_add