### PR TITLE
Skip FFT/IFFT pytests for win32+CUDA114

### DIFF
--- a/python/test/function/test_fft.py
+++ b/python/test/function/test_fft.py
@@ -14,6 +14,7 @@
 
 import pytest
 import numpy as np
+import sys
 import nnabla.functions as F
 from nbla_test_utils import list_context
 
@@ -59,6 +60,12 @@ def ref_grad_fft(x, dy, signal_ndim, normalized, **kw):
 @pytest.mark.parametrize("normalized", [True, False])
 def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
                               signal_ndim, dims, normalized):
+
+    if func_name == "FFTCuda" and sys.platform == 'win32':
+        from nnabla_ext import cuda
+        if cuda._version.__cuda_version__ == '11.4':
+            pytest.skip("Skip win32+CUDA114 tests")
+
     if func_name == "FFT":
         pytest.skip("Not implemented in CPU.")
 
@@ -90,6 +97,12 @@ def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
 @pytest.mark.parametrize("normalized", [True, False])
 def test_fft_double_backward(seed, ctx, func_name, batch_dims,
                              signal_ndim, dims, normalized):
+
+    if func_name == "FFTCuda" and sys.platform == 'win32':
+        from nnabla_ext import cuda
+        if cuda._version.__cuda_version__ == '11.4':
+            pytest.skip("Skip win32+CUDA114 tests")
+
     if func_name == "FFT":
         pytest.skip("Not implemented in CPU.")
 

--- a/python/test/function/test_ifft.py
+++ b/python/test/function/test_ifft.py
@@ -14,6 +14,7 @@
 
 import pytest
 import numpy as np
+import sys
 import nnabla.functions as F
 from nbla_test_utils import list_context
 
@@ -61,6 +62,11 @@ def ref_grad_ifft(x, dy, signal_ndim, normalized, **kw):
 def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
                               signal_ndim, dims, normalized):
 
+    if func_name == "IFFTCuda" and sys.platform == 'win32':
+        from nnabla_ext import cuda
+        if cuda._version.__cuda_version__ == '11.4':
+            pytest.skip("Skip win32+CUDA114 tests")
+
     if func_name == "IFFT":
         pytest.skip("Not implemented in CPU.")
 
@@ -92,6 +98,11 @@ def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
 @pytest.mark.parametrize("normalized", [True, False])
 def test_fft_double_backward(seed, ctx, func_name, batch_dims,
                              signal_ndim, dims, normalized):
+
+    if func_name == "IFFTCuda" and sys.platform == 'win32':
+        from nnabla_ext import cuda
+        if cuda._version.__cuda_version__ == '11.4':
+            pytest.skip("Skip win32+CUDA114 tests")
 
     if func_name == "IFFT":
         pytest.skip("Not implemented in CPU.")


### PR DESCRIPTION
There are some problems to run cuFFT pytest under win32+cuda11.4 environment. We'd like to skip these tests for the combination until a proper fix applied. This is part of modifications to support cuda11.4