### PR TITLE
add comment on the use of SingletonManager::clear()

### DIFF
--- a/examples/cpp/cpp_graph/main.cpp
+++ b/examples/cpp/cpp_graph/main.cpp
@@ -119,6 +119,7 @@ int main() {
     printf("%f\n", data_h[i]);
   }
 
+  // This can only be called at the final point of nnabla session.
   SingletonManager::clear();
   return 0;
 }

--- a/examples/cpp/mnist_runtime/mnist_runtime.cpp
+++ b/examples/cpp/mnist_runtime/mnist_runtime.cpp
@@ -176,6 +176,7 @@ int main(int argc, char *argv[]) {
   std::cout << std::endl;
   std::cout << "Prediction: " << prediction << std::endl;
 
+  // This can only be called at the final point of nnabla session.
   nbla::SingletonManager::clear();
   return 0;
 }


### PR DESCRIPTION
cpp example has `SingletonManager:clear()`, but when performing inference sequentially, this causes an error.
`SingletonManager::clear()` should call only one when graph is discard.