### PR TITLE
 QNN Converter and QAT Scheduler

### DIFF
--- a/doc/python/api/experimentals/graph_converters.rst
+++ b/doc/python/api/experimentals/graph_converters.rst
@@ -43,4 +43,6 @@ Function Modifiers
 
     .. automethod:: __init__
 
+.. autoclass:: nnabla.experimental.graph_converters.QuantizeNonQNNToRecordingModifier
 
+.. autoclass:: nnabla.experimental.graph_converters.QuantizeRecordingToTrainingModifier

--- a/doc/python/api/utils.rst
+++ b/doc/python/api/utils.rst
@@ -11,5 +11,6 @@ Utils
     utils/dlpack.rst
     utils/rnn.rst
     utils/misc.rst
+    utils/quantization_aware_training.rst
 
 

--- a/doc/python/api/utils/quantization_aware_training.rst
+++ b/doc/python/api/utils/quantization_aware_training.rst
@@ -1,0 +1,29 @@
+==============
+Quantization Aware Training
+==============
+
+QATConfig
+==============
+
+Configuration for quantization aware training.
+
+.. autoclass:: nnabla.utils.qnn.QATConfig
+    :members:
+    :inherited-members:
+    :show-inheritance:
+
+QATTensorRTConfig
+==============
+
+The default quantization aware training Configuration that meets the requirements of TensorRT.
+
+.. autoclass:: nnabla.utils.qnn.QATTensorRTConfig
+    :members:
+
+QATScheduler
+==============
+
+.. autoclass:: nnabla.utils.qnn.QATScheduler
+    :members:
+    :inherited-members:
+    :show-inheritance:

--- a/doc/python/file_format_converter/file_format_converter.rst
+++ b/doc/python/file_format_converter/file_format_converter.rst
@@ -1,3 +1,5 @@
+.. _File_Format_Converter:
+
 File format converter
 =====================
 

--- a/doc/python/tutorial.rst
+++ b/doc/python/tutorial.rst
@@ -18,3 +18,4 @@ If you want to run these step-by-step, follow the link and see the instruction f
     tutorial/mixed_precision_training.rst
     tutorial/multi_device_training.rst
     tutorial/function_list_and_converter.rst
+    tutorial/quantization_aware_training.rst

--- a/doc/python/tutorial/quantization_aware_training.rst
+++ b/doc/python/tutorial/quantization_aware_training.rst
@@ -1,0 +1,112 @@
+
+Quantization-Aware-Training Tutorial
+========================================
+
+What is model Quantization-Aware-Training
+--------------------------
+In general, the weights and the activations of artificial neural networks are represented by float32; on the other hand, model quantization means use lower precision to represent numbers, such as float16, int8 and uint8.
+
+By reducing the precision we can reduce model size and memory occupancy. What's more, on some devices we can also shorten the inference time.
+
+However, using lower precision instead of float32 will introduces quantization error to the model. Quantization-Aware-Training (QAT) mitigates the quantization errors by simulating quantization effect at training time.
+
+Quantization-Aware-Training with NNabla
+-----------------------------------
+In nnabla, we divide QAT into two stages, RERORDING and TRAINING.
+In RECORDING stage, we will collect and record the dynamic range of each parameter and buffer.
+In TRAINING stage, we will insert Quantization&Dequantization node to simulate the quantization effect.
+
+We provide QATScheduler to support Quantization-Aware-Training.
+Here is some sample code about QATScheduler.
+
+Create QATScheduler
+~~~~~~~~~~~~~~~~~~~~
+Firstly, we need to create a QATScheduler. QATScheduler will convert the network automatically to make it support Quantization-Aware-Training.
+
+.. code:: python
+
+    from nnabla.utils.qnn import QATScheduler, QATConfig, PrecisionMode
+    # Create training network
+    pred = model(image, test=False)
+    # Create validation network
+    vpred = model(vimage, test=True)
+    # configure of QATScheduler
+    config = QATConfig()
+    config.bn_folding = True
+    config.bn_self_folding = True
+    config.channel_last = False
+    config.precision_mode = PrecisionMode.SIM_QNN
+    config.skip_bias = True
+    config.niter_to_recording = 1
+    config.niter_to_training = steps_per_epoch * 2
+    # Create a QATScheduler object
+    qat_scheduler = QATScheduler(config=config, solver=solver)
+    # register the training network to QATScheduler
+    qat_scheduler(pred)
+    # register the validation network to QATScheduler
+    qat_scheduler(vpred, training=False)
+
+Modify your training loop
+~~~~~~~~~~~~~~~~~~~~~~~~~
+In general, Your training loop should look like this:
+
+.. code:: python
+
+    for step in range(max_step):
+        x, y = dataset.next()
+        image.d, label.d = x, y
+        loss.forward()
+        solver.zero_grad()
+        loss.backword()
+        solver.weight_decay(weight_decay)
+        solver.update()
+
+Compare with the training loop above. You just need to insert a line of code.
+Inside the 'step' function, it records your training step and converts the network when the step reaches 'niter_to_recording' or 'niter_to_recording'.
+
+.. code:: python
+
+    for step in range(max_step):
+        # Run qat_scheduler step by step
+        qat_scheduler.step()
+        x, y = dataset.next()
+        image.d, label.d = x, y
+        loss.forward()
+        solver.zero_grad()
+        loss.backword()
+        solver.weight_decay(weight_decay)
+        solver.update()
+    # Save the QAT model
+    qat_scheduler.save('your_model.nnp', vimage, batch_size=1, deploy=False)
+
+Performance of the quantized model
+----------------------------------
+
+================== =============== ================================= ==========================
+Model              with BN-folding float32 model validation error(%) QAT model validation error(%)
+================== =============== ================================= ==========================
+Mobilenetv1        NO              28.05                             27.53
+Resnet18           NO              29.66                             28.71
+Resnet50           NO              23.46                             23.19
+Mobilenetv1        YES             28.05                             27.92
+Resnet18           YES             29.66                             28.63
+Resnet50           YES             23.46                             23.16
+================== =============== ================================= ==========================
+
+Above is some Quantization-Aware-Training experimental results on imagenet dataset.
+
+Deploy the model with TensorRT
+----------------------------------
+
+========= =============== ====================== ===================== ====================== =====================
+with pow2 with BN-folding maximum absolute error mean absolute error   maximum relative error mean relative error
+========= =============== ====================== ===================== ====================== =====================
+NO        NO              0.0144                 0.0094                9.9737                 0.0907
+NO        YES             4.639e-04              1.577e-04             13.3496                0.0151
+YES       NO              0.0378                 0.0287                21.7627                0.0433
+YES       YES             4.673e-07              3.465e-07             0.00069                2.588e-08
+========= =============== ====================== ===================== ====================== =====================
+
+You can also deploy the NNabla QAT model with other framework by using our :ref:`File_Format_Converter` to convert .nnp to other format.
+Above is the comparision between the output of NNabla and the output of TensorRT. The model we used to compare is mobilenetv1.
+If you want to deploy the model with TensorRT, we recommend that you enable these options in QATConfig: 'bn_folding', 'bn_self_folding', 'pow2', otherwise, the error between NNabla and TensorRT may become large. See also QATTensorRTConfig (lined).

--- a/python/src/nnabla/experimental/graph_converters/__init__.py
+++ b/python/src/nnabla/experimental/graph_converters/__init__.py
@@ -29,3 +29,5 @@ from .test_mode import TestModeModifier
 from .identity import IdentityModifier
 from .no_grad import NoGradModifier
 from .prune import PruningModifier
+from .quantize import (QuantizeNonQNNToRecordingModifier,
+                       QuantizeRecordingToTrainingModifier)

--- a/python/src/nnabla/experimental/graph_converters/graph_converter.py
+++ b/python/src/nnabla/experimental/graph_converters/graph_converter.py
@@ -76,19 +76,12 @@ class FunctionModifier(object):
 
         # Lookup
         inputs = self._map_func_inputs[f]
+
         if len(f.inputs) > 1:
             _inputs = [inp for inp in f.inputs]
-            idxs = []  # index of inpout variable which has already been saved
-            for inp in inputs:
-                for i in range(len(f.inputs)):
-                    finp = f.inputs[i]
-                    if inp.shape[1:] == finp.shape[1:] and i not in idxs:  # ignore batch size
-                        idxs.append(i)
-                        break
-            for i in range(len(idxs)):
-                idx = idxs[i]
-                _inputs[idx] = inputs[i]
-            inputs = _inputs
+            for i in range(len(inputs)):
+                if not inputs[i]:  # i-th input var has not been saved
+                    inputs[i] = _inputs[i]
 
         # Modify
         o = self.modify(f, inputs)
@@ -108,7 +101,11 @@ class FunctionModifier(object):
             if funcs == []:
                 return
             for func in funcs:
