### PR TITLE
add tensorboard version dependency of file format converter

### DIFF
--- a/python/src/nnabla/utils/converter/setup.py
+++ b/python/src/nnabla/utils/converter/setup.py
@@ -37,6 +37,7 @@ if __name__ == '__main__':
 
     install_requires = [
         'ply',
+        'tensorboard>=2.6.0, <=2.9.0'
         'tensorflow>=2.7.0, <=2.7.2',
         'onnx_tf',
         'tf2onnx==1.7.2',


### PR DESCRIPTION
This PR tends to resolve the version dependency problem.

* nnabla requires protobuf (<=3.19.4) for non Windows, and (<=3.20.1) for Windows
* tensorflow requires tensorboard, and tensorboard requires protobuf

Current tensorflow version limitation is >=2.7.0, <=2.7.2, which has tensorboard version limitation ~=2.6 itself. The default tensorboard to be installed is the latest 2.10.0. In this version, it limits protobuf to be >= 3.9.2, < 3.20, which will be incompatible with nnabla.
tensorboard 2.9.0 limits protobuf to be >=3.9.2, so it will be compatible with nnabla.