### PR TITLE
Add TopK support to ONNX importer

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -292,3 +292,5 @@
   Shape_ii: 348
 42:
   Erf_Empty: 349
+43:
+  TopKData_iBBiBB: 350

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -5551,11 +5551,22 @@ Stochasticity:
         doc: First dimension of the sample shape.
         type: int64
         default: '1'
+      largest:
+        doc: Whether to select the `k` largest or smallest values.
+        type: bool
+        default: 'True'
+      with_index:
+        doc: Return top-k values and indices.
+        type: bool
+        default: 'False'
     outputs:
       y:
         doc: N-D array.
+      indices:
+        doc: N-D array of top-k indices.
     function_ids:
       iBBi: 87
+      iBBiBB: 350
     c_runtime: not support
   TopKGrad:
     snake_name: top_k_grad

--- a/include/nbla/utils/top_k.hpp
+++ b/include/nbla/utils/top_k.hpp
@@ -28,12 +28,15 @@ namespace nbla {
  * are the indices of subsequently smaller or equal elements in x.
  */
 
-template <typename T>
+template <typename T, bool largest>
 inline void top_k(const T *x, const size_t n, const size_t k, size_t *out) {
+  using greater =
+      typename std::conditional<largest, std::greater<T>, std::less<T>>::type;
+
   struct cmp {
     bool operator()(const std::pair<T, size_t> &a,
                     const std::pair<T, size_t> &b) {
-      return a.first > b.first;
+      return greater()(a.first, b.first);
     }
   };
 
@@ -46,7 +49,7 @@ inline void top_k(const T *x, const size_t n, const size_t k, size_t *out) {
 
   for (size_t i = k; i < n; ++i) {
     const auto x_at_i = x[i];
-    if (x_at_i > heap[0].first) {
+    if (greater()(x_at_i, heap[0].first)) {
       std::pop_heap(heap.begin(), heap.end(), cmp());
       heap[heap.size() - 1] = std::make_pair(x_at_i, i);
       std::push_heap(heap.begin(), heap.end(), cmp());
@@ -63,12 +66,15 @@ inline void top_k(const T *x, const size_t n, const size_t k, size_t *out) {
  * it considers the absolute values of elements in x.
  */
 
-template <typename T>
+template <typename T, bool largest>
 inline void top_k_abs(const T *x, const size_t n, const size_t k, size_t *out) {
+  using greater =
+      typename std::conditional<largest, std::greater<T>, std::less<T>>::type;
+
   struct cmp {
     bool operator()(const std::pair<T, size_t> &a,
                     const std::pair<T, size_t> &b) {
-      return a.first > b.first;
+      return greater()(a.first, b.first);
     }
   };
 
@@ -81,7 +87,7 @@ inline void top_k_abs(const T *x, const size_t n, const size_t k, size_t *out) {
 
   for (size_t i = k; i < n; ++i) {
     const auto x_at_i = x[i] < 0 ? -x[i] : x[i];
-    if (x_at_i > heap[0].first) {
+    if (greater()(x_at_i, heap[0].first)) {
       std::pop_heap(heap.begin(), heap.end(), cmp());
       heap[heap.size() - 1] = std::make_pair(x_at_i, i);
       std::push_heap(heap.begin(), heap.end(), cmp());

--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -400,6 +400,7 @@ def unsupported_attribute(attr_name, n):
     raise ValueError("Unsupported attribute {} was specified at {}"
                      .format(attr_name, n.op_type))
 
+
 def check_attr_int_type(attr, node):
     if attr.type != AttributeProto.INT:
         raise ValueError(
@@ -4043,11 +4044,11 @@ class OnnxImporter:
             trans_axes = list(range(len(last_shape)))
             trans_axes[axis], trans_axes[-1] = trans_axes[-1], trans_axes[axis]
             trans_func0 = generate_transpose(n.name, topk_out0, out0,
-                                            trans_axes, self._graph.name,
-                                            self._func_counter)
+                                             trans_axes, self._graph.name,
+                                             self._func_counter)
             trans_func1 = generate_transpose(n.name, topk_out1, out1,
-                                            trans_axes, self._graph.name,
-                                            self._func_counter)
+                                             trans_axes, self._graph.name,
+                                             self._func_counter)
             last_shape[axis], last_shape[-1] = last_shape[-1], last_shape[axis]
             self._shape_output[out0] = last_shape
             self._shape_output[out1] = last_shape

--- a/python/test/function/test_top_k_data.py
+++ b/python/test/function/test_top_k_data.py
@@ -20,14 +20,18 @@ from nbla_test_utils import list_context, function_tester
 ctxs = list_context('TopKData')
 
 
-def ref_top_k_data(x, k, abs, reduce, base_axis, grad=None):
+def ref_top_k_data(x, k, abs, reduce, base_axis, largest, with_index,
+                   grad=None):
     ns = np.prod(x.shape[:base_axis], dtype=int)  # number of samples
     ss = np.prod(x.shape[base_axis:], dtype=int)  # sample size
     xd = x.reshape(ns, ss).copy()
-    ix = np.fliplr(np.argsort(np.abs(xd) if abs else xd)[:, -k:])
+    sign = -1.0 if largest else 1.0
+    ix = np.argsort(sign * (np.abs(xd) if abs else xd))[:, :k]
     yd = np.zeros((ns, k if reduce else ss))
+    indices = np.full(yd.shape, -1)
     for idx, row in enumerate(ix):
         yd[idx, slice(None) if reduce else row] = xd[idx, row]
+        indices[idx, slice(None) if reduce else row] = row
     if grad is not None and reduce is True:
         gg = grad.reshape(yd.shape).copy()
         xg = np.zeros(xd.shape)
@@ -37,33 +41,59 @@ def ref_top_k_data(x, k, abs, reduce, base_axis, grad=None):
     else:
         xg = grad
     yd = yd.squeeze(axis=0) if base_axis == 0 else yd
-    return (yd.reshape(x.shape[:base_axis] + (k,) if reduce else x.shape), xg)
+    yd = yd.reshape(x.shape[:base_axis] + (k,) if reduce else x.shape)
+    indices = indices.reshape(yd.shape)
+    if with_index:
+        return ((yd, indices), xg)
+    else:
+        return (yd, xg)
 
 
-def ref_top_k_data_fw(x, k, abs, reduce, base_axis):
-    return ref_top_k_data(x, k, abs, reduce, base_axis)[0]
+def ref_top_k_data_fw(x, k, abs, reduce, base_axis, largest, with_index):
+    return ref_top_k_data(x, k, abs, reduce, base_axis, largest, with_index)[0]
 
 
-def ref_top_k_data_bw(x, g, k, abs, reduce, base_axis, **kw):
-    return ref_top_k_data(x, k, abs, reduce, base_axis, g)[1].flatten()
+def ref_top_k_data_bw(x, g, k, abs, reduce, base_axis, largest, with_index,
+                      **kw):
+    assert not with_index
+    return ref_top_k_data(
+        x, k, abs, reduce, base_axis, largest, with_index, g)[1].flatten()
 
+# reference function takes two grads of outputs when with_index = True
+def ref_top_k_data_bw_with_index(x, gx, gi, k, abs, reduce, base_axis,
+                                 largest, with_index, **kw):
+    assert with_index
+    return ref_top_k_data(
+        x, k, abs, reduce, base_axis, largest, with_index, gx)[1].flatten()
 
 @pytest.mark.parametrize("ctx, fname", ctxs)
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("abs", [False, True])
-@pytest.mark.parametrize("reduce", [True, False])
+@pytest.mark.parametrize("largest", [False, True])
+@pytest.mark.parametrize("reduce, with_index", [
+    (False, False), (True, False), (True, True)
+])
 @pytest.mark.parametrize("ishape, k, base_axis", [
     ((4, 5, 6), 1, 0), ((4, 5, 6), 1, 1), ((4, 5, 6), 1, 2), ((4, 5, 6), 1, -2),
     ((4, 5, 6), 5, 0), ((4, 5, 6), 5, 1), ((4, 5, 6), 5, 2), ((4, 5, 6), 5, -1),
     ((1, 1000), 10, 1), ((1, 100000), 1024, 1), ((
         1, 100000), 1025, 1), ((1, 100000), 1025, -2)
 ])
-def test_forward_backward(seed, ishape, k, abs, reduce, base_axis, ctx, fname):
+def test_forward_backward(seed, ishape, k, abs, reduce, base_axis, largest,
+                          with_index, ctx, fname):
+    # Use unique random numbers because sorting algorithm for top-k 
+    # is not stable.
     rng = np.random.RandomState(seed)
-    inputs = [rng.randn(*ishape).astype(np.float32)]
-    function_tester(rng, F.top_k_data, ref_top_k_data_fw, inputs, ctx=ctx,
-                    func_name=fname, ref_grad=ref_top_k_data_bw,
-                    func_args=[k, abs, reduce, base_axis],
+    n = np.prod(ishape)
+    x = np.arange(n)
+    x[np.arange(n, step=2)] *= -1  # Negate even number
+    rng.shuffle(x)
+    x = x.reshape(ishape).astype(np.float32)
+
+    ref_grad = ref_top_k_data_bw_with_index if with_index else ref_top_k_data_bw
+    function_tester(rng, F.top_k_data, ref_top_k_data_fw, [x], ctx=ctx,
+                    func_name=fname, ref_grad=ref_grad,
+                    func_args=[k, abs, reduce, base_axis, largest, with_index],
                     disable_half_test=k > 10)
 
     # Note: FP16 has too many duplicate value for larger K to get the

--- a/python/test/function/test_top_k_data.py
+++ b/python/test/function/test_top_k_data.py
@@ -60,11 +60,14 @@ def ref_top_k_data_bw(x, g, k, abs, reduce, base_axis, largest, with_index,
         x, k, abs, reduce, base_axis, largest, with_index, g)[1].flatten()
 
 # reference function takes two grads of outputs when with_index = True
+
+
 def ref_top_k_data_bw_with_index(x, gx, gi, k, abs, reduce, base_axis,
                                  largest, with_index, **kw):
     assert with_index
     return ref_top_k_data(
         x, k, abs, reduce, base_axis, largest, with_index, gx)[1].flatten()
+
 
 @pytest.mark.parametrize("ctx, fname", ctxs)
 @pytest.mark.parametrize("seed", [313])
@@ -81,7 +84,7 @@ def ref_top_k_data_bw_with_index(x, gx, gi, k, abs, reduce, base_axis,
 ])
 def test_forward_backward(seed, ishape, k, abs, reduce, base_axis, largest,
                           with_index, ctx, fname):
-    # Use unique random numbers because sorting algorithm for top-k 
+    # Use unique random numbers because sorting algorithm for top-k
     # is not stable.
     rng = np.random.RandomState(seed)
     n = np.prod(ishape)

--- a/src/nbla/function/generic/top_k_data.cpp
+++ b/src/nbla/function/generic/top_k_data.cpp
@@ -21,7 +21,7 @@
 
 namespace nbla {
 
-NBLA_REGISTER_FUNCTION_SOURCE(TopKData, int, bool, bool, int);
+NBLA_REGISTER_FUNCTION_SOURCE(TopKData, int, bool, bool, int, bool, bool);
 
 template <typename T>
 void TopKData<T>::setup_impl(const Variables &inputs,
@@ -42,20 +42,29 @@ void TopKData<T>::setup_impl(const Variables &inputs,
              "k must not exceed the sample size, but k %d > sample size %d", k,
              x->size(base_axis));
 
-  if (!reduce_) {
-    y->reshape(x_shape, true);
-  } else {
-    Shape_t y_shape;
+  Shape_t y_shape = x_shape;
+  if (reduce_) {
+    y_shape = {};
     y_shape.reserve(base_axis + 1);
     std::copy_n(x_shape.begin(), base_axis, std::back_inserter(y_shape));
     y_shape.push_back(k);
-    y->reshape(y_shape, true);
   }
+  y->reshape(y_shape, true);
 
   ss_ = x->size(base_axis); // input sample size
   ns_ = x->size() / ss_;    // number of samples
   fs_ = y->size(base_axis); // output feature size
-  top_k_idx_.reshape(Shape_t{ns_, k}, true);
+
+  if (with_index_) {
+    NBLA_CHECK(outputs.size() >= 2, error_code::value,
+               "The number of outputs must be 2 when with_index = true");
+    NBLA_CHECK(reduce_, error_code::value,
+               "reduce must be true when with_index = true");
+    outputs[1]->reshape(y_shape, true);
+  } else {
+    top_k_idx_.reshape(Shape_t{ns_, k}, true);
+  }
+
   forward_done_ = false;
 }
 
@@ -70,10 +79,16 @@ void TopKData<T>::forward_impl(const Variables &inputs,
 
   auto x_data = x->get_data_pointer<T>(this->ctx_);
   auto y_data = y->cast_data_and_get_pointer<T>(this->ctx_);
-  auto tk_idx = top_k_idx_.cast_data_and_get_pointer<size_t>(this->ctx_);
+  auto top_k_idx = with_index_ ? outputs[1] : &top_k_idx_;
+  auto tk_idx = top_k_idx->cast_data_and_get_pointer<size_t>(this->ctx_);
 
-  function<void(const T *, const size_t, const size_t, size_t *)> top_k_func =
-      this->abs_ ? top_k_abs<T> : top_k<T>;
+  function<void(const T *, const size_t, const size_t, size_t *)> top_k_func;
+
+  if (this->abs_) {
+    top_k_func = this->largest_ ? top_k_abs<T, true> : top_k_abs<T, false>;
+  } else {
+    top_k_func = this->largest_ ? top_k<T, true> : top_k<T, false>;
+  }
 
   for (int s = 0; s < this->ns_; s++) {
     top_k_func(x_data, this->ss_, this->k_, tk_idx);
@@ -108,7 +123,8 @@ void TopKData<T>::backward_impl(const Variables &inputs,
 
   auto y_grad = y->get_grad_pointer<T>(ctx_);
   auto x_grad = x->cast_grad_and_get_pointer<T>(this->ctx_);
-  auto tk_idx = top_k_idx_.get_data_pointer<size_t>(ctx_);
+  auto top_k_idx = with_index_ ? outputs[1] : &top_k_idx_;
+  auto tk_idx = top_k_idx->get_data_pointer<size_t>(this->ctx_);
 
   if (!reduce_) {
     for (Size_t i = 0; i < x->size(); i++) {

--- a/src/nbla/function/generic/top_k_data.cpp
+++ b/src/nbla/function/generic/top_k_data.cpp
@@ -80,7 +80,8 @@ void TopKData<T>::forward_impl(const Variables &inputs,
   auto x_data = x->get_data_pointer<T>(this->ctx_);
   auto y_data = y->cast_data_and_get_pointer<T>(this->ctx_);
   auto top_k_idx = with_index_ ? outputs[1] : &top_k_idx_;
-  auto tk_idx = top_k_idx->cast_data_and_get_pointer<size_t>(this->ctx_);
+  auto tk_idx =
+      top_k_idx->template cast_data_and_get_pointer<size_t>(this->ctx_);
 
   function<void(const T *, const size_t, const size_t, size_t *)> top_k_func;
 
@@ -124,7 +125,7 @@ void TopKData<T>::backward_impl(const Variables &inputs,
   auto y_grad = y->get_grad_pointer<T>(ctx_);
   auto x_grad = x->cast_grad_and_get_pointer<T>(this->ctx_);
   auto top_k_idx = with_index_ ? outputs[1] : &top_k_idx_;
-  auto tk_idx = top_k_idx->get_data_pointer<size_t>(this->ctx_);
+  auto tk_idx = top_k_idx->template get_data_pointer<size_t>(this->ctx_);
 
   if (!reduce_) {
     for (Size_t i = 0; i < x->size(); i++) {

--- a/src/nbla/function/generic/top_k_grad.cpp
+++ b/src/nbla/function/generic/top_k_grad.cpp
@@ -78,7 +78,7 @@ void TopKGrad<T>::backward_impl(const Variables &inputs,
   auto tk_idx = top_k_idx_.cast_data_and_get_pointer<size_t>(this->ctx_);
 
   function<void(const T *, const size_t, const size_t, size_t *)> top_k_func =
-      this->abs_ ? top_k_abs<T> : top_k<T>;
+      this->abs_ ? top_k_abs<T, true> : top_k<T, true>;
 
   auto inner_size = y->size(this->base_axis_);
   auto outer_size = y->size() / inner_size;


### PR DESCRIPTION

This PR adds TopK operator support to ONNX importer.

### Implementation Overview

Convert ONNX `Y, Indices = TopK(X, K, axis, largest, sorted)` to the following nnabla representation:

```
need_transpose = (axis != -1 and axis != len(x_shape) - 1)
if need_transpose:
    x = F.transpose(x, axes=[...])
y, indices = F.top_k_data(x, k, abs=False, reduce=True, base_axis=len(x_shape)-1, largest, with_index=True)
if need_transpose:
    y = F.transpose(y, axes=[...])
    indices = F.transpose(indices, axes=[...])
```

This PR also adds `with_index` and `largest` option to nnabla TopKData to support ONNX `Indices` and `largest` option.

### Limitation

* The input variable `K` of ONNX TopK must be constant or initializer variable in the current implementation.