-                self._map_func_inputs[func].append(o1)
+                if len(self._map_func_inputs[func]) == 0:  # init to None
+                    self._map_func_inputs[func] = [None] * len(func.inputs)
+                for i, inp in enumerate(func.inputs):
+                    if o0 == inp:
+                        self._map_func_inputs[func][i] = o1
 
     def modify(self, f, inputs):
         """Modify the function.

--- a/python/src/nnabla/experimental/graph_converters/quantize.py
+++ b/python/src/nnabla/experimental/graph_converters/quantize.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nnabla as nn
+import nnabla.functions as F
+import numpy as np
+from collections import defaultdict
+
+from .graph_converter import FunctionModifier
+from .batch_normalization_folding import BatchNormalizationFoldingModifier
+from .batch_normalization_self_folding import BatchNormalizationSelfFoldingModifier
+from .remove_function import RemoveFunctionModifier
+
+
+class QuantizeNonQNNToRecordingModifier(FunctionModifier):
+    def __init__(self, functions_ranks, config=None, training=True):
+        super(QuantizeNonQNNToRecordingModifier, self).__init__()
+        self._config = config
+        self._fct_bin_set = {
+            'Add2': F.add2,
+            'Sub2': F.sub2,
+            'Mul2': F.mul2,
+            'Div2': F.div2,
+            'Pow2': F.pow2
+        }
+        self._training = training
+
+        # Dict to record the rank of each function
+        self.functions_ranks = functions_ranks
+
+    def get_function_rank(self, f):
+        rank = self.functions_ranks.get(f, -1)
+        return rank
+
+    def check(self, f):
+        def backward_traverse(f, l):
+            # list functions between input and f
+            for inp in f.inputs:
+                if inp.parent is not None:
+                    l.append(inp.parent)
+                    backward_traverse(inp.parent, l)
+
+        def forward_traverse(f, l):
+            # list functions between f and output
+            for fref in f.outputs[0].function_references:
+                l.append(fref)
+                forward_traverse(fref, l)
+
+        def is_skip_layer(f):
+            skip_inputs_layers = self._config.skip_inputs_layers
+            skip_outputs_layers = self._config.skip_outputs_layers
+            if not skip_inputs_layers and not skip_outputs_layers:
+                return False
+
+            fs = []
+            if skip_outputs_layers:
+                forward_traverse(f, fs)
+            fs = list(set([func.info.type_name for func in fs]))
+            is_output_layer = True if skip_outputs_layers else False
+            for skl in skip_outputs_layers:
+                if skl in fs:
+                    is_output_layer = False
+                    break
+
+            fs = []
+            if skip_inputs_layers:
+                backward_traverse(f, fs)
+            is_input_layer = True if skip_inputs_layers else False
+            fs = list(set([func.info.type_name for func in fs]))
+            for skl in skip_inputs_layers:
+                if skl in fs:
+                    is_input_layer = False
+                    break
+
+            for skl in skip_inputs_layers:
+                if f.info.type_name == skl and is_input_layer:
+                    return True
+            for skl in skip_outputs_layers:
+                if f.info.type_name == skl and is_output_layer:
+                    return True
+            return False
+
+        fn = f.info.type_name
+        cfg = self._config
+
+        # Do not record sink and bn
+        if fn == 'Sink' or fn == 'BatchNormalization':
+            return False
+
+        # Only add recorder to specific layers
+        # If record_layers empty, add to all layers
+        record_layers = cfg.record_layers
+        if record_layers and (fn not in record_layers):
+            return False
+
+        if is_skip_layer(f):
+            return False
+        return True
+
+    def share_recorder(self, f, inputs, new_inputs, cfg):
+        # share quantization parameters for Add2 and Concat
+        fn = f.info.type_name
+        recorder_activation = cfg.recorder_activation
+        recorder_weight = cfg.recorder_weight
+        axes = [3] if cfg.channel_last else [1]
+
+        if fn in ['Add2', 'Concatenate']:
+            idx = 0
+            min_rank = inputs[0].rank
+            for i, input_var in enumerate(new_inputs[1:]):
+                if input_var.rank < min_rank:
+                    idx = i + 1
+                    min_rank = input_var.rank
+            shared_name = 'x0'
+            scope = self.get_parameter_scope(new_inputs[idx].parent.inputs[1])
+            for i, input_var in enumerate(new_inputs):
+                if i == idx:
+                    continue
+                input_var = input_var.parent.inputs[0]
+                with nn.parameter_scope(scope):
+                    input_var = recorder_activation()(
+                        input_var, axes=axes, training=self._training, name=shared_name)
+                new_inputs[i] = input_var
+        return new_inputs
+
+    def add_recorder(self, f, inputs, cfg):
+        fn = f.info.type_name
+        function_rank = self.get_function_rank(f)
+        scope = '{}-{}'.format(fn, function_rank)
+        axes = [3] if cfg.channel_last else [1]
+        recorder_activation = cfg.recorder_activation
+        recorder_weight = cfg.recorder_weight
+
+        params_idx = 1
+        if fn in ['Concatenate', 'Stack']:
+            params_idx = len(inputs)
+        if fn in self._fct_bin_set:
+            params_idx = 2
+
+        new_inputs = []
+        # Add recorder for variable(activation)
+        for i, input_var in enumerate(inputs[:params_idx]):
+            fref = input_var.function_references
+            if fref and fref[0].info.type_name == cfg.recorder_activation().name():
+                input_var = fref[0].outputs[0]
+            else:
+                with nn.parameter_scope(scope):
+                    parent = input_var.parent
+                    if parent and parent.info.type_name == recorder_activation().name():
+                        input_var = input_var
+                    else:
+                        input_var = recorder_activation()(input_var, axes=axes, training=self._training,
+                                                          name='x{}'.format(i))
+            new_inputs.append(input_var)
+
+        # Add recorder for parameters(weight and bias)
+        for i, input_parameter in enumerate(inputs[params_idx:]):
+            with nn.parameter_scope(scope):
+                input_parameter = recorder_weight()(input_parameter, axes=axes, training=self._training,
+                                                    name='w{}'.format(i))
+            new_inputs.append(input_parameter)
+        return new_inputs
+
+    def modify(self, f, inputs):
+        if not self.check(f):
+            return  # Skip modify this function
+
+        fn = f.info.type_name
+        cfg = self._config
+        axes = [3] if cfg.channel_last else [1]
+        recorder_activation = cfg.recorder_activation
+
+        # Add recorder for each input
+        new_inputs = self.add_recorder(f, inputs, cfg)
+        new_inputs = self.share_recorder(f, inputs, new_inputs, cfg)
+
+        h = self._modify_as_same(f, new_inputs)
+
+        # Add recorder before/after a function
+        next_func = f.outputs[0].function_references[0]
+        next_func_rank = self.get_function_rank(next_func)
+        scope = '{}-{}'.format(next_func.info.type_name, next_func_rank)
+        with nn.parameter_scope(scope):
+            if cfg.recorder_position == cfg.RecorderPosition.BOTH:
+                h = recorder_activation()(h, axes=axes, training=self._training, name='x0')
+        return h

--- a/python/src/nnabla/experimental/graph_converters/quantize.py
+++ b/python/src/nnabla/experimental/graph_converters/quantize.py
@@ -195,3 +195,231 @@ class QuantizeNonQNNToRecordingModifier(FunctionModifier):
             if cfg.recorder_position == cfg.RecorderPosition.BOTH:
                 h = recorder_activation()(h, axes=axes, training=self._training, name='x0')
         return h
+
+
+class QuantizeRecordingToTrainingModifier(FunctionModifier):
+    class SimulatedQNN(object):
+        """
+        Doc here.
+        """
+
+        def __init__(self, functions_ranks, modifier=None, config=None):
+            self._config = config
+            self._modifier = modifier
+            # input: [tuple(scale, zeropoint)]
+            self._map_input_scale_zeropoint = defaultdict(list)
+            # Dict to record the rank of each function
+            self.functions_ranks = functions_ranks
+
+        def get_function_rank(self, f):
+            rank = self.functions_ranks.get(f, -1)
+            return rank
+
+        def _quantize_outputs(self, f, output, axes, cfg):
+            # TODO: multi-outputs
+            rm = cfg.round_mode
+            nr = cfg.narrow_range
+            dt = cfg.dtype
+            pow2 = cfg.pow2.value
+
+            h = output
+            for next_func in f.outputs[0].function_references:
+                next_fn = next_func.info.type_name
+                next_func_rank = self.get_function_rank(next_func)
+                name = 'x0'
+                if next_fn in self._modifier._fct_bin_set:
+                    for i, elm in enumerate(next_func.inputs):
+                        if f.outputs[0] == elm:
+                            name = 'x{}'.format(i)
+                scope = '{}-{}'.format(next_fn, next_func_rank)
+                with nn.parameter_scope(scope):
+                    sy, zpy = cfg.recorder_activation.get_scale_zeropoint(
+                        h, axes=axes, narrow_range=nr, round_method=pow2, name=name)
+                if sy is not None:
+                    break
+
+            # D->Q
+            h = self.try_to_quantize(h, sy, zpy, rm, nr, dt)
+
+            self._map_input_scale_zeropoint[h] = (sy, zpy)
+
+            return h
+
+        def try_to_quantize(self, x, scale, zero_point, round_mode, narrow_range, dtype):
+            x = F.quantize_linear(x, scale, zero_point, round_mode,
+                                  narrow_range, dtype) if scale is not None else x
+            return x
+
+        def try_to_dequantize(self, x, scale, zero_point):
+            x = F.dequantize_linear(
+                x, scale, zero_point) if scale is not None else x
+            return x
+
+        def get_quantization_params(self, variable):
+            scale, zero_point = None, None
+            if variable.parent is not None and variable.parent.info.type_name == 'QuantizeLinear':
+                scale = variable.parent.inputs[1].d
+                zero_point = variable.parent.inputs[2].d
+            return scale, zero_point
+
+        def requantize_bias(self, f, inputs, scope, rm, nr, dt, skip_bias=False):
+            def with_bias():
+                return True if len(inputs) == 3 else False
+            functions_with_bias = ['Affine', 'Convolution', 'Deconvolution', 'DepthwiseConvolution',
+                                   'DepthwiseDeconvolution']
+            fn = f.info.type_name
+
+            # handle bias. recalculate scale and zero point of bias
+            if fn in functions_with_bias and with_bias():
+                x, w, b = inputs
+                sx, zpx, sw = None, None, None
+                # Get scale and zero_point of x
+                sx, zpx = self.get_quantization_params(x)
+                # Get scale and zero_point of w
+                sw, _ = self.get_quantization_params(w)
+                if sx is not None and sw is not None:
+                    sbd = np.reshape(sx.copy(), (1,)) * \
+                          np.reshape(sw.copy(), (1,))
+                    with nn.parameter_scope(scope):
+                        sb = nn.parameter.get_parameter_or_create(
+                            'scale-b', (1,), sbd, False)
+                        zpbd = np.reshape(zpx.copy(), (1,))
+                        zpb = nn.parameter.get_parameter_or_create(
+                            'zeropoint-b', (1,), zpbd, False)
+                        if b.parent is not None and b.parent.info.type_name == 'QuantizeLinear':
+                            b = b.parent.inputs[0]
+                            # Quantize/Dequantize Bias only when skip bias is False
+                            b = F.quantize_linear(
+                                b, sb, zpb, rm, nr, dt) if not skip_bias else b
+                            inputs[2] = b
+            return inputs
+
+        def quantize_inputs(self, f, inputs, scope, cfg, axes, rm, nr, dt, pow2):
+            fn = f.info.type_name
+            params_idx = 1
+            if fn in ['Concatenate', 'Stack']:
+                params_idx = len(inputs)
+            if fn in self._modifier._fct_bin_set:
+                params_idx = 2
+            # Quantize input
+            inps = []
+            for i, input_var in enumerate(inputs[:params_idx]):
+                if input_var.rank == 0:
+                    with nn.parameter_scope(scope):
+                        sx, zpx = cfg.recorder_activation.get_scale_zeropoint(
+                            input_var, axes=axes, narrow_range=nr, round_method=pow2, name='x{}'.format(i))
+                        input_var = self.try_to_quantize(
+                            input_var, sx, zpx, rm, nr, dt)
+                        self._map_input_scale_zeropoint[input_var] = (sx, zpx)
+                inps.append(input_var)
+
+            for i, input_parameter in enumerate(inputs[params_idx:]):
+                with nn.parameter_scope(scope):
+                    sw, zpw = cfg.recorder_weight.get_scale_zeropoint(
+                        input_parameter, axes=axes, narrow_range=nr, round_method=pow2, name='w{}'.format(i))
+                    input_parameter = self.try_to_quantize(
+                        input_parameter, sw, zpw, rm, nr, dt)
+                inps.append(input_parameter)
+
+            # handle bias. recalculate scale and zero point of bias
+            inps = self.requantize_bias(
+                f, inps, scope, rm, nr, dt, cfg.skip_bias)
+            return inps
+
+        def dequantize_inputs(self, inps):
+            # Dequantize input
+            for i, var in enumerate(inps):
+                s, zp = None, None
+                frefs = var.function_references
+                for rf in frefs:
+                    if rf.info.type_name == 'DequantizeLinear':
+                        var = rf.outputs[0]
+                        break
+                if var.parent and var.parent.info.type_name == 'QuantizeLinear':
+                    s, zp = var.parent.inputs[1:3]
+                var = self.try_to_dequantize(var, s, zp)
+                inps[i] = var
+            return inps
+
+        def shared_quantization(self, f, inps, cfg):
+            # share quantization parameter for Add2 and Concat
+            fn = f.info.type_name
+            if fn in ['Add2', 'Concatenate']:
+                idx = 0
+                min_rank = inps[0].rank
+                s, zp = None, None
+                for i, x in enumerate(inps[1:]):
+                    if x.parent is not None and x.parent.info.type_name == 'DequantizeLinear':
+                        if x.rank < min_rank:
+                            idx = i + 1
+                            min_rank = x.rank
+                if inps[idx].parent is not None and inps[idx].parent.info.type_name == 'DequantizeLinear':
+                    s, zp = inps[idx].parent.inputs[1:3]
+
+                for i, x in enumerate(inps):
+                    if i == idx:
+                        continue
+                    if inps[i].parent is not None and inps[i].parent.info.type_name == 'DequantizeLinear':
+                        inps[i] = inps[i].parent.inputs[0].parent.inputs[0]
+                    inps[i] = self.try_to_quantize(inps[i], s, zp,
+                                                   cfg.round_mode,
+                                                   cfg.narrow_range,
+                                                   cfg.dtype)
+                    inps[i] = self.try_to_dequantize(inps[i], s, zp)
+            return inps
+
+        def modify(self, f, inputs):
+            fn = f.info.type_name
+            cfg = self._config
+            function_rank = self.get_function_rank(f)
+            scope = '{}-{}'.format(fn, function_rank)
+
+            rm = cfg.round_mode
+            nr = cfg.narrow_range
+            dt = cfg.dtype
+            pow2 = cfg.pow2.value
+            axes = [3] if cfg.channel_last else [1]
+
+            # inputs -> Q -> DQ -> F
+            inps = self.quantize_inputs(
+                f, inputs, scope, cfg, axes, rm, nr, dt, pow2)
+            inps = self.dequantize_inputs(inps)
+            inps = self.shared_quantization(f, inps, cfg)
+            h = self._modifier._modify_as_same(f, inps)
+
+            if f.info.type_name == 'Sink':
+                return h
+
+            h = self._quantize_outputs(f, h, axes, cfg)
+            return h
+
+        def __finish__(self):
+            # input: [tuple(scale, zeropoint)]
+            self._map_input_scale_zeropoint = defaultdict(list)
+
+    """
+    Doc here.
+    """
+
+    def __init__(self, functions_ranks, config=None):
+        super(QuantizeRecordingToTrainingModifier, self).__init__()
+        self._fct_bin_set = {
+            'Add2': F.add2,
+            'Sub2': F.sub2,
+            'Mul2': F.mul2,
+            'Div2': F.div2,
+            'Pow2': F.pow2
+        }
+
+        from nnabla.utils.qnn import PrecisionMode
+        self._mode = self._precision_mode_set = {
+            PrecisionMode.QNN: None,
+            PrecisionMode.SIM_QNN: self.SimulatedQNN,
+            PrecisionMode.MIXED_QNN: None
+        }[config.precision_mode](functions_ranks, self, config)
+
+    def modify(self, f, inputs):
+        return self._mode.modify(f, inputs)
+
+    def __finish__(self):
+        self._mode.__finish__()

--- a/python/src/nnabla/experimental/graph_converters/quantize.py
+++ b/python/src/nnabla/experimental/graph_converters/quantize.py
@@ -226,6 +226,10 @@ class QuantizeRecordingToTrainingModifier(FunctionModifier):
             for next_func in f.outputs[0].function_references:
                 next_fn = next_func.info.type_name
                 next_func_rank = self.get_function_rank(next_func)
+
+                if next_fn == 'Sink':
+                    return h
+
                 name = 'x0'
                 if next_fn in self._modifier._fct_bin_set:
                     for i, elm in enumerate(next_func.inputs):
@@ -387,9 +391,10 @@ class QuantizeRecordingToTrainingModifier(FunctionModifier):
             inps = self.shared_quantization(f, inps, cfg)
             h = self._modifier._modify_as_same(f, inps)
 
-            if f.info.type_name == 'Sink':
+            if fn == 'Sink':
                 return h
 
+            # F -> output -> Q -> DQ
             h = self._quantize_outputs(f, h, axes, cfg)
             return h
 

--- a/python/src/nnabla/experimental/graph_converters/unfused_batch_normalization.py
+++ b/python/src/nnabla/experimental/graph_converters/unfused_batch_normalization.py
@@ -57,5 +57,5 @@ class UnfusedBatchNormalizationModifier(FunctionModifier):
         del args['nonlinearity']
 
         # Replace FBN to "BN -> Add2 -> Non-linear"
-        h = PF.batch_normalization(inputs[1], **args)
-        return self._fct_set[f_non_linear](inputs[0] + h)
+        h = PF.batch_normalization(inputs[0], **args)
+        return self._fct_set[f_non_linear](h) if len(inputs) == 5 else self._fct_set[f_non_linear](inputs[5] + h)

--- a/python/src/nnabla/utils/qnn.py
+++ b/python/src/nnabla/utils/qnn.py
@@ -653,11 +653,11 @@ class QATConfig:
 
     #: Enable Batch Normalization Folding.
     #: Note that sometimes this can cause the training become unstable.
-    bn_folding = True
+    bn_folding = False
 
     #: Enable Batch Normalization Self-Folding.
     #: Note that sometimes this can cause the training become unstable.
-    bn_self_folding = True
+    bn_self_folding = False
 
     #: One of :obj:`nnabla.utils.qnn.MinMaxMinMaxRecorderCallback`,
     #: :obj:`nnabla.utils.qnn.AbsMaxRecorderCallback`,
@@ -713,8 +713,8 @@ class QATConfig:
 
 class QATTensorRTConfig(QATConfig):
     pow2 = QATConfig.RoundingMethod.ROUND
-    bn_folding = False
-    bn_self_folding = False
+    bn_folding = True
+    bn_self_folding = True
     record_layers = ["Convolution", "Deconvolution",
                      "Affine", "BatchMatmul", "ReLU"]
     record_position = QATConfig.RecorderPosition.BEFORE

--- a/python/src/nnabla/utils/qnn.py
+++ b/python/src/nnabla/utils/qnn.py
@@ -115,13 +115,19 @@ class MinMaxMinMaxRecorderCallback(object):
         m = nn.parameter.get_parameter_or_create('m-{}'.format(name), shape)
         M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
 
+        # If recorder is not added before Q/DQ, return neither scale nor zp
+        if np.count_nonzero(m) == 0 and np.count_nonzero(M) == 0:
+            return None, None
+
         n_bits = 8
         im = - 2 ** (n_bits - 1)
         iM = 2 ** (n_bits - 1) - 1
         de = (iM - im) if not narrow_range else (iM - (im + 1))
-        scale = (M.d - m.d) / de  # MinMaxMinMax
-        if np.count_nonzero(scale) == 0:
-            return None, None
+
+        # MinMaxMinMax, 1e-24 is a small experience value to avoid zero scale
+        scale = np.maximum((M.d - m.d), 1e-24) / de
+
+        # round
         _round = __round_methods__[round_method]
         scale = 2 ** (_round(np.log(scale) / np.log(2))
                       ) if _round else scale  # pow2 scale
@@ -221,13 +227,17 @@ class AbsMaxRecorderCallback(object):
         shape = [1] * x.ndim
         M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
 
+        # If recorder is not added before Q/DQ, return neither scale nor zp
+        if np.count_nonzero(M) == 0:
+            return None, None
+
         n_bits = 8
         im = - 2 ** (n_bits - 1)
         iM = 2 ** (n_bits - 1) - 1
         de = (iM - im) if not narrow_range else (iM - (im + 1))
         scale = (2 * M.d) / de  # AbsMax
-        if np.count_nonzero(scale) == 0:
-            return None, None
+
+        # round
         _round = __round_methods__[round_method]
         scale = 2 ** (_round(np.log(scale) / np.log(2))
                       ) if _round else scale  # pow2 scale
@@ -336,13 +346,19 @@ class MinMaxMvaRecorderCallback(object):
         m = nn.parameter.get_parameter_or_create('m-{}'.format(name), shape)
         M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
 
+        # If recorder is not added before Q/DQ, return neither scale nor zp
+        if np.count_nonzero(m) == 0 and np.count_nonzero(M) == 0:
+            return None, None
+
         n_bits = 8
         im = - 2 ** (n_bits - 1)
         iM = 2 ** (n_bits - 1) - 1
         de = (iM - im) if not narrow_range else (iM - (im + 1))
-        scale = (M.d - m.d) / de  # MinMaxMva
-        if np.count_nonzero(scale) == 0:
-            return None, None
+
+        # MinMaxMva, 1e-24 is a small experience value to avoid zero scale
+        scale = np.maximum((M.d - m.d), 1e-24) / de
+
+        # round
         _round = __round_methods__[round_method]
         scale = 2 ** (_round(np.log(scale) / np.log(2))
                       ) if _round else scale  # pow2 scale
@@ -442,13 +458,17 @@ class MaxMaxRecorderCallback(object):
         shape = [1] * x.ndim
         M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
 
+        # If recorder is not added before Q/DQ, return neither scale nor zp
+        if np.count_nonzero(M) == 0:
+            return None, None
+
         n_bits = 8
         im = - 2 ** (n_bits - 1)
         iM = 2 ** (n_bits - 1) - 1
         de = (iM - im) if not narrow_range else (iM - (im + 1))
         scale = (2 * M.d) / de  # MaxMax
-        if np.count_nonzero(scale) == 0:
-            return None, None
+
+        # round
         _round = __round_methods__[round_method]
         scale = 2 ** (_round(np.log(scale) / np.log(2))
                       ) if _round else scale  # pow2 scale
@@ -550,13 +570,17 @@ class MaxMvaRecorderCallback(object):
         shape = [1] * x.ndim
         M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
 
+        # If recorder is not added before Q/DQ, return neither scale nor zp
+        if np.count_nonzero(M) == 0:
+            return None, None
+
         n_bits = 8
         im = - 2 ** (n_bits - 1)
         iM = 2 ** (n_bits - 1) - 1
         de = (iM - im) if not narrow_range else (iM - (im + 1))
         scale = (2 * M.d) / de  # MaxMva
-        if np.count_nonzero(scale) == 0:
-            return None, None
+
+        # round
         _round = __round_methods__[round_method]
         scale = 2 ** (_round(np.log(scale) / np.log(2))
                       ) if _round else scale  # pow2 scale

--- a/python/src/nnabla/utils/qnn.py
+++ b/python/src/nnabla/utils/qnn.py
@@ -775,6 +775,12 @@ class QNNScheduler:
 
         """
         self.config = config
