### PR TITLE
add code to allow unlink variable

### DIFF
--- a/python/src/nnabla/utils/nnp_graph.py
+++ b/python/src/nnabla/utils/nnp_graph.py
@@ -46,7 +46,8 @@ class NnpNetwork(object):
         self.proto_network(batch_size=batch_size)
         for k, v in itertools.chain(
                 self.proto_network.variables.items(), self.proto_network.parameters.items()):
-            v.variable_instance.name = k
+            if v.variable_instance is not None:
+                v.variable_instance.name = k
         self._inputs = {
             i: self.proto_network.variables[i].variable_instance
             for i in self.proto_network.inputs


### PR DESCRIPTION
This PR tends to allow isloted and unlinked variable, which is a kind of ill-formed network, but we should allow it and quietly ommit it.


Here is the example of issue:
```text
$ python load_resnet.py
2022-08-23 10:58:38,806 [nnabla][INFO]: Initializing CPU extension...
['Training', 'Validation', 'Runtime', 'Validation5']
Traceback (most recent call last):
  File "load_resnet.py", line 7, in <module>
    net = nnp.get_network('Runtime', batch_size=1)
  File "nnabla/utils/nnp_graph.py", line 133, in get_network
    return NnpNetwork(self.network_dict[name], batch_size, callback=callback)
  File "nnabla/utils/nnp_graph.py", line 49, in __init__
    v.variable_instance.name = k
AttributeError: 'NoneType' object has no attribute 'name'

Process finished with exit code 1
```

The test code is as this:

```python
from nnabla.utils.nnp_graph import NnpLoader
from nnabla.utils.inspection import pprint
import nnabla.functions as F

nnp = NnpLoader('Resnet-50.nnp')
print(nnp.get_network_names())
net = nnp.get_network('Runtime', batch_size=1)
outputs = [v for v in net.outputs.values()]
pprint(outputs[0])
```
