### PR TITLE
pack flatc binary files for windows/linux/mac into python wheel

### DIFF
--- a/build-tools/msvc/tools/get_flatbuffers.bat
+++ b/build-tools/msvc/tools/get_flatbuffers.bat
@@ -17,19 +17,23 @@ REM limitations under the License.
 REM Download bulit flatbuffers binary
 
 SET FLATC_PACKAGE=flatc-v2.0.0
-powershell "[Net.ServicePointManager]::SecurityProtocol +='tls12'; iwr %nnabla_iwr_options% -Uri https://github.com/google/flatbuffers/releases/download/v2.0.0/Windows.flatc.binary.zip -OutFile %FLATC_PACKAGE%.zip" || GOTO :error
 
-MD %FLATC_PACKAGE%
-CD %FLATC_PACKAGE%
-cmake -E tar xvzf ..\%FLATC_PACKAGE%.zip || GOTO :error
-
-MOVE flatc.exe %third_party_folder%
-CD ..
-
-DEL %FLATC_PACKAGE%.zip
-RMDIR /s /q %FLATC_PACKAGE%
-
+call :download_flatc_and_rename https://github.com/google/flatbuffers/releases/download/v2.0.0/Windows.flatc.binary.zip flatc.exe flatc_windows.exe
+call :download_flatc_and_rename https://github.com/google/flatbuffers/releases/download/v2.0.0/Mac.flatc.binary.zip flatc flatc_mac
+call :download_flatc_and_rename https://github.com/google/flatbuffers/releases/download/v2.0.0/Linux.flatc.binary.clang++-9.zip flatc flatc_linux
 exit /b
+
+:download_flatc_and_rename
+    powershell "[Net.ServicePointManager]::SecurityProtocol +='tls12'; iwr %nnabla_iwr_options% -Uri %1 -OutFile %FLATC_PACKAGE%.zip" || GOTO :error
+    ECHO downloading %3
+    MD %FLATC_PACKAGE%
+    CD %FLATC_PACKAGE%
+    cmake -E tar xvzf ..\%FLATC_PACKAGE%.zip || GOTO :error
+    MOVE %2 %third_party_folder%\%3
+    CD ..
+    DEL %FLATC_PACKAGE%.zip
+    RMDIR /s /q %FLATC_PACKAGE%
+    exit /b
 
 :error
 ECHO failed with error code %errorlevel%.

--- a/python/src/nnabla/utils/converter/setup.py
+++ b/python/src/nnabla/utils/converter/setup.py
@@ -56,12 +56,13 @@ if __name__ == '__main__':
     package_data = {"nnabla.utils.converter.tflite": [
         'schema.fbs',
     ]}
+    flatc_files = ['flatc_linux', 'flatc_mac', 'flatc_windows.exe']
     try:
-        fn = 'flatc.exe' if sys.platform == 'win32' else 'flatc'
-        shutil.copyfile(os.path.join(root_dir, '../../../../../', 'third_party', fn),
-                        os.path.join(tflite_src_dir, fn))
-        os.chmod(os.path.join(tflite_src_dir, fn), 0o755)
-        package_data["nnabla.utils.converter.tflite"].append(fn)
+        for fn in flatc_files:
+            shutil.copyfile(os.path.join(root_dir, '../../../../../', 'third_party', fn),
+                            os.path.join(tflite_src_dir, fn))
+            os.chmod(os.path.join(tflite_src_dir, fn), 0o755)
+            package_data["nnabla.utils.converter.tflite"].append(fn)
     except:
         raise OSError(f"Not found: {fn} in third_party")
 

--- a/python/src/nnabla/utils/converter/tflite/exporter.py
+++ b/python/src/nnabla/utils/converter/tflite/exporter.py
@@ -26,7 +26,12 @@ import sys
 
 
 random_seed = 0
-fn = 'flatc.exe' if sys.platform == 'win32' else 'flatc'
+if sys.platform == 'linux':
+    fn = 'flatc_linux'
+elif sys.platform == 'darwin':
+    fn = 'flatc_mac'
+else:
+    fn = 'flatc_windows.exe'
 flatc_path = os.path.join(os.path.dirname(__file__), fn)
 
 

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -43,11 +43,21 @@ endif()
 
 download_and_extract_library(eigen-3.3.5 .zip https://gitlab.com/libeigen/eigen/-/archive/3.3.5/eigen-3.3.5.zip)
 
-if(APPLE)
-  download_and_extract_library(flatbuffers .zip https://github.com/google/flatbuffers/releases/download/v2.0.0/Mac.flatc.binary.zip)
-elseif(UNIX)
-  download_and_extract_library(flatbuffers .zip https://github.com/google/flatbuffers/releases/download/v2.0.0/Linux.flatc.binary.clang++-9.zip)
-endif()
+set(flatbuffers_info
+  "https://github.com/google/flatbuffers/releases/download/v2.0.0/Mac.flatc.binary.zip\;flatc\;flatc_mac"
+  "https://github.com/google/flatbuffers/releases/download/v2.0.0/Linux.flatc.binary.clang++-9.zip\;flatc\;flatc_linux"
+  "https://github.com/google/flatbuffers/releases/download/v2.0.0/Windows.flatc.binary.zip\;flatc.exe\;flatc_windows.exe"
+  )
+
+foreach(component ${flatbuffers_info})
+  list(GET component 0 url)
+  list(GET component 1 filename_old)
+  list(GET component 2 filename_new)
+  download_and_extract_library(flatbuffers .zip ${url})
+  execute_process(
+    COMMAND ${CMAKE_COMMAND} -E
+    rename ${CMAKE_SOURCE_DIR}/third_party/${filename_old} ${CMAKE_SOURCE_DIR}/third_party/${filename_new})
+endforeach()
 
 if(BUILD_TEST)
   download_and_extract_library(googletest-release-1.10.0 .zip https://github.com/google/googletest/archive/release-1.10.0.zip)


### PR DESCRIPTION
Until now, it was necessary to install flatc when converting tflite with nnabla-converter.
This PR includes flatc in nnabla-converter so that users don't have to install it separately.