+        if config.niter_to_training <= 0 or config.niter_to_recording < 0:
+            raise ValueError(
+                'Please set niter_to_recording and niter_to_training correctly! niter_to_recording should be greater than or equal to 0. niter_to_training should be greater than 0')
+        if (config.niter_to_training - config.niter_to_recording) <= 0:
+            raise ValueError(
+                'Please set niter_to_recording and niter_to_training correctly! The number of steps between recording and training should be greater than the number of steps of one epoch training.')
         self.solver = solver
         self.counter = 0
         self.state = QNNState.NON_QNN

--- a/python/src/nnabla/utils/qnn.py
+++ b/python/src/nnabla/utils/qnn.py
@@ -1,0 +1,895 @@
+# Open question
+# TODO: save in a nice way, the save should be of nnp format
+# TODO: address the data format (since int8x32 convolution is normally fastest among large shape)
+# TODO: Input data quantize, e.g, input= image do not update scale (min/max) in recording, use 1 / 255 and remove F.mul2_scalar(255)
+
+
+"""
+QNN-specific Functions
+"""
+import nnabla as nn
+import nnabla.functions as F
+import numpy as np
+import nnabla_ext
+import nnabla.experimental.graph_converters as GC
+
+from enum import Enum
+from nnabla.function import PythonFunction
+from nnabla.initializer import ConstantInitializer
+
+__round_methods__ = {
+    'CEIL': np.ceil,
+    'ROUND': np.round,
+    'FLOOR': np.floor,
+    'NOTROUND': None
+}
+
+
+class MinMaxMinMaxRecorder(PythonFunction):
+    """
+    MinMaxMinMaxRecorder records the min and max of the batch over the training iterations.
+    """
+
+    def __init__(self, ctx, training=True):
+        super(MinMaxMinMaxRecorder, self).__init__(ctx)
+        self.training = training
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def min_outputs(self):
+        return 1
+
+    def setup_impl(self, inputs, outputs):
+        assert len(inputs) == 3, "len(inputs) must be 3; data, min, max."
+        x = inputs[0]
+        m = inputs[1]
+        M = inputs[2]
+        assert m.ndim == x.ndim and M.ndim == x.ndim, \
+            "ndim of min and max must be same as ndim of data."
+        assert np.prod(m.shape) == 1 and np.prod(M.shape) == 1, \
+            "Any dimenstion of the shape of min and max must be 1."
+        y = outputs[0]
+        y.reset_shape(x.shape, True)
+        # inplace
+        # y.data = x.data
+
+    def forward_impl(self, inputs, outputs):
+        x = inputs[0].data
+        m = inputs[1].data
+        M = inputs[2].data
+        y = outputs[0].data
+        y.copy_from(x)
+
+        if not self.training:
+            return
+        mb = F.min(x, keepdims=True)
+        Mb = F.max(x, keepdims=True)
+        F.minimum2(m, mb, outputs=[m])
+        F.maximum2(M, Mb, outputs=[M])
+
+    def backward_impl(self, inputs, outputs, propagate_down, accum):
+        dx = inputs[0].grad
+        dy = outputs[0].grad
+        dy.copy_from(dx)
+
+        if propagate_down[0]:
+            if accum[0]:
+                dx += dy
+            else:
+                dx.copy_from(dy)
+
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
+
+def minmax_minmax_recorder(x, m, M, training=True):
+    ctx = nn.get_current_context()
+    func = MinMaxMinMaxRecorder(ctx, training)
+    return func(x, m, M)
+
+
+class MinMaxMinMaxRecorderCallback(object):
+    def __init__(self):
+        self._function = minmax_minmax_recorder
+
+    def name(self):
+        n = self.__class__.__name__
+        return n[:n.rfind('Callback')]
+
+    def __call__(self, x, axes=[1], training=True, name=''):
+        shape = [1] * x.ndim
+        m = nn.parameter.get_parameter_or_create('m-{}'.format(name), shape,
+                                                 ConstantInitializer())
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape,
+                                                 ConstantInitializer())
+        y = self._function(x, m, M, training=training)
+        return y
+
+    def get_scale_zeropoint(x, axes=[1], narrow_range=False, round_method='NOTROUND', name=''):
+        shape = [1] * x.ndim
+        m = nn.parameter.get_parameter_or_create('m-{}'.format(name), shape)
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
+
+        n_bits = 8
+        im = - 2 ** (n_bits - 1)
+        iM = 2 ** (n_bits - 1) - 1
+        de = (iM - im) if not narrow_range else (iM - (im + 1))
+        scale = (M.d - m.d) / de  # MinMaxMinMax
+        if np.count_nonzero(scale) == 0:
+            return None, None
+        _round = __round_methods__[round_method]
+        scale = 2 ** (_round(np.log(scale) / np.log(2))
+                      ) if _round else scale  # pow2 scale
+
+        # set zeropoint to zero
+        zp = np.round((np.zeros_like(m.d) / scale).astype(np.int8))
+        zp = nn.parameter.get_parameter_or_create('zeropoint-{}'.format(name),
+                                                  zp.shape, zp, False)
+
+        scale = nn.parameter.get_parameter_or_create('scale-{}'.format(name),
+                                                     scale.shape, scale, False)
+
+        return scale, zp
+
+
+class AbsMaxRecorder(PythonFunction):
+    """
+    AbsMaxRecorder records the max of the aboslute of the batch over the training iterations.
+    """
+
+    def __init__(self, ctx, training=True):
+        super(AbsMaxRecorder, self).__init__(ctx)
+        self.training = training
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def min_outputs(self):
+        return 1
+
+    def setup_impl(self, inputs, outputs):
+        assert len(inputs) == 2, "len(inputs) must be 2; data, abs_max."
+        x = inputs[0]
+        M = inputs[1]
+        assert M.ndim == x.ndim, \
+            "ndim of abs_max must be same as ndim of data."
+        assert np.prod(M.shape) == 1, \
+            "Any dimenstion of the shape of min and max must be 1."
+        y = outputs[0]
+        y.reset_shape(x.shape, True)
+        # inplace
+        # y.data = x.data
+
+    def forward_impl(self, inputs, outputs):
+        x = inputs[0].data
+        M = inputs[1].data
+        y = outputs[0].data
+        y.copy_from(x)
+
+        if not self.training:
+            return
+        Mb = F.max(F.abs(x), keepdims=True)
+        F.maximum2(M, Mb, outputs=[M])
+
+    def backward_impl(self, inputs, outputs, propagate_down, accum):
+        dx = inputs[0].grad
+        dy = outputs[0].grad
+        dy.copy_from(dx)
+
+        if propagate_down[0]:
+            if accum[0]:
+                dx += dy
+            else:
+                dx.copy_from(dy)
+
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
+
+def abs_max_recorder(x, M, training=True):
+    ctx = nn.get_current_context()
+    func = AbsMaxRecorder(ctx, training)
+    return func(x, M)
+
+
+class AbsMaxRecorderCallback(object):
+    def __init__(self):
+        self._function = abs_max_recorder
+
+    def name(self):
+        n = self.__class__.__name__
+        return n[:n.rfind('Callback')]
+
+    def __call__(self, x, axes=[1], training=True, name=''):
+        shape = [1] * x.ndim
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape,
+                                                 ConstantInitializer())
+
+        y = self._function(x, M, training=training)
+        return y
+
+    def get_scale_zeropoint(x, axes=[1], narrow_range=False, round_method='NOTROUND', name=''):
+        shape = [1] * x.ndim
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
+
+        n_bits = 8
+        im = - 2 ** (n_bits - 1)
+        iM = 2 ** (n_bits - 1) - 1
+        de = (iM - im) if not narrow_range else (iM - (im + 1))
+        scale = (2 * M.d) / de  # AbsMax
+        if np.count_nonzero(scale) == 0:
+            return None, None
+        _round = __round_methods__[round_method]
+        scale = 2 ** (_round(np.log(scale) / np.log(2))
+                      ) if _round else scale  # pow2 scale
+
+        # set zeropoint to zero
+        zp = np.round((np.zeros_like(M.d) / scale).astype(np.int8))
+        zp = nn.parameter.get_parameter_or_create('zeropoint-{}'.format(name),
+                                                  zp.shape, zp, False)
+
+        scale = nn.parameter.get_parameter_or_create('scale-{}'.format(name),
+                                                     scale.shape, scale, False)
+
+        return scale, zp
+
+
+class MinMaxMvaRecorder(PythonFunction):
+    """
+    MinMaxMvaRecorder records the moving average of the min and max of the batch over the training iterations.
+    """
+
+    def __init__(self, ctx, decay=0.99, training=True):
+        super(MinMaxMvaRecorder, self).__init__(ctx)
+
+        self.decay = decay
+        self.training = training
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def min_outputs(self):
+        return 1
+
+    def setup_impl(self, inputs, outputs):
+        assert len(inputs) == 3, "len(inputs) must be 3; data, min, max."
+        x = inputs[0]
+        m = inputs[1]
+        M = inputs[2]
+        assert m.ndim == x.ndim and M.ndim == x.ndim, \
+            "ndim of min and max must be same as ndim of data."
+        assert np.prod(m.shape) == 1 and np.prod(M.shape) == 1, \
+            "Any dimenstion of the shape of min and max must be 1."
+        y = outputs[0]
+        y.reset_shape(x.shape, True)
+        # inplace
+        # y.data = x.data
+
+    def forward_impl(self, inputs, outputs):
+        x = inputs[0].data
+        m = inputs[1].data
+        M = inputs[2].data
+        y = outputs[0].data
+        y.copy_from(x)
+
+        if not self.training:
+            return
+        mb = F.min(x, keepdims=True)
+        Mb = F.max(x, keepdims=True)
+        F.identity(self.decay * m + (1 - self.decay) * mb, outputs=[m])
+        F.identity(self.decay * M + (1 - self.decay) * Mb, outputs=[M])
+
+    def backward_impl(self, inputs, outputs, propagate_down, accum):
+        dx = inputs[0].grad
+        dy = outputs[0].grad
+        dy.copy_from(dx)
+
+        if propagate_down[0]:
+            if accum[0]:
+                dx += dy
+            else:
+                dx.copy_from(dy)
+
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
+
+def minmax_mva_recorder(x, m, M, decay=0.99, training=True):
+    ctx = nn.get_current_context()
+    func = MinMaxMvaRecorder(ctx, decay, training)
+    return func(x, m, M)
+
+
+class MinMaxMvaRecorderCallback(object):
+    def __init__(self):
+        self._function = minmax_mva_recorder
+
+    def name(self):
+        n = self.__class__.__name__
+        return n[:n.rfind('Callback')]
+
+    def __call__(self, x, axes=[1], training=True, name=''):
+        shape = [1] * x.ndim
+        m = nn.parameter.get_parameter_or_create('m-{}'.format(name), shape,
+                                                 ConstantInitializer())
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape,
+                                                 ConstantInitializer())
+
+        y = self._function(x, m, M, training=training)
+        return y
+
+    def get_scale_zeropoint(x, axes=[1], narrow_range=False, round_method='NOTROUND', name=''):
+        shape = [1] * x.ndim
+        m = nn.parameter.get_parameter_or_create('m-{}'.format(name), shape)
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
+
+        n_bits = 8
+        im = - 2 ** (n_bits - 1)
+        iM = 2 ** (n_bits - 1) - 1
+        de = (iM - im) if not narrow_range else (iM - (im + 1))
+        scale = (M.d - m.d) / de  # MinMaxMva
+        if np.count_nonzero(scale) == 0:
+            return None, None
+        _round = __round_methods__[round_method]
+        scale = 2 ** (_round(np.log(scale) / np.log(2))
+                      ) if _round else scale  # pow2 scale
+
+        # set zeropoint to zero
+        zp = np.round((np.zeros_like(m.d) / scale).astype(np.int8))
+        zp = nn.parameter.get_parameter_or_create('zeropoint-{}'.format(name),
+                                                  zp.shape, zp, False)
+
+        scale = nn.parameter.get_parameter_or_create('scale-{}'.format(name),
+                                                     scale.shape, scale, False)
+
+        return scale, zp
+
+
+class MaxMaxRecorder(PythonFunction):
+    """
+    MaxMaxRecorder records the max of the batch over the training iterations.
+    """
+
+    def __init__(self, ctx, training=True):
+        super(MaxMaxRecorder, self).__init__(ctx)
+        self.training = training
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def min_outputs(self):
+        return 1
+
+    def setup_impl(self, inputs, outputs):
+        assert len(inputs) == 2, "len(inputs) must be 2; data, max."
+        x = inputs[0]
+        M = inputs[1]
+        assert M.ndim == x.ndim, \
+            "ndim of max must be same as ndim of data."
+        assert np.prod(M.shape) == 1, \
+            "Any dimenstion of the shape of max must be 1."
+        y = outputs[0]
+        y.reset_shape(x.shape, True)
+        # inplace
+        # y.data = x.data
+
+    def forward_impl(self, inputs, outputs):
+        x = inputs[0].data
+        M = inputs[1].data
+        y = outputs[0].data
+        y.copy_from(x)
+
+        if not self.training:
+            return
+        Mb = F.max(x, keepdims=True)
+        F.maximum2(M, Mb, outputs=[M])
+
+    def backward_impl(self, inputs, outputs, propagate_down, accum):
+        dx = inputs[0].grad
+        dy = outputs[0].grad
+        dy.copy_from(dx)
+
+        if propagate_down[0]:
+            if accum[0]:
+                dx += dy
+            else:
+                dx.copy_from(dy)
+
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
+
+def max_max_recorder(x, M, training=True):
+    ctx = nn.get_current_context()
+    func = MaxMaxRecorder(ctx, training)
+    return func(x, M)
+
+
+class MaxMaxRecorderCallback(object):
+    def __init__(self):
+        self._function = max_max_recorder
+
+    def name(self):
+        n = self.__class__.__name__
+        return n[:n.rfind('Callback')]
+
+    def __call__(self, x, axes=[1], training=True, name=''):
+        shape = [1] * x.ndim
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape,
+                                                 ConstantInitializer())
+
+        y = self._function(x, M, training=training)
+        return y
+
+    def get_scale_zeropoint(x, axes=[1], narrow_range=False, round_method='NOTROUND', name=''):
+        shape = [1] * x.ndim
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
+
+        n_bits = 8
+        im = - 2 ** (n_bits - 1)
+        iM = 2 ** (n_bits - 1) - 1
+        de = (iM - im) if not narrow_range else (iM - (im + 1))
+        scale = (2 * M.d) / de  # MaxMax
+        if np.count_nonzero(scale) == 0:
+            return None, None
+        _round = __round_methods__[round_method]
+        scale = 2 ** (_round(np.log(scale) / np.log(2))
+                      ) if _round else scale  # pow2 scale
+
+        # set zeropoint to zero
+        zp = np.round((np.zeros_like(M.d) / scale).astype(np.int8))
+        zp = nn.parameter.get_parameter_or_create('zeropoint-{}'.format(name),
+                                                  zp.shape, zp, False)
+
+        scale = nn.parameter.get_parameter_or_create('scale-{}'.format(name),
+                                                     scale.shape, scale, False)
+
+        return scale, zp
+
+
+class MaxMvaRecorder(PythonFunction):
+    """
+    MaxMvaRecorder records the moving average of the max of the batch over the training iterations.
+    """
+
+    def __init__(self, ctx, decay=0.99, training=True):
+        super(MaxMvaRecorder, self).__init__(ctx)
+
+        self.decay = decay
+        self.training = training
+
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    def min_outputs(self):
+        return 1
+
+    def setup_impl(self, inputs, outputs):
+        assert len(inputs) == 2, "len(inputs) must be 2; data, max."
+        x = inputs[0]
+        M = inputs[1]
+        assert M.ndim == x.ndim, \
+            "ndim of max must be same as ndim of data."
+        assert np.prod(M.shape) == 1, \
+            "Any dimenstion of the shape of max must be 1."
+        y = outputs[0]
+        y.reset_shape(x.shape, True)
+        # inplace
+        # y.data = x.data
+
+    def forward_impl(self, inputs, outputs):
+        x = inputs[0].data
+        M = inputs[1].data
+        y = outputs[0].data
+        y.copy_from(x)
+
+        if not self.training:
+            return
+        Mb = F.max(x, keepdims=True)
+        F.identity(self.decay * M + (1 - self.decay) * Mb, outputs=[M])
+
+    def backward_impl(self, inputs, outputs, propagate_down, accum):
+        dx = inputs[0].grad
+        dy = outputs[0].grad
+        dy.copy_from(dx)
+
+        if propagate_down[0]:
+            if accum[0]:
+                dx += dy
+            else:
+                dx.copy_from(dy)
+
+    def grad_depends_output_data(self, i, o):
+        return False
+
+    def grad_depends_input_data(self, i, j):
+        return False
+
+
+def max_mva_recorder(x, M, decay=0.99, training=True):
+    ctx = nn.get_current_context()
+    func = MaxMvaRecorder(ctx, decay, training)
+    return func(x, M)
+
+
+class MaxMvaRecorderCallback(object):
+    def __init__(self):
+        self._function = max_mva_recorder
+
+    def name(self):
+        n = self.__class__.__name__
+        return n[:n.rfind('Callback')]
+
+    def __call__(self, x, axes=[1], training=True, name=''):
+        shape = [1] * x.ndim
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape,
+                                                 ConstantInitializer())
+
+        y = self._function(x, M, training=training)
+        return y
+
+    def get_scale_zeropoint(x, axes=[1], narrow_range=False, round_method='NOTROUND', name=''):
+        shape = [1] * x.ndim
+        M = nn.parameter.get_parameter_or_create('M-{}'.format(name), shape)
+
+        n_bits = 8
+        im = - 2 ** (n_bits - 1)
+        iM = 2 ** (n_bits - 1) - 1
+        de = (iM - im) if not narrow_range else (iM - (im + 1))
+        scale = (2 * M.d) / de  # MaxMva
+        if np.count_nonzero(scale) == 0:
+            return None, None
+        _round = __round_methods__[round_method]
+        scale = 2 ** (_round(np.log(scale) / np.log(2))
+                      ) if _round else scale  # pow2 scale
+
+        # set zeropoint to zero
+        zp = np.round((np.zeros_like(M.d) / scale).astype(np.int8))
+        zp = nn.parameter.get_parameter_or_create('zeropoint-{}'.format(name),
+                                                  zp.shape, zp, False)
+
+        scale = nn.parameter.get_parameter_or_create('scale-{}'.format(name),
+                                                     scale.shape, scale, False)
+
+        return scale, zp
+
+
+class PrecisionMode(Enum):
+    # Quantized functions only
+    QNN = 0
+    # Quantize/Dequantize only
+    SIM_QNN = 1
+    # Quantized functions as much as possible;
+    # otherwise Quantize/Dequantize (simulated quantization) are used
+    MIXED_QNN = 2
+
+
+class QNNState(Enum):
+    # Floating network
+    NON_QNN = 0
+    # Recording min/max at some weights and activations
+    RECORDING = 1
+    # Quantized network, some layers are quantized, depending on layer configuration
+    TRAINING = 2
+    # TODO: Deployment network, quantized weights might be fused and saved as int8
+    DEPLOYMENT = 3
+
+
+# TODO : elaborate more
+
+
+class QNNConfig:
+    #: Extension Context. 'cpu', 'cuda' or 'cudnn'
+    ext_name = "cudnn"
+
+    #: Use zero-point (asymmetric) or not use (symmetric)
+    zero_point = False
+
+    #: precision
+    dtype = np.int8
+    precision_mode = PrecisionMode.SIM_QNN
+
+    #: channel last (channel_first is only supported now)
+    channel_last = False
+
+    # (TODO: near future, normally used for weights)
+    #: channel-wise quantization
+    channel_wise = False
+
+    #: Step start to record
+    niter_to_recording = 0
+
+    #: Step start to QAT
+    niter_to_training = -1
+
+    #: Coerce to power-of-2 scale when transiting from the recording graph
+    class RoundingMethod(Enum):
+        """
+        Round method of scale
+        """
+        #: round up.
+        #: e.g. ceil(9.4) = 10
+        CEIL = 'CEIL'  # round up
+        #: round.
+        #: e.g. round(9.4) = 9, round(9.5) = 10
+        ROUND = 'ROUND'
+        #: round down.
+        #: e.g. floor(9.5) = 9
+        FLOOR = 'FLOOR'  # round down
+        #: not round
+        NOTROUND = 'NOTROUND'
+
+    #: Member of :obj:`nnabla.utils.qnn.QNNConfig.RoundingMethod`.
+    #: Round scale to power-of-2.
+    pow2 = RoundingMethod.ROUND
+
+    #: narrow the lower-bound (e.g., when in int8, -128 -> -127)
+    narrow_range = False
+
+    #: Round mode of quantize layer
+    round_mode = 'HALF_TO_EVEN'
+
+    # (TODO: decide by experiments for ImageNet classification and super resolution task)
+
+    #: BN folding
+    bn_folding = True
+
+    #: BN self folding
+    bn_self_folding = True
+
+    #: One of :obj:`nnabla.utils.qnn.MinMaxMinMaxRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.AbsMaxRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.MinMaxMvaRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.MaxMaxRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.MaxMvaRecorderCallback`
+    #: Recorder of weight
+    recorder_weight = MinMaxMinMaxRecorderCallback
+
+    #: One of :obj:`nnabla.utils.qnn.MinMaxMinMaxRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.AbsMaxRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.MinMaxMvaRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.MaxMaxRecorderCallback`,
+    #: :obj:`nnabla.utils.qnn.MaxMvaRecorderCallback`
+    #: Recorder of activation
+    recorder_activation = MaxMvaRecorderCallback
+
+    #: list of nnabla function names.
+    #: Recording layers.
+    #: If empty, add recoders to all layers. Otherwise, only add recoders to functions in record_layers.
+    record_layers = []
+
+    class RecorderPosition(Enum):
+        """
+        Position to add recorder for function.
+        """
+
+        #: Add recoder only before a function
+        BEFORE = 0
+
+        #: Add recoder before/after a function
+        BOTH = 1
+
+    #: Member of :obj:`nnabla.utils.qnn.QNNConfig.RecorderPosition`.
+    #: Recorder position
+    recorder_position = RecorderPosition.BEFORE
+
+    #: List of nnabla function name.
+    #: Skip quantizing inputs layers of network
+    skip_inputs_layers = ['Convolution', 'Deconvolution']
+
+    #: List of nnabla function name.
+    #: Skip quantizing outputs layers of network
+    skip_outputs_layers = ['Affine']
+
+    #: QAT Learning_rate = NonQNN Learning_rate * learning_rate_scale
+    learning_rate_scale = 0.1
+
+    #: Skip quantizing bias of Affine and bias of the Convolution function family
+    skip_bias = False
+
+
+class QNNTensorRTConfig(QNNConfig):
+    pow2 = QNNConfig.RoundingMethod.ROUND
+    bn_folding = False
+    bn_self_folding = False
+    record_layers = ["Convolution", "Deconvolution",
+                     "Affine", "BatchMatmul", "ReLU"]
+    record_position = QNNConfig.RecorderPosition.BEFORE
+
+
+qnn_default_config = QNNTensorRTConfig()
+
+
+class FunctionsRankRecorder(object):
+    def __init__(self, functions_only_for_training=['ImageAugmentation', 'Dropout']):
+        self.functions_only_for_training = functions_only_for_training
+        self.rank = 0
+        self.functions_ranks = {}
+
+    def __call__(self, f):
+        if f.info.type_name not in self.functions_only_for_training:
+            self.functions_ranks[f] = self.rank
+            self.rank += 1
+
+
+class QNNScheduler:
+    """
+    Scheduler for quantization aware training.
+
+    Args:
+      config (:obj:`QNNConfig`): Quantized Neural Network Configuration
+      solver (:obj:`nnabla.solver.Solver`): Neural Network Solver
+
+    Example:
+
+        .. code-block:: python
+
+            from nnabla.utils.qnn import QNNScheduler, QNNConfig, PrecisionMode
+
+            # Set configuration
+            config = QNNConfig()
+            config.bn_folding = True
+            config.bn_self_folding = True
+            config.channel_last = False
+            config.precision_mode = PrecisionMode.SIM_QNN
+            config.niter_to_recording = 1
+            config.niter_to_training = 500
+
+            qnn_scheduler = QNNScheduler(config=config, solver=solver)
+
+            # convert graph to enable quantization aware training.
+            qnn_scheduler(pred) # pred is output variable of training network
+            qnn_scheduler(vpred, training=False) # vpred is output variable of evaluation network
+
+            # Training loop
+            for i in range(training_step):
+                qnn_wrapper.step()
+
+                # Your training code here
+    """
+
+    # set default config
+    def __init__(self, config=qnn_default_config, solver=None):
+        """
+        Args:
+          config (:obj:`QNNConfig`):
+          solver (:obj: 'nnabla.solvers.Solver'): Neural Network Solver
+
+        """
+        self.config = config
+        self.solver = solver
+        self.counter = 0
+        self.state = QNNState.NON_QNN
+        self.registry = []  # [(nn.Variable, training)]
+
+    def __call__(self, pred, training=True):
+        """
+        Wrap the network to quantized.
+
+        Args:
+          pred (:obj:`nnabla.Variable` or list of :obj:`nnabla.Variable`): Network output; the output of the original computation graph to be quantized.
+        """
+        # TODO: address list case (e.g., multiple outputs)
+        self.registry.append((pred, training))
+
+    def _register_params(self, solver):
+        """
+        Re-register parameters to `solver`
+        """
+        if not solver:
+            return
+
+        if (not self.config.bn_folding) and (not self.config.bn_self_folding):
+            return
+
+        solver.set_parameters(nn.get_parameters(grad_only=True))
+
+    def _set_qat_learning_rate(self):
+        self.solver.set_learning_rate(self.solver.learning_rate()
+                                      * self.config.learning_rate_scale)
+
+    def _fold_bn(self, pred):
+        qpred_prev = pred
+        # BN folding & BN self folding
+        modifiers = [] if not self.config.bn_folding else [GC.BatchNormalizationFoldingModifier(
+                opposite=False, channel_last=self.config.channel_last), GC.BatchNormalizationFoldingModifier(
+                opposite=True, channel_last=self.config.channel_last)]
+        modifiers = modifiers + \
+            [GC.BatchNormalizationSelfFoldingModifier(
+            )] if self.config.bn_self_folding else modifiers
+        if len(modifiers) > 0:
+            # expand fused_batch_normalization if BN folding or BN self folding is enabled.
+            modifiers.insert(0, GC.UnfusedBatchNormalizationModifier())
+            qpred_without_bn = GC.GraphConverter(
+                modifiers).convert(qpred_prev)
+            qpred_prev.rewire_on(qpred_without_bn)
+        return qpred_prev
+
+    def _clear_memory_cache(self):
+        if self.config.ext_name in ["cuda", "cudnn"]:
+            nnabla_ext.cuda.clear_memory_cache()
+
+    def _schedule_to_recording(self):
+        for i, elm in enumerate(self.registry):
+            pred, training = elm
+            qpred_prev = pred
+            qpred_prev = self._fold_bn(qpred_prev)
+
+            # Collect functions rank
+            rank_recorder = FunctionsRankRecorder()
+            qpred_prev.visit(rank_recorder)
+
+            qpred_curr = GC.GraphConverter([
+                GC.QuantizeNonQNNToRecordingModifier(
+                    rank_recorder.functions_ranks, config=self.config, training=training)]).convert(qpred_prev)
+            qpred_prev.rewire_on(qpred_curr)
+            qpred_prev.need_grad = False
+            self._register_params(self.solver)
+            self.registry[i] = (qpred_prev, training)
+            self.state = QNNState.RECORDING
+            print(
+                'QNNState.NON_QNN -> QNNState.RECORDING: graph={}'.format(qpred_prev))
+
+    def _schedule_to_training(self):
+        for i, elm in enumerate(self.registry):
+            pred, training = elm
+            qpred_prev = pred
+
+            # Remove recorder
+            modifiers = []
+            modifiers.append(GC.RemoveFunctionModifier(
+                rm_funcs=[self.config.recorder_activation().name(),
+                          self.config.recorder_weight().name()]))
+            qpred_noqnn = GC.GraphConverter(modifiers).convert(qpred_prev)
+            qpred_prev.rewire_on(qpred_noqnn)
+
+            # Collect functions rank
+            rank_recorder = FunctionsRankRecorder()
+            qpred_prev.visit(rank_recorder)
+
+            # Recording to training
+            qpred_curr = GC.GraphConverter([
+                GC.QuantizeRecordingToTrainingModifier(rank_recorder.functions_ranks, config=self.config)]).convert(
+                qpred_prev)
+            qpred_prev.rewire_on(qpred_curr)
+            self._register_params(self.solver)
+            self._set_qat_learning_rate()
+            self.registry[i] = (qpred_prev, training)
+            self.state = QNNState.TRAINING
+            print(
+                'QNNState.RECORDING -> QNNState.TRAINING: graph={}'.format(qpred_prev))
+
+    def step(self):
+        """
+        Step in the state of QNN. According to the number of iterations in config.
+        """
+
+        # TODO: there is other patterns
+        # TODO: address list case (e.g., multiple outputs)
+        if self.counter == self.config.niter_to_recording:
+            self._clear_memory_cache()
+            self._schedule_to_recording()
+
+        elif self.counter == self.config.niter_to_training:
+            self._clear_memory_cache()
+            self._schedule_to_training()
+
+        self.counter += 1

