### PR TITLE
Fix a bug in OnnxImporter.get_func_input_shape

### DIFF
--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -753,7 +753,7 @@ class OnnxImporter:
             for i in self._graph.initializer:
                 if i.name == input_name:
                     input_shape = normalize_shape(i.dims)
-                    return input_shape
+                    return list(input_shape)
         if not input_shape:
             raise ValueError(
                 "The shape of {} was not found".format(input_name))


### PR DESCRIPTION
This PR fixes a bug where `OnnxImporter.get_func_input_shape` does not return a list value when a specified variable is defined as an initializer.

## How to Reproduce

For example, `nnabla_cli` fails to convert MobileNet v2 in ONNX Model Zoo to a NNP file:

```
$ wget -O mobilenet_v2_orig.onnx https://github.com/onnx/models/blob/main/vision/classification/mobilenet/model/mobilenetv2-7.onnx?raw=true
(snip)

$ onnxsim --input-shape input:1,3,224,244 -- mobilenet_v2_orig.onnx mobilenet_v2_simplified.onnx
Simplifying...
(snip)

$ nnabla_cli convert mobilenet_v2_simplified.onnx mobilenet_v2.nnp
2022-09-20 16:27:48,669 [nnabla][INFO]: Initializing CPU extension...
NNabla command line interface (Version:1.31.0.dev1, Build:220920060321)
(snip)
Traceback (most recent call last):
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/cli/cli.py", line 147, in cli_main
    return_value = args.func(args)
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/cli/convert.py", line 111, in convert_command
    nnabla.utils.converter.convert_files(args, args.files, output)
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/commands.py", line 255, in convert_files
    nnp = _import_file(args, ifiles)
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/commands.py", line 41, in _import_file
    return OnnxImporter(*ifiles).execute()
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/onnx/importer.py", line 4130, in execute
    return self.onnx_model_to_nnp_protobuf()
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/onnx/importer.py", line 4114, in onnx_model_to_nnp_protobuf
    self.onnx_graph_to_nnp_protobuf(pb)
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/onnx/importer.py", line 3985, in onnx_graph_to_nnp_protobuf
    fl = self.convert_to_functions(n)
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/onnx/importer.py", line 3975, in convert_to_functions
    ft(func_list, n)
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/onnx/importer.py", line 1523, in Gemm
    expand_bm = self.generate_expand_batchmatmul(
  File "/home/i/local/nnabla-dev/lib/python3.8/site-packages/nnabla/utils/converter/onnx/importer.py", line 879, in generate_expand_batchmatmul
    [1] + transB_shape, self._graph.name, self._func_counter)
TypeError: can only concatenate list (not "google.protobuf.pyext._message.RepeatedScalarContainer") to list
```

In this example, OnnxImporter.get_func_input_shape returns a value of `google.protobuf.pyext._message.RepeatedScalarContainer`, which does not support list concatenation.

## How to Fix

This PR inserts a type conversion from `google.protobuf.pyext._message.RepeatedScalarContainer` to `list` in
`OnnxImporter.get_func_input_shape`.

After this fix, `nnabla_cli` can successfully convert the ONNX file:

```
$ nnabla_cli convert mobilenet_v2_simpified.onnx mobilenet_v2.nnp
2022-09-20 16:46:52,537 [nnabla][INFO]: Initializing CPU extension...
NNabla command line interface (Version:1.31.0.dev1, Build:220920060321)
(snip)
2022-09-20 16:46:56,403 [nnabla][INFO]: Converting: mobilenet_v2.nnp successfully!
```