### PR TITLE
Fix issues in ONNX importer

### DIFF
--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -642,7 +642,7 @@ class OnnxImporter:
         # opset_11 table
         self.table_op_set_11 = {
             "Clip": partial(self.Clip, 11),
-            "Round": partial(self.GeneralOperator, 'Round'),
+            "Round": self.Round,
             "Pad": partial(self.Pad, '11'),
         }
         self.table_op_set_11 = dict(
@@ -3777,6 +3777,11 @@ class OnnxImporter:
         func_list.append(gf)
         # dynamic output shape
         self._shape_output[n.output[0]] = input_shape
+
+    def Round(self, func_list, n):
+        logger.warning("nnabla Round is not compatible to ONNX Round, " +
+                       "which performs rounding to nearest-even integer.")
+        return self.GeneralOperator('Round', func_list, n)
 
     def convert_to_functions(self, n):
         ft = self._onnx_optype_to_nnabla_function_type.get(n.op_type)

--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -533,7 +533,7 @@ class OnnxImporter:
             "Reciprocal": partial(self.ElementWiseScalar, 'RDivScalar'),
             "Neg": partial(self.ElementWiseScalar, 'MulScalar'),
             "LogSoftmax": self.LogSoftmax,
-            "Softplus": partial(self.GeneralOperator, 'SoftPlus'),
+            "Softplus": self.Softplus,
             "Softsign": partial(self.GeneralOperator, 'SoftSign'),
             "LRN": self.LRN,
             "Clip": partial(self.Clip, 6),
@@ -2060,6 +2060,14 @@ class OnnxImporter:
                             self._graph.name, self._func_counter)
         self._shape_output[n.output[0]] = input_shape
         func_list.append(ge)
+
+        
+    def Softplus(self, func_list, n):
+        func = self.generate_default_function("SoftPlus", n)
+        func.softplus_param.beta = 1.0
+        self._shape_output[func.output[0]] = self.get_func_input_shape(func.input[0])
+        func_list.append(func)
+        
 
     def Clip(self, opset, func_list, n):
         func = self.generate_default_function("Clip", n)

--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -21,7 +21,8 @@ import numpy as np
 from nnabla.utils import nnabla_pb2
 
 try:
-    from onnx import (ModelProto, TensorProto, AttributeProto, TensorShapeProto)
+    from onnx import (ModelProto, TensorProto,
+                      AttributeProto, TensorShapeProto)
 except:
     print('ONNX import support disabled because onnx python package is not found.')
     print(' You may install onnx package with "pip install onnx".')
@@ -2088,13 +2089,12 @@ class OnnxImporter:
         self._shape_output[n.output[0]] = input_shape
         func_list.append(ge)
 
-        
     def Softplus(self, func_list, n):
         func = self.generate_default_function("SoftPlus", n)
         func.softplus_param.beta = 1.0
-        self._shape_output[func.output[0]] = self.get_func_input_shape(func.input[0])
+        self._shape_output[func.output[0]
+                           ] = self.get_func_input_shape(func.input[0])
         func_list.append(func)
-        
 
     def Clip(self, opset, func_list, n):
         func = self.generate_default_function("Clip", n)
@@ -2857,7 +2857,7 @@ class OnnxImporter:
                     o = (i - 1) * s + adj + (k - 1) * d + 1\
                         - pads[index] - pads[index+dim]
                 output_shape.append(o)
-                
+
         cp.output_padding.dim.extend(output_padding)
 
         padval = []
@@ -2877,7 +2877,7 @@ class OnnxImporter:
             # Add a separate Slice Function for asymmetry padding
             start = [0, 0] + [pads[i] for i in range(dim)]
             stop = input_shape[:1] + [weight_shape[1]] + \
-                   [output_shape[i] + pads[i] for i in range(dim)]
+                [output_shape[i] + pads[i] for i in range(dim)]
             step = [1, ] * (dim + 2)
             slicef = generate_slice(n.name, deconv_out, n.output[0],
                                     start, stop, step,


### PR DESCRIPTION
This PR fixes the following issues in ONNX importer.

* Binary operators (Add, Mul, Pow, etc.)
    * nnabla runtime causes an error `Failed ndim == inputs[1]->ndim(): Dimensions of inputs must match. inputs[0]: 1 != inputs[1]: 0.` when broadcasting an input variable whose shape is scalar `()` (e.g. `Pow(x : (3,), y : ())`).
        * This is because input variables in a binary operator must have the same number of dimensions, 
          and the ONNX importer does not convert shape `()` to `(1,)` in `add_value_info_as_variable()`.
    * This issue can be reproduced with `test_pow_bcast_scalar_cpu` in onnx.backend.test.
* Softplus
    * nnabla Softplus converted from ONNX Softplus always returns `inf`.
        * ONNX importer does not properly set `beta` parameter. `beta` must be 1.0 but the default value is 0.0.
* Conv
    * The output shape is incorrect when `auto_pad` is `SAME_UPPER` or `SAME_LOWER` because of incorrect calculation of padding value:
        1. `dilations` parameter is ignored.
        2. The calculation of `pads_value` is obviously incorrect when `auto_pad` is `SAME_UPPER`:
           `pads[i + dims] = pads_value[i] - pads[i + dims]` must be `pads[i + dims] = pads_value[i] - pads[i]`.
    * This issue can be reproduced with `test_conv_with_autopad_same_cpu` in onnx.backend.test.
* ConvTranspose
    * The output shape is incorrect when `output_shape` is not specified and `auto_pad` is `SAME_UPPER` or `SAME_LOWER`:
        1. `auto_pad` is not considered in the current implementation.
        2. The padding implementation is incorrect when input padding (attribute `pads`) is asymmetric.
           In this case, the current implementation inserts padding to the output variable, but
           attribute `pads` in ConvTranspose means not "padding" but "slice" for output variable.
    * This issue can be reproduced with `test_convtranspose_autopad_same_cpu` in onnx.backend.test.
* MaxPooling, AveragePooing
    * The output shape is incorrect when `ceil_mode` is 1.
        * Add error handling for this case.
    * Attribute `dilations` is not supported.
        * Support conversion when dilations is 1.
* Round
    * ONNX Round requires rounding half to "nearest-even" integers, but nnabla Round does not support it.
        * Add warning when converting ONNX Round.