### PR TITLE
Update scipy I/F from 1.9.x

### DIFF
--- a/python/test/function/test_istft.py
+++ b/python/test/function/test_istft.py
@@ -39,6 +39,7 @@ def ref_istft(y_r, y_i, window_size, stride, fft_size, window_type, center, pad_
         length = x_shape[1]
 
         # librosa.istft does not support batched input.
+        window_type = 'hann' if window_type == 'hanning' else window_type
         b = y.shape[0]
         xs = []
         for i in range(b):

--- a/python/test/function/test_stft.py
+++ b/python/test/function/test_stft.py
@@ -76,6 +76,7 @@ def ref_stft(x, window_size, stride, fft_size, window_type, center, pad_mode, as
         # Use librosa.stft as the forward reference.
 
         # librosa.stft does not support batched input.
+        window_type = 'hann' if window_type == 'hanning' else window_type
         b = x.shape[0]
         ys = []
         for i in range(b):


### PR DESCRIPTION
From scipy v1.9.0, `signal.windows.hanning` was changed to `signal.windows.hann`.
So, this PR changes `hanning` to `hann` in calling places.

ref: https://docs.scipy.org/doc/scipy/release.1.9.0.html
