### PR TITLE
use numpy 1.20.0 and later

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -57,7 +57,7 @@ CALL pip install %PIP_INS_OPTS% ^
            ipython ^
            librosa ^
            mako ^
-           numpy ^
+           "numpy>=1.20.0" ^
            pip ^
            protobuf ^
            pytest ^

--- a/docker/development/Dockerfile.document
+++ b/docker/development/Dockerfile.document
@@ -29,20 +29,30 @@ ENV LANGUAGE C
 
 RUN eval ${APT_OPTS} \
     && apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
     clang-format-3.9 \
     cmake \
     curl \
     g++ \
     git \
     make \
-    python3-dev \
-    python3-pip \
+    python3.7-dev \
+    python3.7 \
     python3-setuptools \
     unzip \
     zip \
     zlib1g-dev \
     libhdf5-dev \
-    libarchive-dev
+    libarchive-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3.7 get-pip.py ${PIP_INS_OPTS} \
+    && rm get-pip.py
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 0
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 0
 
 ADD python/setup_requirements.txt /tmp/deps/
 RUN pip3 install ${PIP_INS_OPTS} -U -r /tmp/deps/setup_requirements.txt

--- a/docker/development/Dockerfile.nnabla-test-aarch64
+++ b/docker/development/Dockerfile.nnabla-test-aarch64
@@ -101,7 +101,7 @@ RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip
 RUN echo "[global]" >/etc/pip.conf
 RUN echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
 
-RUN pip3 install ${PIP_INS_OPTS} numpy\<1.22
+RUN pip3 install ${PIP_INS_OPTS} 'numpy>=1.20.0,<1.22'
 
 RUN pip3 install ${PIP_INS_OPTS} -r /tmp/deps/setup_requirements.txt
 

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ Cython
 boto3
 h5py
 imageio
-numpy
+numpy>=1.20.0
 pillow
 protobuf
 pyyaml

--- a/python/setup.py
+++ b/python/setup.py
@@ -24,7 +24,7 @@ from collections import namedtuple
 
 setup_requires = [
     'setuptools',
-    'numpy',
+    'numpy>=1.20.0',
     'Cython',  # Requires python-dev.
 ]
 


### PR DESCRIPTION
Currently, we don't specify numpy version, so the following error occurs when system has numpy v1.19.5.

```python
Traceback (most recent call last):
  File "classification.py", line 23, in <module>
    import nnabla as nn
  File "lib/python3.7/site-packages/nnabla/__init__.py", line 32, in <module>
    from .variable import Variable, Context
  File "lib/python3.7/site-packages/nnabla/variable.py", line 17, in <module>
    from ._variable import Context
  File "_variable.pyx", line 1, in init nnabla._variable
  File "_nd_array.pyx", line 1, in init nnabla._nd_array
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "<frozen importlib._bootstrap>", line 983, in _find_and_load
  File "<frozen importlib._bootstrap>", line 953, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "lib/python3.7/site-packages/nnabla/__init__.py", line 32, in <module>
    from .variable import Variable, Context
  File "lib/python3.7/site-packages/nnabla/variable.py", line 17, in <module>
    from ._variable import Context
  File "_variable.pyx", line 1, in init nnabla._variable
  File "_nd_array.pyx", line 1, in init nnabla._nd_array
ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject
```

So, explicitly require numpy v1.20.0 and later when installing nnabla.