### PR TITLE
Add narrow function for NdArray

### DIFF
--- a/include/nbla/array/cpu_array.hpp
+++ b/include/nbla/array/cpu_array.hpp
@@ -26,9 +26,8 @@ namespace nbla {
 class NBLA_API CpuArray : public Array {
 protected:
 public:
-  CpuArray(const Size_t size, dtypes dtype, const Context &ctx);
   CpuArray(const Size_t size, dtypes dtype, const Context &ctx,
-           AllocatorMemory &&mem);
+           const AllocatorMemoryPtr mem = nullptr, const Size_t offset = 0);
   virtual ~CpuArray();
   virtual void copy_from(const Array *src_array);
   virtual void zero();
@@ -40,7 +39,9 @@ public:
  */
 class NBLA_API CpuCachedArray : public CpuArray {
 public:
-  explicit CpuCachedArray(const Size_t size, dtypes dtype, const Context &ctx);
+  explicit CpuCachedArray(const Size_t size, dtypes dtype, const Context &ctx,
+                          const AllocatorMemoryPtr mem = nullptr,
+                          const Size_t offset = 0);
   virtual ~CpuCachedArray();
   static Context filter_context(const Context &ctx);
 };

--- a/include/nbla/array/cpu_dlpack_array.hpp
+++ b/include/nbla/array/cpu_dlpack_array.hpp
@@ -23,7 +23,9 @@ namespace nbla {
 */
 class NBLA_API CpuDlpackArray : public DlpackArray {
 public:
-  explicit CpuDlpackArray(const Size_t size, dtypes dtype, const Context &ctx);
+  explicit CpuDlpackArray(const Size_t size, dtypes dtype, const Context &ctx,
+                          const AllocatorMemoryPtr mem = nullptr,
+                          const Size_t offset = 0);
   virtual ~CpuDlpackArray();
   virtual void copy_from(const Array *src_array);
   virtual void zero();

--- a/include/nbla/array/dlpack_array.hpp
+++ b/include/nbla/array/dlpack_array.hpp
@@ -38,6 +38,8 @@ public:
       DlpackArray::borrow must be done to complete the construction.
    */
   DlpackArray(const Size_t size, dtypes dtype, const Context &ctx);
+  DlpackArray(const Size_t size, dtypes dtype, const Context &ctx,
+              const AllocatorMemoryPtr mem, const Size_t offset);
   virtual ~DlpackArray();
   void borrow(DLManagedTensor *dlp);
 

--- a/include/nbla/array_registry.hpp
+++ b/include/nbla/array_registry.hpp
@@ -53,12 +53,16 @@ private:
 /** ArrayCreator class this is never be instantiated. */
 class NBLA_API ArrayCreator {
 public:
-  typedef function<Array *(const Size_t, dtypes, const Context &)> Creator;
+  typedef function<Array *(const Size_t, dtypes, const Context &,
+                           AllocatorMemoryPtr, const Size_t)>
+      Creator;
   typedef function<Context(const Context &ctx)> FilterContext;
   typedef map<string, pair<Creator, FilterContext>> Registry_t;
 
   /** Interface to create array */
-  static Array *create(const Size_t size, dtypes dtype, const Context &ctx);
+  static Array *create(const Size_t size, dtypes dtype, const Context &ctx,
+                       const AllocatorMemoryPtr mem = nullptr,
+                       const Size_t offset = 0);
 
   /** Filter an context into minimal info that describes the context.
   */
@@ -120,9 +124,11 @@ NBLA_API void synchronizer_default(Array *src, Array *dst,
 
 #define NBLA_REGISTER_ARRAY_CREATOR(CLS)                                       \
   {                                                                            \
-    function<Array *(const Size_t, dtypes, const Context &)> func =            \
-        [](const Size_t size, dtypes dtype, const Context &ctx) {              \
-          return new_object<CLS>(size, dtype, ctx);                            \
+    function<Array *(const Size_t, dtypes, const Context &,                    \
+                     const AllocatorMemoryPtr, const Size_t)>                  \
+        func = [](const Size_t size, dtypes dtype, const Context &ctx,         \
+                  const AllocatorMemoryPtr mem, const Size_t offset) {         \
+          return new_object<CLS>(size, dtype, ctx, mem, offset);               \
         };                                                                     \
     ArrayCreator::add_creator(#CLS, func, CLS::filter_context);                \
   }

--- a/include/nbla/memory/allocator.hpp
+++ b/include/nbla/memory/allocator.hpp
@@ -108,6 +108,9 @@ public:
   void operator=(const AllocatorMemory &) = delete;
 };
 
+///< Shared pointer of AllocatorMemory.
+typedef shared_ptr<AllocatorMemory> AllocatorMemoryPtr;
+
 /** Allocator interface class.
 
     A derived class implements logics that manage cached device memory blocks.
@@ -152,7 +155,7 @@ public:
               AllocatorMemory must be moved to Array instance using std::move.
 
    */
-  AllocatorMemory alloc(size_t bytes, const string &device_id);
+  AllocatorMemoryPtr alloc(size_t bytes, const string &device_id);
 
   /** User should call this. This is called from destructor of AllocatorMemory.
 

--- a/include/nbla/nd_array.hpp
+++ b/include/nbla/nd_array.hpp
@@ -18,6 +18,7 @@
 #include <nbla/synced_array.hpp>
 
 #include <memory>
+#include <string>
 
 namespace nbla {
 
@@ -153,6 +154,19 @@ public:
    */
   NBLA_API shared_ptr<Array> cast_sp(dtypes dtype, const Context &ctx,
                                      bool write_only = false);
+
+  /** Returns a new array that is a narrowed part of this array. The narrowed
+     part is specified by the slice of this array from `start` to `start` +
+     `length` along the dimension `dim`.  The returned array and this array
+     share the same underlying allocated memory.
+
+      @param[in] dim Dimension along which to narrow. Currently, only 0 can be
+     specified.
+      @param[in] start Starting index in specified dimension.
+      @param[in] length Distance to the ending index from `start`.
+   */
+  NBLA_API Ptr narrow(const Size_t dim, const Size_t start,
+                      const Size_t length);
 
   DISABLE_COPY_AND_ASSIGN(NdArray);
 };

--- a/python/src/nnabla/_nd_array.pxd
+++ b/python/src/nnabla/_nd_array.pxd
@@ -62,6 +62,7 @@ cdef extern from "nbla/nd_array.hpp" namespace "nbla":
         unsigned long data_ptr(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except+
         CArray * cast(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
         ArrayPtr cast_sp(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
+        shared_ptr[CNdArray] narrow(const Size_t dim, const Size_t start, const Size_t length) except+
 
     ctypedef shared_ptr[CNdArray] NdArrayPtr
 

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -207,7 +207,7 @@ cdef class NdArray:
         return tuple(self.arrp.shape())
 
 
-    def data_ptr(self, dtype, ctx=None):
+    def data_ptr(self, dtype, ctx=None, cpp_bool write_only=False):
         """Get array's pointer.
 
         The behavior is similar to `cast` method but returns the data pointer based on the `ctx`.
@@ -216,6 +216,7 @@ cdef class NdArray:
         Args: 
             dtype (:obj:`numpy.dtype`):  Numpy Data type.
             ctx (:obj:`nnabla.Context`, optional): Context descriptor.
+            write_only (:obj:`bool`, optional): No synchronization happens.
 
         Returns:
             int: The data pointer.
@@ -230,7 +231,7 @@ cdef class NdArray:
         cdef CContext cctx = <CContext ?> ctx_
         cdef unsigned long ptr
         with nogil:
-            ptr = <unsigned long> self.arrp.data_ptr(< dtypes > type_num, cctx, False)
+            ptr = <unsigned long> self.arrp.data_ptr(< dtypes > type_num, cctx, write_only)
         return ptr
 
 
@@ -563,3 +564,20 @@ cdef class NdArray:
 
     def __setitem__(self, key, value):
         IDX.setitem(self, key, value)
+
+    def narrow(self, dim, start, length):
+        """
+        Returns a new array that is a narrowed part of this array.
+        The narrowed part is specified by the slice of this array from `start` to `start` + `length` along the dimension `dim`.
+        The returned array and this array share the same underlying allocated memory.
+
+        Args:
+            dim (int): Dimension along which to narrow. Currently, only 0 can be specified.
+            start (int): Starting index in specified dimension.
+            length (int): Distance to the ending index from `start`.
+
+        See :function:`nnabla.NdArray.narrow` for more details.
+
+        """
+        arr = self.arrp.narrow(dim, start, length)
+        return NdArray.create(arr)

--- a/python/test/test_nd_array.py
+++ b/python/test/test_nd_array.py
@@ -18,6 +18,8 @@ import numpy as np
 import nnabla as nn
 
 import pytest
+from nnabla.ext_utils import get_extension_context
+import nnabla.functions as F
 
 
 def test_nd_array():
@@ -101,3 +103,498 @@ def test_clear_called():
 
     a.data[0] = -1
     assert a.clear_called == False
+
+
+def test_clear_called_narrow():
+    a = nn.NdArray(2, 2)
+    assert a.clear_called == False
+    a.fill(3)
+    assert a.clear_called == False
+
+    b = a.narrow(0, 0, 1)
+    assert b.clear_called == False
+
+    with pytest.raises(RuntimeError):
+        b.clear()
+
+
+def test_nd_array_initialize():
+    shape = [2, 3, 4]
+    a = nn.NdArray(shape)  # uninitialized, but is filled by zeros
+
+    ref_a = np.zeros(shape, dtype=np.float32)
+    assert (a.data == ref_a).all()
+
+
+class TestNdArrayNarrow():
+
+    def setup_method(self):
+        self._ctx = nn.get_current_context()
+
+    def teardown_method(self):
+        nn.set_default_context(self._ctx)
+
+    def try_to_set_ctx(self, ctx_name):
+        try:
+            ctx = get_extension_context(ctx_name)
+        except Exception as e:
+            pytest.skip("Import of nnabla-ext-cuda failed, so skip this test.")
+
+        nn.set_default_context(ctx)
+
+    @pytest.mark.parametrize("shape", [
+        [10, 5], [100, 100], [1000, 1000], [20], [10, 10, 10]])
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow(self, shape, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        x = shape[0]
+        s = x // 10
+        a = nn.NdArray(shape)
+        a.fill(3.0)
+        b = a.narrow(0, 0, 4 * s)
+        b.fill(5.0)
+        c = a.narrow(0, 6 * s, 4 * s)
+        c.fill(7.0)
+        d = c.narrow(0, 2 * s, 2 * s)
+        d.fill(9.0)
+        b += c
+
+        ref_a = np.zeros(shape, dtype=np.float32)
+        ref_a.fill(3.0)
+        ref_b = ref_a[0:4*s]
+        ref_b.fill(5.0)
+        ref_c = ref_a[6*s:10*s]
+        ref_c.fill(7.0)
+        ref_d = ref_c[2*s:4*s]
+        ref_d.fill(9.0)
+        ref_b += ref_c
+
+        assert a.shape == tuple(shape)
+
+        assert (a.data == ref_a).all()
+        assert (b.data == ref_b).all()
+        assert (c.data == ref_c).all()
+        assert (d.data == ref_d).all()
+
+        assert a.data.dtype == ref_a.dtype
+        assert b.data.dtype == ref_b.dtype
+        assert c.data.dtype == ref_c.dtype
+        assert d.data.dtype == ref_d.dtype
+
+    @pytest.mark.parametrize("shape", [
+        [10, 5], [100, 100], [1000, 1000], [20], [10, 10, 10]])
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow_2(self, shape, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        x = shape[0]
+        s = x // 10
+        a = nn.NdArray(shape)  # uninitialized
+        b = a.narrow(0, 0, 5 * s)
+        b.fill(5.0)
+        c = a.narrow(0, 5 * s, 5 * s)
+        c.fill(7.0)
+        d = c.narrow(0, 2 * s, 2 * s)
+        d.fill(9.0)
+        b += c
+
+        ref_a = np.zeros(shape, dtype=np.float32)
+        ref_b = ref_a[0:5*s]
+        ref_b.fill(5.0)
+        ref_c = ref_a[5*s:10*s]
+        ref_c.fill(7.0)
+        ref_d = ref_c[2*s:4*s]
+        ref_d.fill(9.0)
+        ref_b += ref_c
+
+        assert a.shape == ref_a.shape
+        assert b.shape == ref_b.shape
+        assert c.shape == ref_c.shape
+        assert d.shape == ref_d.shape
+
+        assert a.size == ref_a.size
+        assert b.size == ref_b.size
+        assert c.size == ref_c.size
+        assert d.size == ref_d.size
+
+        assert (a.data == ref_a).all()
+        assert (b.data == ref_b).all()
+        assert (c.data == ref_c).all()
+        assert (d.data == ref_d).all()
+
+        assert a.data.dtype == ref_a.dtype
+        assert b.data.dtype == ref_b.dtype
+        assert c.data.dtype == ref_c.dtype
+        assert d.data.dtype == ref_d.dtype
+
+        a = nn.NdArray.from_numpy_array(np.zeros(shape, dtype=np.float32))
+
+        # If created with from_numpy_array, head array's context of NdArray becomes cpu.
+        # Therefore, use identity to change context into current_context(cpu or cuda or cudnn).
+        a = F.identity(a)
+        b = a.narrow(0, 0, 5 * s)
+        b.fill(5.0)
+        c = a.narrow(0, 5 * s, 5 * s)
+        c.fill(7.0)
+        d = c.narrow(0, 2 * s, 2 * s)
+        d.fill(9.0)
+
+        b += c
+        assert (a.data == ref_a).all()
+        assert (b.data == ref_b).all()
+        assert (c.data == ref_c).all()
+        assert (d.data == ref_d).all()
+
+        a = nn.NdArray.from_numpy_array(np.zeros(shape, dtype=np.float64))
+        b = a.narrow(0, 0, 5 * s)
+        b.fill(5.0)
+        c = a.narrow(0, 5 * s, 5 * s)
+        b.fill(7.0)
+        with pytest.raises(RuntimeError):
+            # Failed `root_key == created_key || is_root()`: cast of child-arrays is not permitted
+            # (0:cpu:DOUBLE cannot convert to 0:cpu:FLOAT)
+            b += c
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow_fill(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        # child fill first
+        ref_0 = np.array([0, 0, 5, 5, 3, 3, 5, 5, 7, 7])
+        # grandchild fill first
+        ref_1 = np.array([0, 0, 5, 5, 5, 5, 5, 5, 7, 7])
+
+        x = nn.NdArray(10)
+        x.fill(0)
+        x = F.identity(x)
+
+        # parent-child relation
+        # x -- a -- b
+        #  \-- c
+        a = x.narrow(0, 2, 6)
+        b = a.narrow(0, 2, 2)
+        c = x.narrow(0, 8, 2)
+
+        a.fill(5)
+        b.fill(3)
+        c.fill(7)
+        assert (x.get_data(mode="r") == ref_0).all()
+
+        x.fill(0)
+        b.fill(3)
+        a.fill(5)
+        c.fill(7)
+        assert (x.get_data(mode="r") == ref_1).all()
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow_get_cast(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        a = nn.NdArray(2, 2)
+        a.fill(3)
+        a = F.identity(a)
+
+        b = a.narrow(0, 0, 1)
+        c = b.narrow(0, 0, 1)
+
+        assert (a.get_data(mode="r") == np.full([2, 2], 3)).all()
+        assert (b.get_data(mode="r") == np.full([1, 2], 3)).all()
+        assert (c.get_data(mode="r") == np.full([1, 2], 3)).all()
+
+        # get_data with type conversion is allowed only when read-only-mode.
+        b.get_data(mode='r', dtype=np.float16)
+        c.get_data(mode='r', dtype=np.float16)
+
+        with pytest.raises(RuntimeError):
+            b.get_data(mode='rw', dtype=np.float16)
+
+        with pytest.raises(RuntimeError):
+            c.get_data(mode='rw', dtype=np.float16)
+
+        # Check the change is reflected in parent array after cast.
+        # Only the same dtype of cast for narrow array is allowed.
+        b.cast(dtype=np.float32, ctx=nn.get_current_context())
+        b += 1
+        assert (a.get_data(mode="r") == np.array([[4, 4], [3, 3]])).all()
+
+        c.cast(dtype=np.float32, ctx=nn.get_current_context())
+        c += 1
+        assert (a.get_data(mode="r") == np.array([[5, 5], [3, 3]])).all()
+
+        with pytest.raises(RuntimeError):
+            b.cast(dtype=np.float16)
+
+        with pytest.raises(RuntimeError):
+            c.cast(dtype=np.float16)
+
+        assert a.dtype == np.float32
+        assert b.dtype == np.float32
+        assert c.dtype == np.float32
+
+        # cast for parent array is allowed.
+        a.cast(dtype=np.float16)
+        assert a.dtype == np.float16
+
+        # If parent array is cast, dtype in narrow array also changes.
+        assert b.dtype == np.float16
+        assert c.dtype == np.float16
+
+        # Value of `a` remains the same and the parent-child relationship is maintained.
+        assert (a.data == np.array([[5, 5], [3, 3]])).all()
+        b.fill(0)
+        assert (a.data == np.array([[0, 0], [3, 3]])).all()
+        assert (c.data == np.array([[0, 0]])).all()
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow_get_cache(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        a = nn.NdArray(3)
+        a = F.identity(a)
+        a.fill(1)
+
+        b = a.narrow(0, 0, 2)
+        c = b.narrow(0, 0, 1)
+
+        b.fill(2)
+        c.fill(3)
+
+        # Make head array's context in `a` become current context
+        a.cast(dtype=np.float32, ctx=nn.get_current_context())
+
+        # Create a cache of different type data
+        a.get_data(mode="r", dtype=np.float16)
+        b.get_data(mode="r", dtype=np.float16)
+        c.get_data(mode="r", dtype=np.float16)
+
+        assert (a.get_data(mode="r", dtype=np.float16)
+                == np.array([3, 2, 1])).all()
+
+        c += 1
+
+        # If the cache remains, the following test will fail.
+        assert (a.get_data(mode="r", dtype=np.float16)
+                == np.array([4, 2, 1])).all()
+        assert (b.get_data(mode="r", dtype=np.float16)
+                == np.array([4, 2])).all()
+        assert (c.get_data(mode="r", dtype=np.float16) == np.array([4])).all()
+
+        c.fill(5)
+
+        assert (a.get_data(mode="r", dtype=np.float16)
+                == np.array([5, 2, 1])).all()
+        assert (b.get_data(mode="r", dtype=np.float16)
+                == np.array([5, 2])).all()
+        assert (c.get_data(mode="r", dtype=np.float16) == np.array([5])).all()
+
+        c.zero()
+
+        assert (a.get_data(mode="r", dtype=np.float16)
+                == np.array([0, 2, 1])).all()
+        assert (b.get_data(mode="r", dtype=np.float16)
+                == np.array([0, 2])).all()
+        assert (c.get_data(mode="r", dtype=np.float16) == np.array([0])).all()
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow_copy(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        a = nn.NdArray(2, 2)
+        a.fill(3)
+        a = F.identity(a)
+        assert (a.get_data(mode="r") == np.full([2, 2], 3)).all()
+
+        b = a.narrow(0, 0, 1)
+
+        c = nn.NdArray(b.shape)
+        c.fill(5)
+
+        # Check copy_from array to narrow array
+        b.copy_from(c)
+        assert (b.get_data(mode="r") == c.data).all()
+        assert (b.get_data(mode="r") == np.full([1, 2], 5)).all()
+        assert (a.data[0:1] == b.data).all()
+
+        # Check copy_from narrow array to array
+        a = nn.NdArray(2, 2)
+        a.fill(8)
+        a = F.identity(a)
+        b = a.narrow(0, 0, 1)
+        c.copy_from(b)
+        assert (b.get_data(mode="r") == c.data).all()
+        assert (b.get_data(mode="r") == np.full([1, 2], 8)).all()
+
+        a = nn.NdArray(2, 2)
+        a.fill(3)
+        a = F.identity(a)
+        assert (a.get_data(mode="r") == np.full([2, 2], 3)).all()
+
+        b = a.narrow(0, 0, 1)
+
+        c = nn.NdArray(b.shape)
+        c.fill(5)
+
+        # Check substitution with NdArray.data
+        # Tested only when ctx_name is "cpu", since NdArray.data is implicitly use cpu context.
+        if ctx_name != "cpu":
+            with pytest.raises(RuntimeError):
+                b.data = c.data
+        else:
+            b.data = c.data
+            assert (b.get_data(mode="r") == c.data).all()
+            assert (b.get_data(mode="r") == np.full([1, 2], 5)).all()
+            assert (a.data[0:1] == b.data).all()
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow_errors(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        with pytest.raises(RuntimeError):
+            # Failed `length >= 0`: negative number for `length` (-5) is not permitted
+            a = nn.NdArray((10, 5))
+            _ = a.narrow(0, 2, -5)
+        with pytest.raises(RuntimeError):
+            # Failed `length >= 0 && start + length <= size`: start (2) + length (50) exceeds dimension size (10)
+            a = nn.NdArray((10, 5))
+            _ = a.narrow(0, 2, 50)
+        with pytest.raises(RuntimeError):
+            # Failed `dim == 0`: `dim` is out of range (expected to be 0, but got 1)
+            a = nn.NdArray((10, 5))
+            _ = a.narrow(1, 2, 5)
+        with pytest.raises(RuntimeError):
+            # Failed `start0 >= -size && start0 < size`: `start0` is out of range (expected to be [-10, 9], but got -11)
+            a = nn.NdArray((10, 5))
+            _ = a.narrow(0, -11, 5)
+
+        # Failed if overlapped area.
+        a = nn.NdArray(10)
+        b = a.narrow(0, 2, 2)
+        with pytest.raises(RuntimeError):
+            d = a.narrow(0, 0, 3)
+        with pytest.raises(RuntimeError):
+            d = a.narrow(0, 2, 2)
+        with pytest.raises(RuntimeError):
+            d = a.narrow(0, 3, 2)
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu", "cuda", "cudnn"])
+    def test_nd_array_narrow_zeroing(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        a = nn.NdArray(3)
+        assert not a.zeroing
+
+        a.zero()
+        assert a.zeroing
+        a.fill(3)
+        assert not a.zeroing
+
+        a.zero()
+        assert a.zeroing
+        a.cast(np.float16)
+        assert not a.zeroing
+
+        a.zero()
+        assert a.zeroing
+        a.get_data(mode="rw")
+        assert not a.zeroing
+
+        a.zero()
+        assert a.zeroing
+        a.get_data(mode="r")
+        assert a.zeroing
+
+        a.zero()
+        assert a.zeroing
+        a.data
+        assert not a.zeroing
+
+        a = nn.NdArray(3)
+        a.data  # make array
+        b = a.narrow(0, 0, 1)
+        assert not b.zeroing
+
+        b.zero()
+        assert b.zeroing
+        b.fill(3)
+        assert not b.zeroing
+
+        b.zero()
+        assert b.zeroing
+        b.get_data(mode="r")
+        assert b.zeroing
+
+        b.zero()
+        assert b.zeroing
+        b.data
+        assert not b.zeroing
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cpu"])
+    def test_nd_array_narrow_array_class_cpu(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        ctx = nn.get_current_context()
+
+        ctx.array_class = "CpuArray"
+        a = nn.NdArray(2, 5)
+        a.cast(np.float32, ctx=ctx)
+        # No error
+        b = a.narrow(0, 0, 1)
+
+        ctx.array_class = "CpuCachedArray"
+        a = nn.NdArray(2, 5)
+        a.cast(np.float32, ctx=ctx)
+        # No error
+        b = a.narrow(0, 0, 1)
+
+        # CpuDlpackArray
+        # Dlpack Array is created using nn.utils.dlpack.to_dlpack, but is not tested here because it is not NdArray.
+
+    @pytest.mark.parametrize("ctx_name", [
+        "cuda"])
+    def test_nd_array_narrow_array_class_cuda(self, ctx_name):
+        self.try_to_set_ctx(ctx_name)
+
+        ctx = nn.get_current_context()
+
+        ctx.array_class = "CudaArray"
+        a = nn.NdArray(2, 5)
+        a.cast(np.float32, ctx=ctx)
+        # No error
+        b = a.narrow(0, 0, 1)
+
+        ctx.array_class = "CudaCachedArray"
+        a = nn.NdArray(2, 5)
+        a.cast(np.float32, ctx=ctx)
+        # No error
+        b = a.narrow(0, 0, 1)
+
+        # CudaDlpackArray
+        # Dlpack Array is created using nn.utils.dlpack.to_dlpack, but is not tested here because it is not NdArray.
+
+        ctx.array_class = "CudaCachedUnifiedArray"
+        a = nn.NdArray(2, 5)
+        a.cast(np.float32, ctx=ctx)
+        with pytest.raises(RuntimeError):
+            b = a.narrow(0, 0, 1)
+
+        ctx.array_class = "CudaCachedHostArray"
+        a = nn.NdArray(2, 5)
+        a.cast(np.float32, ctx=ctx)
+        with pytest.raises(RuntimeError):
+            b = a.narrow(0, 0, 1)
+
+        ctx.array_class = "CudaCachedVirtualArray"
+        a = nn.NdArray(2, 5)
+        a.cast(np.float32, ctx=ctx)
+        with pytest.raises(RuntimeError):
+            b = a.narrow(0, 0, 1)

--- a/src/nbla/array/array.cpp
+++ b/src/nbla/array/array.cpp
@@ -22,8 +22,9 @@
 namespace nbla {
 
 Array::Array(const Size_t size, dtypes dtype, const Context &ctx,
-             AllocatorMemory &&mem)
-    : size_(size), dtype_(dtype), ctx_(ctx), mem_(std::move(mem)) {}
+             const AllocatorMemoryPtr mem, const Size_t offset)
+    : size_(size), dtype_(dtype), ctx_(ctx), mem_(mem), offset_(offset),
+      offset_bytes_(offset * sizeof_dtype(dtype)) {}
 
 Array::~Array() { wait_event(ctx_); }
 

--- a/src/nbla/array/cpu_array.cpp
+++ b/src/nbla/array/cpu_array.cpp
@@ -23,14 +23,13 @@
 
 namespace nbla {
 
-CpuArray::CpuArray(const Size_t size, dtypes dtype, const Context &ctx)
-    : Array::Array(size, dtype, ctx,
-                   SingletonManager::get<Cpu>()->naive_allocator()->alloc(
-                       Array::size_as_bytes(size, dtype), "")) {}
-
 CpuArray::CpuArray(const Size_t size, dtypes dtype, const Context &ctx,
-                   AllocatorMemory &&mem)
-    : Array::Array(size, dtype, ctx, std::move(mem)) {}
+                   const AllocatorMemoryPtr mem, const Size_t offset)
+    : Array::Array(size, dtype, ctx,
+                   mem ? mem
+                       : SingletonManager::get<Cpu>()->naive_allocator()->alloc(
+                             Array::size_as_bytes(size, dtype), ""),
+                   offset) {}
 
 CpuArray::~CpuArray() {}
 
@@ -50,10 +49,13 @@ NBLA_DEFINE_FUNC_FILL(CpuArray, cpu_fill, cpu);
 // CpuCachedArray implementation
 /////////////////////////////////
 CpuCachedArray::CpuCachedArray(const Size_t size, dtypes dtype,
-                               const Context &ctx)
+                               const Context &ctx, const AllocatorMemoryPtr mem,
+                               const Size_t offset)
     : CpuArray(size, dtype, ctx,
-               SingletonManager::get<Cpu>()->caching_allocator()->alloc(
-                   Array::size_as_bytes(size, dtype), "")) {}
+               mem ? mem
+                   : SingletonManager::get<Cpu>()->caching_allocator()->alloc(
+                         Array::size_as_bytes(size, dtype), ""),
+               offset) {}
 
 CpuCachedArray::~CpuCachedArray() {}
 

--- a/src/nbla/array/cpu_dlpack_array.cpp
+++ b/src/nbla/array/cpu_dlpack_array.cpp
@@ -20,8 +20,9 @@
 namespace nbla {
 
 CpuDlpackArray::CpuDlpackArray(const Size_t size, dtypes dtype,
-                               const Context &ctx)
-    : DlpackArray(size, dtype, ctx) {}
+                               const Context &ctx, const AllocatorMemoryPtr mem,
+                               const Size_t offset)
+    : DlpackArray(size, dtype, ctx, mem, offset) {}
 
 CpuDlpackArray::~CpuDlpackArray() {}
 

--- a/src/nbla/array/dlpack_array.cpp
+++ b/src/nbla/array/dlpack_array.cpp
@@ -17,8 +17,15 @@
 
 namespace nbla {
 
-DlpackArray::DlpackArray(const Size_t size, dtypes dtype, const Context &ctx)
-    : Array(size, dtype, ctx, AllocatorMemory()) {}
+DlpackArray::DlpackArray(const Size_t size, dtypes dtype, const Context &ctx,
+                         const AllocatorMemoryPtr mem, const Size_t offset)
+    : Array(size, dtype, ctx, mem ? mem : std::make_shared<AllocatorMemory>(),
+            offset) {
+  if (mem) {
+    NBLA_ERROR(error_code::runtime,
+               "Memory sharing is not allowed in this class.");
+  }
+}
 
 DlpackArray::~DlpackArray() {
   call_deleter(dlp_); // Call the given deleter to return the borrowed array.

--- a/src/nbla/array_registry.cpp
+++ b/src/nbla/array_registry.cpp
@@ -68,12 +68,12 @@ check_registry_contains_class_or_throw(const ArrayCreator::Registry_t &registry,
              array_class.c_str(), string_join(keys, ", ").c_str());
 }
 
-Array *ArrayCreator::create(const Size_t size, dtypes dtype,
-                            const Context &ctx) {
+Array *ArrayCreator::create(const Size_t size, dtypes dtype, const Context &ctx,
+                            const AllocatorMemoryPtr mem, const Size_t offset) {
   init_cpu();
   Registry_t &registry = get_registry();
   check_registry_contains_class_or_throw(registry, ctx.array_class);
-  return registry[ctx.array_class].first(size, dtype, ctx);
+  return registry[ctx.array_class].first(size, dtype, ctx, mem, offset);
 }
 
 Context ArrayCreator::filter_context(const Context &ctx) {

--- a/src/nbla/memory/allocator.cpp
+++ b/src/nbla/memory/allocator.cpp
@@ -20,7 +20,7 @@ namespace nbla {
 Allocator::Allocator() {}
 Allocator::~Allocator() {}
 
-AllocatorMemory Allocator::alloc(size_t bytes, const string &device_id) {
+AllocatorMemoryPtr Allocator::alloc(size_t bytes, const string &device_id) {
   // Ensuring at least 1 byte. Workaround while knowing that it's in efficient.
   std::lock_guard<std::mutex> lock(mutex_);
   bytes = std::max(bytes, (size_t)1);
@@ -31,7 +31,7 @@ AllocatorMemory Allocator::alloc(size_t bytes, const string &device_id) {
     callback_->on_alloc(mem->bytes(), mem->device_id());
   }
   // NOTE: Allocator is always instantiated as a shared_ptr.
-  return AllocatorMemory(mem, this->shared_from_this());
+  return make_shared<AllocatorMemory>(mem, this->shared_from_this());
 }
 void Allocator::free(shared_ptr<Memory> memory) {
   std::lock_guard<std::mutex> lock(mutex_);


### PR DESCRIPTION
This PR introduces `NdArray.narrow`.
`NdArray.narrow` returns a sub-array that is a narrowed version of a base array.
For more details, see the example below.

```python
x = nn.NdArray([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])

x1 = x.narrow(dim=0, start=0, length=4)
# x1 == nn.NdArray([0, 1, 2, 3])

x2 = x.narrow(0, 6, 4)
# x2 == nn.NdArray([6, 7, 8, 9])
```

ext-cuda: https://github.com/sony/nnabla-ext-cuda/pull/420