### PR TITLE
fix numpy indice error due to numpy version update

### DIFF
--- a/python/test/function/refs.py
+++ b/python/test/function/refs.py
@@ -113,8 +113,9 @@ def convolution_nd(x, w, b, pad, stride, dilation, group, dtype=np.float32):
     outshape = get_conv_out_size_recursive(0, ndim)
     inshape_pad = [C] + [inshape[d] + 2 * pad[d] for d in range(ndim)]
     x_pad = np.zeros(inshape_pad, dtype=dtype)
-    x_pad[[slice(None,)] + [slice(pad[d], pad[d] + inshape[d])
-                            for d in range(ndim)]] = x
+    s = [slice(None,)] + [slice(pad[d], pad[d] + inshape[d])
+                          for d in range(ndim)]
+    x_pad[tuple(s)] = x
     y = np.zeros([K] + outshape, dtype=dtype)
     for k in range(K):
         g = int(k // (K // group))
@@ -125,7 +126,7 @@ def convolution_nd(x, w, b, pad, stride, dilation, group, dtype=np.float32):
             y[(k,) + tuple(outindex)] = (w[k] *
                                          x_pad[np.ix_(ci, *inindex)]).sum()
     if b is not None:
-        y += b[[Ellipsis] + [np.newaxis for d in range(ndim)]]
+        y += b[tuple([Ellipsis] + [np.newaxis for d in range(ndim)])]
     return y
 
 

--- a/python/test/function/test_scatter_nd.py
+++ b/python/test/function/test_scatter_nd.py
@@ -23,7 +23,7 @@ ctxs = list_context('ScatterNd')
 def scatter_nd(data, indices, shape):
     indices = indices.tolist() if isinstance(indices, np.ndarray) else indices
     result = np.zeros(shape, dtype=data.dtype)
-    result[indices] = data
+    result[tuple(indices)] = data
     return result
 
 

--- a/python/test/function/test_slice.py
+++ b/python/test/function/test_slice.py
@@ -26,7 +26,7 @@ ctxs = list_context('Slice')
 def ref_slice(x, start, stop, step):
     s = [slice(start[axis], stop[axis], step[axis])
          for axis in range(len(start))]
-    return x[s]
+    return x[tuple(s)]
 
 
 @pytest.mark.parametrize("ctx, fname", ctxs)


### PR DESCRIPTION
The latest numpy 1.23.0 does not support to use a list as an index.
This PR overcome this issue by not using list.