--- a/python/test/utils/test_graph_converters/graph_converter_test_utils.py
+++ b/python/test/utils/test_graph_converters/graph_converter_test_utils.py
@@ -65,11 +65,13 @@ def structure_tester(v_ref, v_act):
         assert f_ref.name == f_act.name
 
 
-def value_tester(v_ref, v_act, rtol=1e-04, atol=1e-05, clear_no_need_grad=False):
+def value_tester(v_ref, v_act, rtol=1e-04, atol=1e-05, clear_no_need_grad=False, forward=True):
     from nbla_test_utils import ArrayDiffStats
 
-    v_ref.forward(clear_no_need_grad)
-    v_act.forward(clear_no_need_grad)
+    if forward:
+        v_ref.forward(clear_no_need_grad)
+        v_act.forward(clear_no_need_grad)
+
     print(ArrayDiffStats(v_ref.d, v_act.d))
     assert_allclose(v_ref.d, v_act.d, rtol=rtol, atol=atol)
 

--- a/python/test/utils/test_graph_converters/ref_graphs/helper.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/helper.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import
 
+import numpy as np
+import nnabla as nn
 
 from nnabla.parameter import get_parameter_or_create
 
@@ -30,3 +32,29 @@ def create_scale_bias(idx, maps, ndim=4, axes=[1]):
 
 def get_channel_axes(channel_last=False, dims=2):
     return [dims+1] if channel_last else [1]
+
+
+def create_conv_weight_bias(inp, maps=16, kernel=(3, 3),
+                            channel_last=False, name=''):
+    if channel_last:
+        channels = inp.shape[-1]
+        filter_shape = tuple(kernel) + (channels, )
+    else:
+        channels = inp.shape[1]
+        filter_shape = (channels,) + tuple(kernel)
+
+    w = get_parameter_or_create("w-{}".format(name), (maps,) + filter_shape,
+                                None, True, True)
+    b = get_parameter_or_create("b-{}".format(name), (maps,),
+                                None, True, True)
+
+    return w, b
+
+
+def create_affine_weight_bias(inp, n_outmaps=10, name=''):
+    w = get_parameter_or_create("w-{}".format(name), [int(np.prod(inp.shape[1:]))] + [n_outmaps],
+                                None, True, True)
+    b = get_parameter_or_create("b-{}".format(name), (n_outmaps, ),
+                                None, True, True)
+
+    return w, b

--- a/python/test/utils/test_graph_converters/ref_graphs/helper.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/helper.py
@@ -30,8 +30,9 @@ def create_scale_bias(idx, maps, ndim=4, axes=[1]):
     return a, b
 
 
-def get_channel_axes(channel_last=False, dims=2):
-    return [dims+1] if channel_last else [1]
+def get_channel_axes(x, channel_last=False, dims=2):
+    assert dims+1 == x.ndim-1
+    return [x.ndim-1] if channel_last else [1]
 
 
 def create_conv_weight_bias(inp, maps=16, kernel=(3, 3),

--- a/python/test/utils/test_graph_converters/ref_graphs/lenets.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/lenets.py
@@ -66,24 +66,26 @@ def cl_lenet(image, test=False):
 
 # BN LeNet
 def bn_lenet(image, test=False, channel_last=False, w_bias=False):
-    axes = get_channel_axes(channel_last)
     h = PF.convolution(image, 16, (5, 5), (1, 1), with_bias=w_bias,
                        channel_last=channel_last, name='conv1')
+    axes = get_channel_axes(h, channel_last)
     h = PF.batch_normalization(
         h, axes=axes, batch_stat=not test, name='conv1-bn')
-    h = F.max_pooling(h, (2, 2))
+    h = F.max_pooling(h, (2, 2), channel_last=channel_last)
     h = F.relu(h)
 
-    h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True,
+    h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=w_bias,
                        channel_last=channel_last, name='conv2')
+    axes = get_channel_axes(h, channel_last)
     h = PF.batch_normalization(
-        h, axes=axes, batch_stat=not test, name='conv2-bn')
+        h, axes=axes, batch_stat=not test, name='conv2')
     h = F.max_pooling(h, (2, 2), channel_last=channel_last)
     h = F.relu(h)
 
     h = PF.affine(h, 10, with_bias=True, name='fc1')
+    axes = get_channel_axes(h, channel_last)
     h = PF.batch_normalization(
-        h, axes=axes, batch_stat=not test, name='fc1-bn')
+        h, axes=axes, batch_stat=not test, name='fc1')
     h = F.relu(h)
 
     pred = PF.affine(h, 10, with_bias=True, name='fc2')
@@ -131,7 +133,7 @@ def bsf_lenet(image, test=False, w_bias=False):
 
 # BN LeNet Opposite
 def bn_opp_lenet(image, test=False, channel_last=False, w_bias=False):
-    axes = get_channel_axes(channel_last)
+    axes = get_channel_axes(image, channel_last)
     h = PF.batch_normalization(
         image, axes=axes, batch_stat=not test, name='conv1-bn')
     h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=w_bias,
@@ -139,13 +141,15 @@ def bn_opp_lenet(image, test=False, channel_last=False, w_bias=False):
     h = F.max_pooling(h, (2, 2))
     h = F.relu(h)
 
+    axes = get_channel_axes(h, channel_last)
     h = PF.batch_normalization(
         h, axes=axes, batch_stat=not test, name='conv2-bn')
-    h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=True,
+    h = PF.convolution(h, 16, (5, 5), (1, 1), with_bias=w_bias,
                        channel_last=channel_last, name='conv2')
     h = F.max_pooling(h, (2, 2), channel_last=channel_last)
     h = F.relu(h)
 
+    axes = get_channel_axes(h, channel_last)
     h = PF.batch_normalization(
         h, axes=axes, batch_stat=not test, name='fc1-bn')
     h = PF.affine(h, 10, with_bias=True, name='fc1')

--- a/python/test/utils/test_graph_converters/ref_graphs/resnets.py
+++ b/python/test/utils/test_graph_converters/ref_graphs/resnets.py
@@ -19,42 +19,10 @@ import nnabla as nn
 import nnabla.functions as F
 import nnabla.parametric_functions as PF
 
-from .helper import create_scale_bias, get_channel_axes
-
-
-# Small Channel First ResNet
-def cf_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
-                test=False, channel_last=False, name='cf-convblock'):
-    axes = get_channel_axes(channel_last)
-    h = x
-    with nn.parameter_scope(name):
-        h = PF.convolution(h, maps, kernel=kernel, pad=pad, stride=stride,
-                           channel_last=channel_last, with_bias=False)
-        h = PF.batch_normalization(h, axes=axes, batch_stat=not test)
-    return F.relu(h + x)
-
-
-def small_cf_resnet(image, test=False, channel_last=False):
-    axes = get_channel_axes(channel_last)
-    h = image
-    h /= 255.0
-    h = PF.convolution(h, 16, kernel=(3, 3), pad=(1, 1), channel_last=channel_last,
-                       with_bias=False, name='first-cf-conv')
-    h = PF.batch_normalization(
-        h, axes=axes, batch_stat=not test, name='first-cf-bn')
-    h = F.relu(h)
-    h = F.max_pooling(h, (2, 2), channel_last=channel_last)
-    h = cf_resblock(h, maps=16, test=test,
-                    channel_last=channel_last, name='cf-cb1')
-    h = cf_resblock(h, maps=16, test=test,
-                    channel_last=channel_last, name='cf-cb2')
-    h = cf_resblock(h, maps=16, test=test,
-                    channel_last=channel_last, name='cf-cb3')
-    h = cf_resblock(h, maps=16, test=test,
-                    channel_last=channel_last, name='cf-cb4')
-    h = F.average_pooling(h, (2, 2), channel_last=channel_last)
-    pred = PF.affine(h, 10, name='cf-fc')
-    return pred
+from .helper import (create_scale_bias,
+                     create_conv_weight_bias,
+                     create_affine_weight_bias,
+                     get_channel_axes)
 
 
 # Small Channel Last ResNet
@@ -92,9 +60,9 @@ def bn_self_folding_resblock(x, i, maps, kernel=(3, 3), pad=(1, 1),
     with nn.parameter_scope(name):
         h = PF.convolution(h, maps, kernel=kernel, pad=pad, stride=stride,
                            channel_last=channel_last, with_bias=False)
-        axes = get_channel_axes(channel_last)
+        axes = get_channel_axes(h, channel_last)
         a, b = create_scale_bias(1, h.shape, axes=axes)
-        h = a * h + b
+        h = h * a + b
     return F.relu(h + x)
 
 
@@ -103,9 +71,9 @@ def small_bn_self_folding_resnet(image, channel_last=False, name='bn-self-foldin
     h /= 255.0
     h = PF.convolution(h, 16, kernel=(3, 3), pad=(1, 1), channel_last=channel_last,
                        with_bias=False, name='first-conv')
-    axes = get_channel_axes(channel_last)
+    axes = get_channel_axes(h, channel_last)
     a, b = create_scale_bias(1, h.shape, axes=axes)
-    h = a * h + b
+    h = h * a + b
     h = F.relu(h)
     h = F.max_pooling(h, (2, 2), channel_last=channel_last)
     h = bn_self_folding_resblock(
@@ -124,7 +92,6 @@ def small_bn_self_folding_resnet(image, channel_last=False, name='bn-self-foldin
 # BatchNormalization Small ResNet
 def bn_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
                 test=False, w_bias=False, channel_last=False, name='convblock', dims=2):
-    axes = get_channel_axes(channel_last, dims)
     h = x
     kernel = (3,) * dims
     pad = (1,) * dims
@@ -132,20 +99,21 @@ def bn_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
     with nn.parameter_scope(name):
         h = PF.convolution(h, maps, kernel=kernel, pad=pad, stride=stride,
                            channel_last=channel_last, with_bias=w_bias)
+        axes = get_channel_axes(h, channel_last, dims)
         h = PF.batch_normalization(h, axes=axes, batch_stat=not test)
     return F.relu(h + x)
 
 
 def small_bn_resnet(image, test=False, w_bias=False, channel_last=False, name='bn-graph-ref', dims=2):
-    axes = get_channel_axes(channel_last, dims)
-
     kernel = (3,) * dims
     pool_kernel = (2,) * dims
     pad = (1,) * dims
+
     h = image
     h /= 255.0
     h = PF.convolution(h, 16, kernel=kernel, pad=pad, channel_last=channel_last,
                        with_bias=w_bias, name='first-conv')
+    axes = get_channel_axes(h, channel_last, dims)
     h = PF.batch_normalization(
         h, axes=axes, batch_stat=not test, name='first-bn')
     h = F.relu(h)
@@ -309,10 +277,11 @@ def small_opp_dcn(image, test=False, w_bias=True, channel_last=False, name='smal
 # BatchNormalization Small ResNet Opposite
 def bn_opp_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
                     test=False, channel_last=False, name='convblock', dims=2):
-    axes = get_channel_axes(channel_last, dims)
+    axes = get_channel_axes(x, channel_last, dims)
     kernel = (3,) * dims
     pad = (1,) * dims
     stride = (1,) * dims
+
     with nn.parameter_scope(name):
         h = PF.batch_normalization(x, axes=axes, batch_stat=not test)
         z = h
@@ -322,17 +291,17 @@ def bn_opp_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
 
 
 def small_bn_opp_resnet(image, test=False, w_bias=False, channel_last=False, name='bn-graph-ref', dims=2):
-    axes = get_channel_axes(channel_last, dims)
-
     kernel = (3,) * dims
     pool_kernel = (2,) * dims
     pad = (1,) * dims
+
     h = image
     h /= 255.0
+    axes = get_channel_axes(h, channel_last, dims)
     h = PF.batch_normalization(
         h, axes=axes, batch_stat=not test, name='first-bn')
     h = PF.convolution(h, 16, kernel=kernel, pad=pad, channel_last=channel_last,
-                       with_bias=w_bias, name='first-conv')
+                       with_bias=True, name='first-conv')
     h = F.relu(h)
     h = F.max_pooling(
         h, pool_kernel, channel_last=channel_last) if dims > 1 else h
@@ -352,7 +321,7 @@ def small_bn_opp_resnet(image, test=False, w_bias=False, channel_last=False, nam
 
 # BatchNormalization Folding Small ResNet
 def bn_folding_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
-                        test=False, channel_last=False, name='convblock', dims=2):
+                        channel_last=False, name='convblock', dims=2):
     h = x
     kernel = (3,) * dims
     pad = (1,) * dims
@@ -363,7 +332,7 @@ def bn_folding_resblock(x, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
     return F.relu(h + x)
 
 
-def small_bn_folding_resnet(image, test=False, channel_last=False, name='bn-graph-ref', dims=2):
+def small_bn_folding_resnet(image, channel_last=False, name='bn-graph-ref', dims=2):
     h = image
     h /= 255.0
     kernel = (3,) * dims
@@ -374,13 +343,13 @@ def small_bn_folding_resnet(image, test=False, channel_last=False, name='bn-grap
     h = F.relu(h)
     h = F.max_pooling(
         h, pool_kernel, channel_last=channel_last) if dims > 1 else h
-    h = bn_folding_resblock(h, maps=16, test=test,
+    h = bn_folding_resblock(h, maps=16,
                             channel_last=channel_last, name='cb1', dims=dims)
-    h = bn_folding_resblock(h, maps=16, test=test,
+    h = bn_folding_resblock(h, maps=16,
                             channel_last=channel_last, name='cb2', dims=dims)
-    h = bn_folding_resblock(h, maps=16, test=test,
+    h = bn_folding_resblock(h, maps=16,
                             channel_last=channel_last, name='cb3', dims=dims)
-    h = bn_folding_resblock(h, maps=16, test=test,
+    h = bn_folding_resblock(h, maps=16,
                             channel_last=channel_last, name='cb4', dims=dims)
     h = F.average_pooling(
         h, pool_kernel, channel_last=channel_last) if dims > 1 else h
@@ -732,5 +701,341 @@ def depthwise_net_for_pruning(image, threshold, with_bias=False, channel_last=Fa
         axis = 1
         # force reset the weight value
         reset_the_weight_value(inputs, axis, threshold)
+
+        return pred
+
+
+# NonQNN to Recording Small ResNet
+def nonqnn_to_recording_resblock(x, cfg, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
+                                 test=False, channel_last=False, bn_self_folding=False,
+                                 record_layers=(), name='convblock'):
+    recorder = cfg.recorder_activation
+    recorder_weight = cfg.recorder_weight
+    axes = get_channel_axes(x, channel_last)
+
+    with nn.parameter_scope(name):
+        h = x
+
+    with nn.parameter_scope('{}-conv'.format(name)):
+        h = recorder()(h, axes=axes)
+        hr1 = h
+        w, b = create_conv_weight_bias(h, maps=maps, kernel=kernel,
+                                       channel_last=channel_last, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        h = F.convolution(h, w, b, pad=pad, stride=stride,
+                          channel_last=channel_last)
+    if bn_self_folding:
+        a, b = create_scale_bias(1, h.shape, axes=axes)
+
+        with nn.parameter_scope('{}-Mul2'.format(name)):
+            if not record_layers:
+                hr2 = recorder()(h, axes=axes)
+                h = hr2 * recorder()(a, axes=axes)
+            else:
+                h = h * a
+
+        with nn.parameter_scope('{}-Add2'.format(name)):
+            if not record_layers:
+                hr3 = recorder()(h, axes=axes)
+                h = hr3 + recorder()(b, axes=axes)
+            else:
+                h = h + b
+    with nn.parameter_scope('{}/ReLU-Add2'.format(name)):
+        if not record_layers:
+            hr2 = recorder()(h, axes=axes)
+        else:
+            hr2 = h
+        h = hr2 + hr1
+
+    with nn.parameter_scope('{}-ReLU'.format(name)):
+        if not record_layers:
+            h = recorder()(h, axes=axes)
+        else:
+            h = h
+    return F.relu(h)
+
+
+def small_nonqnn_to_recording_resnet(image, config, test=False, channel_last=False,
+                                     bn_self_folding=False, record_layers=(), name='bn-graph-ref'):
+    recorder = config.recorder_activation
+    recorder_weight = config.recorder_weight
+    axes = get_channel_axes(image, channel_last)
+
+    h = image
+    func_id = 0
+    with nn.parameter_scope('MulScale-{}'.format(func_id)):
+        if not record_layers:
+            h = recorder()(h, axes=axes)
+        h /= 255.0
+        func_id += 1
+    with nn.parameter_scope('first-conv'):
+        h = recorder()(h, axes=axes)
+        w, b = create_conv_weight_bias(h, 16, kernel=(3, 3),
+                                       channel_last=channel_last, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        h = F.convolution(h, w, b, pad=(1, 1), stride=(1, 1),
+                          channel_last=channel_last)
+    if bn_self_folding:
+        a, b = create_scale_bias(1, h.shape, axes=axes)
+        with nn.parameter_scope('Mul2-{}'.format(func_id)):
+            if not record_layers:
+                h = recorder()(h, axes=axes)
+                h = h * recorder()(a, axes=axes)
+            else:
+                h = h * a
+            func_id += 1
+        with nn.parameter_scope('Add2-{}'.format(func_id)):
+            if not record_layers:
+                h = recorder()(h, axes=axes)
+                h = h + recorder()(b, axes=axes)
+            else:
+                h = h + b
+            func_id += 1
+
+    with nn.parameter_scope('ReLU-{}'.format(func_id)):
+        if not record_layers:
+            h = recorder()(h, axes=axes)
+        h = F.relu(h)
+        func_id += 1
+    with nn.parameter_scope('MaxPooling-{}'.format(func_id)):
+        if not record_layers:
+            h = recorder()(h, axes=axes)
+        h = F.max_pooling(h, (2, 2), channel_last=channel_last)
+        func_id += 1
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, bn_self_folding=bn_self_folding,
+                                     record_layers=record_layers, name='cb1')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, bn_self_folding=bn_self_folding,
+                                     record_layers=record_layers, name='cb2')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, bn_self_folding=bn_self_folding,
+                                     record_layers=record_layers, name='cb3')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, bn_self_folding=bn_self_folding,
+                                     record_layers=record_layers, name='cb4')
+    with nn.parameter_scope('AveragePooling-16'):
+        if not record_layers:
+            h = recorder()(h, axes=axes)
+        h = F.average_pooling(h, (2, 2), channel_last=channel_last)
+    with nn.parameter_scope('fc'):
+        h = recorder()(h, axes=axes)
+        w, b = create_affine_weight_bias(h, 10, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        pred = F.affine(h, w, b)
+        return pred
+
+
+# NonQNN to Specific Recording Position Small ResNet (Convolution, Affine)
+def nonqnn_to_specific_recording_pos_resblock(x, cfg, maps, kernel=(3, 3), pad=(1, 1), stride=(1, 1),
+                                              test=False, channel_last=False,
+                                              bn_self_folding=False, record_layers=(), name='convblock'):
+    recorder = cfg.recorder_activation
+    recorder_weight = cfg.recorder_weight
+    axes = get_channel_axes(x, channel_last)
+
+    with nn.parameter_scope(name):
+        h = x
+
+    with nn.parameter_scope('{}-conv'.format(name)):
+        h = recorder()(h, axes=axes)
+        hr1 = h
+        w, b = create_conv_weight_bias(h, maps=maps, kernel=kernel,
+                                       channel_last=channel_last, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        h = F.convolution(h, w, b, pad=pad, stride=stride,
+                          channel_last=channel_last)
+        h = recorder()(h, axes=axes)
+
+        h = h + hr1
+
+    return F.relu(h)
+
+
+def small_nonqnn_to_specific_recording_pos_resnet(image, config, test=False, channel_last=False,
+                                                  bn_self_folding=False, record_layers=(),
+                                                  name='bn-graph-ref'):
+    recorder = config.recorder_activation
+    recorder_weight = config.recorder_weight
+    axes = get_channel_axes(image, channel_last)
+
+    h = image
+    h /= 255.0
+
+    with nn.parameter_scope('first-conv'):
+        h = recorder()(h, axes=axes)
+        w, b = create_conv_weight_bias(h, 16, kernel=(3, 3),
+                                       channel_last=channel_last, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        h = F.convolution(h, w, b, pad=(1, 1), stride=(1, 1),
+                          channel_last=channel_last)
+        h = recorder()(h, axes=axes)
+    h = F.relu(h)
+    h = F.max_pooling(h, (2, 2), channel_last=channel_last)
+    h = nonqnn_to_specific_recording_pos_resblock(h, config, maps=16, test=test,
+                                                  channel_last=channel_last, name='cb1')
+    h = nonqnn_to_specific_recording_pos_resblock(h, config, maps=16, test=test,
+                                                  channel_last=channel_last, name='cb2')
+    h = nonqnn_to_specific_recording_pos_resblock(h, config, maps=16, test=test,
+                                                  channel_last=channel_last, name='cb3')
+    h = nonqnn_to_specific_recording_pos_resblock(h, config, maps=16, test=test,
+                                                  channel_last=channel_last, name='cb4')
+    h = F.average_pooling(h, (2, 2), channel_last=channel_last)
+
+    with nn.parameter_scope('fc'):
+        h = recorder()(h, axes=axes)
+        w, b = create_affine_weight_bias(h, 10, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        h = F.affine(h, w, b)
+    with nn.parameter_scope('fc-rec'):
+        pred = recorder()(h, axes=axes)
+
+    return pred
+
+
+def small_bn_fcn(image, test=False, w_bias=False, channel_last=False, name='bn-graph-ref'):
+    h = image
+    h /= 255.0
+    h = PF.convolution(h, 16, kernel=(3, 3), pad=(1, 1), channel_last=channel_last,
+                       with_bias=w_bias, name='first-conv')
+    axes = get_channel_axes(h, channel_last)
+    h = PF.batch_normalization(
+        h, axes=axes, batch_stat=not test, name='first-bn')
+    h = F.relu(h)
+    h = F.max_pooling(h, (2, 2), channel_last=channel_last)
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb1')
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb2')
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb3')
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb4')
+    h = F.average_pooling(h, (2, 2), channel_last=channel_last)
+    pred = PF.convolution(h, 16, kernel=(3, 3), pad=(1, 1), channel_last=channel_last,
+                          with_bias=w_bias, name='last-conv')
+    return pred
+
+
+def small_nonqnn_to_recording_skip_conv_fcn(image, config, test=False, channel_last=False,
+                                            bn_self_folding=False, record_layers=(),
+                                            name='bn-graph-ref'):
+    recorder = config.recorder_activation
+    recorder_weight = config.recorder_weight
+    axes = get_channel_axes(image, channel_last)
+
+    h = image
+    with nn.parameter_scope('MulScale-0'):
+        h = recorder()(h, axes=axes)
+        h /= 255.0
+    with nn.parameter_scope('first-conv'):  # skip recording first conv
+        w, b = create_conv_weight_bias(h, 16, kernel=(3, 3),
+                                       channel_last=channel_last, name=name)
+        h = F.convolution(h, w, b, pad=(1, 1), stride=(1, 1),
+                          channel_last=channel_last)
+    with nn.parameter_scope('ReLU-2'):
+        h = recorder()(h, axes=axes)
+        h = F.relu(h)
+    with nn.parameter_scope('MaxPooling-3'):
+        h = recorder()(h, axes=axes)
+        h = F.max_pooling(h, (2, 2), channel_last=channel_last)
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb1')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb2')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb3')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb4')
+    with nn.parameter_scope('AveragePooling-16'):
+        h = recorder()(h, axes=axes)
+        h = F.average_pooling(h, (2, 2), channel_last=channel_last)
+    with nn.parameter_scope('last-conv'):  # skip recording last conv
+        w, b = create_conv_weight_bias(h, 16, kernel=(3, 3),
+                                       channel_last=channel_last, name=name)
+        pred = F.convolution(h, w, b, pad=(1, 1), stride=(1, 1),
+                             channel_last=channel_last)
+        return pred
+
+
+def small_bn_multi_fc_resnet(image, test=False, w_bias=False, channel_last=False, name='bn-graph-ref'):
+    h = image
+    h /= 255.0
+    h = PF.convolution(h, 16, kernel=(3, 3), pad=(1, 1), channel_last=channel_last,
+                       with_bias=w_bias, name='first-conv')
+    axes = get_channel_axes(h, channel_last)
+    h = PF.batch_normalization(
+        h, axes=axes, batch_stat=not test, name='first-bn')
+    h = F.relu(h)
+    h = F.max_pooling(h, (2, 2), channel_last=channel_last)
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb1')
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb2')
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb3')
+    h = bn_resblock(h, maps=16, test=test, w_bias=w_bias,
+                    channel_last=channel_last, name='cb4')
+    h = F.average_pooling(h, (2, 2), channel_last=channel_last)
+    h = PF.affine(h, 256, name='fc1')
+    h = PF.affine(h, 128, name='fc2')
+    pred = PF.affine(h, 10, name='fc3')
+    return pred
+
+
+def small_nonqnn_to_recording_skip_affine_resnet(image, config, test=False, channel_last=False,
+                                                 bn_self_folding=False, record_layers=(),
+                                                 name='bn-graph-ref'):
+    recorder = config.recorder_activation
+    recorder_weight = config.recorder_weight
+    axes = get_channel_axes(image, channel_last)
+
+    h = image
+    with nn.parameter_scope('MulScale-0'):
+        h = recorder()(h, axes=axes)
+        h /= 255.0
+    with nn.parameter_scope('first-conv'):
+        h = recorder()(h, axes=axes)
+        w, b = create_conv_weight_bias(h, 16, kernel=(3, 3),
+                                       channel_last=channel_last, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        h = F.convolution(h, w, b, pad=(1, 1), stride=(1, 1),
+                          channel_last=channel_last)
+    with nn.parameter_scope('ReLU-2'):
+        h = recorder()(h, axes=axes)
+        h = F.relu(h)
+    with nn.parameter_scope('MaxPooling-3'):
+        h = recorder()(h, axes=axes)
+        h = F.max_pooling(h, (2, 2), channel_last=channel_last)
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb1')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb2')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb3')
+    h = nonqnn_to_recording_resblock(h, config, maps=16, test=test,
+                                     channel_last=channel_last, name='cb4')
+    with nn.parameter_scope('AveragePooling-16'):
+        h = recorder()(h, axes=axes)
+        h = F.average_pooling(h, (2, 2), channel_last=channel_last)
+    with nn.parameter_scope('fc1'):  # skip recording first affine
+        w, b = create_affine_weight_bias(h, 256, name=name)
+        h = F.affine(h, w, b)
+    with nn.parameter_scope('fc2'):
+        h = recorder()(h, axes=axes)
+        w, b = create_affine_weight_bias(h, 128, name=name)
+        w = recorder_weight()(w, axes=axes, name='w')
+        b = recorder_weight()(b, axes=axes, name='b')
+        h = F.affine(h, w, b)
+    with nn.parameter_scope('fc3'):  # skip recording last affine
+        w, b = create_affine_weight_bias(h, 10, name=name)
+        pred = F.affine(h, w, b)
 
         return pred

--- a/python/test/utils/test_graph_converters/test_batch_normalization_folding.py
+++ b/python/test/utils/test_graph_converters/test_batch_normalization_folding.py
@@ -41,10 +41,11 @@ resnet_ref = small_bn_folding_resnet
 @pytest.mark.parametrize('ctx, func_name', ctxs)
 @pytest.mark.parametrize('seed', [313])
 @pytest.mark.parametrize('test', [True])
-@pytest.mark.parametrize('w_bias', [True])
-@pytest.mark.parametrize('channel_last', [False, True])
+@pytest.mark.parametrize('w_bias', [True]) # TODO: dcn w_bias=False
+@pytest.mark.parametrize('channel_last', [True, False])
 @pytest.mark.parametrize('graph_ref, graph_act, opposite',
-                         [(resnet_ref, small_bn_resnet, False),
+                         [#(lenet_ref, bn_lenet, False)])#,
+                          (resnet_ref, small_bn_resnet, False),
                           (resnet_ref, small_bn_opp_resnet, True),
                           (small_dcn, small_bn_dcn, False),
                           (small_opp_dcn, small_bn_opp_dcn, True)])
@@ -79,8 +80,8 @@ def test_batch_normalization_folding(ctx, func_name, seed, test, w_bias,
         y_act = GC.GraphConverter(modifiers).convert(y_tgt)
 
         # Ref Graph
-        y_ref = graph_ref(x, test=test, channel_last=channel_last, dims=dims)
+        y_ref = graph_ref(x, channel_last=channel_last, dims=dims)
 
         # Test
         structure_tester(y_ref, y_act)
-        value_tester(y_tgt, y_act, rtol=6e-02, atol=5e-02)
+        value_tester(y_tgt, y_act, rtol=6e-04, atol=5e-04)

--- a/python/test/utils/test_graph_converters/test_batch_normalization_folding.py
+++ b/python/test/utils/test_graph_converters/test_batch_normalization_folding.py
@@ -41,10 +41,10 @@ resnet_ref = small_bn_folding_resnet
 @pytest.mark.parametrize('ctx, func_name', ctxs)
 @pytest.mark.parametrize('seed', [313])
 @pytest.mark.parametrize('test', [True])
-@pytest.mark.parametrize('w_bias', [True]) # TODO: dcn w_bias=False
+@pytest.mark.parametrize('w_bias', [True])  # TODO: dcn w_bias=False
 @pytest.mark.parametrize('channel_last', [True, False])
 @pytest.mark.parametrize('graph_ref, graph_act, opposite',
-                         [#(lenet_ref, bn_lenet, False)])#,
+                         [  # (lenet_ref, bn_lenet, False)])#,
                           (resnet_ref, small_bn_resnet, False),
                           (resnet_ref, small_bn_opp_resnet, True),
                           (small_dcn, small_bn_dcn, False),

--- a/python/test/utils/test_graph_converters/test_batch_normalization_self_folding.py
+++ b/python/test/utils/test_graph_converters/test_batch_normalization_self_folding.py
@@ -20,7 +20,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.experimental.graph_converters as GC
 
-from .ref_graphs.resnets import small_cf_resnet, small_bn_self_folding_resnet
+from .ref_graphs.resnets import small_bn_resnet, small_bn_self_folding_resnet
 
 
 batch_size = 1
@@ -29,7 +29,7 @@ resnet_ref = small_bn_self_folding_resnet
 
 @pytest.mark.parametrize('seed', [313])
 @pytest.mark.parametrize('test', [True])
-@pytest.mark.parametrize('graph_ref, graph_act', [(resnet_ref, small_cf_resnet)])
+@pytest.mark.parametrize('graph_ref, graph_act', [(resnet_ref, small_bn_resnet)])
 def test_batch_normalization_self_folding(seed, test, graph_ref, graph_act):
     from .graph_converter_test_utils import structure_tester, value_tester
 

--- a/python/test/utils/test_graph_converters/test_channel_first.py
+++ b/python/test/utils/test_graph_converters/test_channel_first.py
@@ -22,12 +22,12 @@ import nnabla.experimental.graph_converters as GC
 
 from nnabla.ext_utils import get_extension_context
 
-from .ref_graphs.resnets import small_cl_resnet, small_cf_resnet
+from .ref_graphs.resnets import small_cl_resnet, small_bn_resnet
 from nbla_test_utils import list_context
 
 ctxs = list_context('Convolution')  # proxy to switch the context
 batch_size = 1
-resnet_ref = small_cf_resnet
+resnet_ref = small_bn_resnet
 
 
 @pytest.mark.parametrize("ctx, func_name", ctxs)

--- a/python/test/utils/test_graph_converters/test_channel_last.py
+++ b/python/test/utils/test_graph_converters/test_channel_last.py
@@ -22,7 +22,7 @@ import nnabla.experimental.graph_converters as GC
 
 from nnabla.ext_utils import get_extension_context
 
-from .ref_graphs.resnets import small_cf_resnet, small_cl_resnet
+from .ref_graphs.resnets import small_bn_resnet, small_cl_resnet
 from nbla_test_utils import list_context
 
 ctxs = list_context('Convolution')  # proxy to switch the context
@@ -33,7 +33,7 @@ resnet_ref = small_cl_resnet
 @pytest.mark.parametrize('ctx, func_name', ctxs)
 @pytest.mark.parametrize('seed', [313])
 @pytest.mark.parametrize('test', [True, False])
-@pytest.mark.parametrize('graph_ref, graph_act', [(resnet_ref, small_cf_resnet)])
+@pytest.mark.parametrize('graph_ref, graph_act', [(resnet_ref, small_bn_resnet)])
 def test_channel_last(ctx, func_name, seed, test, graph_ref, graph_act):
     from .graph_converter_test_utils import structure_tester, value_tester
 

--- a/python/test/utils/test_graph_converters/test_identity.py
+++ b/python/test/utils/test_graph_converters/test_identity.py
@@ -20,7 +20,7 @@ import numpy as np
 import nnabla as nn
 import nnabla.experimental.graph_converters as GC
 
-from .ref_graphs.resnets import small_cf_resnet, small_id_resnet
+from .ref_graphs.resnets import small_bn_resnet, small_id_resnet
 from .ref_graphs.lenets import lenet, id_lenet
 
 
@@ -33,7 +33,7 @@ resnet_ref = small_id_resnet
 @pytest.mark.parametrize('test', [False, True])
 @pytest.mark.parametrize('diff_batchsize', [True, False])
 @pytest.mark.parametrize('graph_ref, graph_act', [(lenet_ref, lenet),
-                                                  (resnet_ref, small_cf_resnet)])
+                                                  (resnet_ref, small_bn_resnet)])
 def test_identity(seed, test, diff_batchsize, graph_ref, graph_act):
     from .graph_converter_test_utils import structure_tester, value_tester
 

--- a/python/test/utils/test_graph_converters/test_no_grad.py
+++ b/python/test/utils/test_graph_converters/test_no_grad.py
@@ -20,12 +20,12 @@ import numpy as np
 import nnabla as nn
 import nnabla.experimental.graph_converters as GC
 
-from .ref_graphs.resnets import small_cf_resnet
+from .ref_graphs.resnets import small_bn_resnet
 from .ref_graphs.lenets import lenet
 
 
 @pytest.mark.parametrize('seed', [313])
-@pytest.mark.parametrize('graph', [lenet, small_cf_resnet])
+@pytest.mark.parametrize('graph', [lenet, small_bn_resnet])
 def test_no_grad(seed, graph):
     from .graph_converter_test_utils import structure_tester, value_tester
 

--- a/python/test/utils/test_graph_converters/test_quantize.py
+++ b/python/test/utils/test_graph_converters/test_quantize.py
@@ -1,0 +1,147 @@
+# Copyright (c) 2020 Sony Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+import pytest
+import numpy as np
+
+import nnabla as nn
+import nnabla.experimental.graph_converters as GC
+import nnabla.functions as F
+import nnabla.solvers as S
+
+
+from nnabla.utils.qnn import QNNConfig, PrecisionMode, FunctionsRankRecorder
+from nnabla.ext_utils import get_extension_context
+from nbla_test_utils import list_context
+from .ref_graphs.resnets import (small_bn_resnet,
+                                 small_nonqnn_to_recording_resnet,
+                                 small_nonqnn_to_specific_recording_pos_resnet,
+                                 small_bn_fcn,
+                                 small_nonqnn_to_recording_skip_conv_fcn,
+                                 small_bn_multi_fc_resnet,
+                                 small_nonqnn_to_recording_skip_affine_resnet,
+                                 small_bn_opp_resnet)
+
+
+ctxs = list_context('Convolution')  # proxy to switch the context
+batch_size = 1
+record_layers = [
+    [],  # If empty add to all layers
+    ['Convolution', 'Affine']
+]
+skip_layers = [
+    [],
+    ['Convolution'],
+    ['Affine']
+]
+
+
+@pytest.mark.parametrize('ctx, func_name', ctxs)
+@pytest.mark.parametrize('seed', [520])
+@pytest.mark.parametrize('test', [True])
+@pytest.mark.parametrize('w_bias', [True])
+@pytest.mark.parametrize('channel_last', [True, False])
+@pytest.mark.parametrize('graph_ref, graph_act, folding, \
+                          self_folding, rec_lays, rec_pos, skip_lays',
+                         [(small_nonqnn_to_recording_resnet, small_bn_resnet,
+                           True, False, record_layers[0],
+                           QNNConfig.RecorderPosition.BEFORE,
+                           skip_layers[0]),
+                          (small_nonqnn_to_recording_resnet, small_bn_opp_resnet,
+                           True, False, record_layers[0],
+                           QNNConfig.RecorderPosition.BEFORE,
+                           skip_layers[0]),
+                          (small_nonqnn_to_recording_resnet, small_bn_resnet,
+                           False, True, record_layers[0],
+                           QNNConfig.RecorderPosition.BEFORE,
+                           skip_layers[0]),
+                          (small_nonqnn_to_recording_resnet, small_bn_resnet,
+                           False, True, record_layers[1],
+                           QNNConfig.RecorderPosition.BEFORE,
+                           skip_layers[0]),
+                          (small_nonqnn_to_specific_recording_pos_resnet, small_bn_resnet,
+                           True, True, record_layers[1],
+                           QNNConfig.RecorderPosition.BOTH,
+                           skip_layers[0]),
+                          (small_nonqnn_to_recording_skip_conv_fcn, small_bn_fcn,
+                           True, True, record_layers[0],
+                           QNNConfig.RecorderPosition.BEFORE,
+                           skip_layers[1]),
+                          (small_nonqnn_to_recording_skip_affine_resnet, small_bn_multi_fc_resnet,
+                           True, True, record_layers[0],
+                           QNNConfig.RecorderPosition.BEFORE,
+                           skip_layers[2])
+                          ])
+def test_nonqnn_to_recording(ctx, func_name, seed, test, w_bias, channel_last,
+                             graph_ref, graph_act, folding, self_folding, rec_lays, rec_pos, skip_lays):
+    from .graph_converter_test_utils import structure_tester, value_tester
+
+    if channel_last == True and not func_name.endswith('Cudnn'):
+        pytest.skip(
+            'ChannelLast conversion is only supported in cuDNN context.')
+
+    cfg = QNNConfig()
+    cfg.bn_folding = folding
+    cfg.bn_self_folding = self_folding
+    cfg.channel_last = channel_last
+    cfg.record_layers = rec_lays
+    cfg.recorder_position = rec_pos
+    cfg.skip_inputs_layers = skip_lays
+    cfg.skip_outputs_layers = skip_lays
+
+    with nn.context_scope(ctx):
+        # Random number
+        np.random.seed(seed)
+        rng = np.random.RandomState(seed)
+
+        # Graph
+        x_data = rng.randn(batch_size, 32, 32, 3) if channel_last == True \
+            else rng.randn(batch_size, 3, 32, 32)
+        x = nn.Variable.from_numpy_array(x_data)
+
+        y_tgt = graph_act(x, test=test, w_bias=w_bias,
+                          channel_last=channel_last)
+
+        # BN folding & BN self folding
+        modifiers = []
+        if cfg.bn_folding:
+            modifiers.append(GC.BatchNormalizationFoldingModifier(
+                opposite=False, channel_last=cfg.channel_last))
+            modifiers.append(GC.BatchNormalizationFoldingModifier(
+                opposite=True, channel_last=cfg.channel_last))
+        # Go through BN self folding
+        if cfg.bn_self_folding:
+            modifiers.append(GC.BatchNormalizationSelfFoldingModifier())
+        if len(modifiers) > 0:
+            y_tgt_without_bn = GC.GraphConverter(modifiers).convert(y_tgt)
+            y_tgt.rewire_on(y_tgt_without_bn)
+
+        # FunctionModifier
+        funcrankrecorder = FunctionsRankRecorder()
+        y_tgt.visit(funcrankrecorder)
+        modifiers = []
+        modifiers.append(GC.QuantizeNonQNNToRecordingModifier(
+            funcrankrecorder.functions_ranks, config=cfg))
+
+        y_act = GC.GraphConverter(modifiers).convert(y_tgt)
+
+        # Ref Graph
+        y_ref = graph_ref(x, cfg, test=test, channel_last=channel_last,
+                          bn_self_folding=self_folding, record_layers=rec_lays)
+
+        # Test
+        structure_tester(y_ref, y_act)
+        value_tester(y_tgt, y_act, rtol=6e-02, atol=5e-02)

--- a/python/test/utils/test_graph_converters/test_quantize.py
+++ b/python/test/utils/test_graph_converters/test_quantize.py
@@ -24,7 +24,6 @@ import nnabla.solvers as S
 
 
 from nnabla.utils.qnn import QATConfig, PrecisionMode, FunctionsRankRecorder
-from nnabla.ext_utils import get_extension_context
 from nbla_test_utils import list_context
 from .ref_graphs.resnets import (small_bn_resnet,
                                  small_nonqnn_to_recording_resnet,
@@ -40,15 +39,6 @@ from .ref_graphs.resnets import (small_bn_resnet,
 
 ctxs = list_context('Convolution')  # proxy to switch the context
 batch_size = 1
-record_layers = [
-    [],  # If empty add to all layers
-    ['Convolution', 'Affine']
-]
-skip_layers = [
-    [],
-    ['Convolution'],
-    ['Affine']
-]
 
 
 @pytest.mark.parametrize('ctx, func_name', ctxs)
@@ -59,33 +49,33 @@ skip_layers = [
 @pytest.mark.parametrize('graph_ref, graph_act, folding, \
                           self_folding, rec_lays, rec_pos, skip_lays',
                          [(small_nonqnn_to_recording_resnet, small_bn_resnet,
-                           True, False, record_layers[0],
+                           True, False, [],
                            QATConfig.RecorderPosition.BEFORE,
-                           skip_layers[0]),
+                           []),
                           (small_nonqnn_to_recording_resnet, small_bn_opp_resnet,
-                           True, False, record_layers[0],
+                           True, False, [],
                            QATConfig.RecorderPosition.BEFORE,
-                           skip_layers[0]),
+                           []),
                           (small_nonqnn_to_recording_resnet, small_bn_resnet,
-                           False, True, record_layers[0],
+                           False, True, [],
                            QATConfig.RecorderPosition.BEFORE,
-                           skip_layers[0]),
+                           []),
                           (small_nonqnn_to_recording_resnet, small_bn_resnet,
-                           False, True, record_layers[1],
+                           False, True, ['Convolution', 'Affine'],
                            QATConfig.RecorderPosition.BEFORE,
-                           skip_layers[0]),
+                           []),
                           (small_nonqnn_to_specific_recording_pos_resnet, small_bn_resnet,
-                           True, True, record_layers[1],
+                           True, True, ['Convolution', 'Affine'],
                            QATConfig.RecorderPosition.BOTH,
-                           skip_layers[0]),
+                           []),
                           (small_nonqnn_to_recording_skip_conv_fcn, small_bn_fcn,
-                           True, True, record_layers[0],
+                           True, True, [],
                            QATConfig.RecorderPosition.BEFORE,
-                           skip_layers[1]),
+                           ['Convolution']),
                           (small_nonqnn_to_recording_skip_affine_resnet, small_bn_multi_fc_resnet,
-                           True, True, record_layers[0],
+                           True, True, [],
                            QATConfig.RecorderPosition.BEFORE,
-                           skip_layers[2])
+                           ['Affine'])
                           ])
 def test_nonqnn_to_recording(ctx, func_name, seed, test, w_bias, channel_last,
                              graph_ref, graph_act, folding, self_folding, rec_lays, rec_pos, skip_lays):

--- a/python/test/utils/test_graph_converters/test_quantize.py
+++ b/python/test/utils/test_graph_converters/test_quantize.py
@@ -23,7 +23,7 @@ import nnabla.functions as F
 import nnabla.solvers as S
 
 
-from nnabla.utils.qnn import QNNConfig, PrecisionMode, FunctionsRankRecorder
+from nnabla.utils.qnn import QATConfig, PrecisionMode, FunctionsRankRecorder
 from nnabla.ext_utils import get_extension_context
 from nbla_test_utils import list_context
 from .ref_graphs.resnets import (small_bn_resnet,
@@ -60,31 +60,31 @@ skip_layers = [
                           self_folding, rec_lays, rec_pos, skip_lays',
                          [(small_nonqnn_to_recording_resnet, small_bn_resnet,
                            True, False, record_layers[0],
-                           QNNConfig.RecorderPosition.BEFORE,
+                           QATConfig.RecorderPosition.BEFORE,
                            skip_layers[0]),
                           (small_nonqnn_to_recording_resnet, small_bn_opp_resnet,
                            True, False, record_layers[0],
-                           QNNConfig.RecorderPosition.BEFORE,
+                           QATConfig.RecorderPosition.BEFORE,
                            skip_layers[0]),
                           (small_nonqnn_to_recording_resnet, small_bn_resnet,
                            False, True, record_layers[0],
-                           QNNConfig.RecorderPosition.BEFORE,
+                           QATConfig.RecorderPosition.BEFORE,
                            skip_layers[0]),
                           (small_nonqnn_to_recording_resnet, small_bn_resnet,
                            False, True, record_layers[1],
-                           QNNConfig.RecorderPosition.BEFORE,
+                           QATConfig.RecorderPosition.BEFORE,
                            skip_layers[0]),
                           (small_nonqnn_to_specific_recording_pos_resnet, small_bn_resnet,
                            True, True, record_layers[1],
-                           QNNConfig.RecorderPosition.BOTH,
+                           QATConfig.RecorderPosition.BOTH,
                            skip_layers[0]),
                           (small_nonqnn_to_recording_skip_conv_fcn, small_bn_fcn,
                            True, True, record_layers[0],
-                           QNNConfig.RecorderPosition.BEFORE,
+                           QATConfig.RecorderPosition.BEFORE,
                            skip_layers[1]),
                           (small_nonqnn_to_recording_skip_affine_resnet, small_bn_multi_fc_resnet,
                            True, True, record_layers[0],
-                           QNNConfig.RecorderPosition.BEFORE,
+                           QATConfig.RecorderPosition.BEFORE,
                            skip_layers[2])
                           ])
 def test_nonqnn_to_recording(ctx, func_name, seed, test, w_bias, channel_last,
@@ -95,7 +95,7 @@ def test_nonqnn_to_recording(ctx, func_name, seed, test, w_bias, channel_last,
         pytest.skip(
             'ChannelLast conversion is only supported in cuDNN context.')
 
-    cfg = QNNConfig()
+    cfg = QATConfig()
     cfg.bn_folding = folding
     cfg.bn_self_folding = self_folding
     cfg.channel_last = channel_last
@@ -157,7 +157,7 @@ def test_nonqnn_to_recording(ctx, func_name, seed, test, w_bias, channel_last,
 def test_recording_to_training(ctx, func_name, seed, precision_mode, graph_ref, graph_act):
     from .graph_converter_test_utils import structure_tester, value_tester
 
-    cfg = QNNConfig()
+    cfg = QATConfig()
     cfg.bn_folding = True
     cfg.bn_self_folding = True
     cfg.channel_last = False


### PR DESCRIPTION
This PR includes following features
* QNN converter and scheduler to convert the python computational graph to the quantized-aware training (QAT) graph
* QNN configuration specific to [TensorRT](https://docs.nvidia.com/deeplearning/tensorrt/developer-guide/index.html)
* Several bugfix

Quantization-Aware-Training with NNabla
---
In nnabla, we divide QAT into two stages, RECORDING and TRAINING.
In RECORDING stage, we collect and record the dynamic range of each weight and activation.
In TRAINING stage, we insert Quantization & Dequantization node to simulate the quantization effect.

We provide QATScheduler to support Quantization-Aware-Training.

Create QATScheduler
---
```python
from nnabla.utils.qnn import QATScheduler, QATConfig, PrecisionMode
# Create training network
pred = model(image, test=False)
# Create validation network
vpred = model(vimage, test=True)
# configure of QATScheduler
config = QATConfig()
config.bn_folding = True
config.bn_self_folding = True
config.channel_last = False
config.precision_mode = PrecisionMode.SIM_QNN
config.skip_bias = True
config.niter_to_recording = 1
config.niter_to_training = steps_per_epoch * 2
# Create a QATScheduler object
qat_scheduler = QATScheduler(config=config, solver=solver)
# register the training network to QATScheduler
qat_scheduler(pred)
# register the validation network to QATScheduler
qat_scheduler(vpred, training=False)
```

**Shorthand for TensorRT**
```python
from nnabla.utils.qnn import QATScheduler, QATTensorRTConfig
config = QATTensorRTConfig()
qat_scheduler = QATScheduler(config=config, solver=solver)
qat_scheduler(pred)
qat_scheduler(vpred, training=False)
```


Modify your training loop
---
![qat](https://user-images.githubusercontent.com/38904108/169938654-81a75866-26d9-47cd-8d2c-47af479234e2.png)
