### PR TITLE
correct index error in generate_cache_dir().

### DIFF
--- a/python/test/utils/conftest.py
+++ b/python/test/utils/conftest.py
@@ -108,11 +108,11 @@ def generate_cache_dir(num_of_data):
                                   "cache_{}_{}.npy".format(
                                       str(i).zfill(8), str(i + cache_block_size - 1).zfill(8)))
             with open(npy_fn, 'wb') as f:
-                numpy.save(f, data_x[i: i + cache_block_size - 1])
-                numpy.save(f, data_y[i: i + cache_block_size - 1])
+                numpy.save(f, data_x[i: i + cache_block_size])
+                numpy.save(f, data_y[i: i + cache_block_size])
 
             cache_info.append(
-                (npy_fn, len(data_y[i: i + cache_block_size - 1])))
+                (npy_fn, len(data_y[i: i + cache_block_size])))
 
         # generate cache_index.csv
         with open(os.path.join(imgdir, 'cache_index.csv'), 'w') as f:

--- a/python/test/utils/test_sliced_data_iterator.py
+++ b/python/test/utils/test_sliced_data_iterator.py
@@ -166,4 +166,4 @@ def test_sliced_data_iterator_race_condition(num_of_slices, size, batch_size, sh
 
         for i in range(size + 5):
             d = sliced_it.next()
-        iterator.close()
+        sliced_it.close()


### PR DESCRIPTION
On python test, there is sometimes crash happen when data_iterator test.

> 'gw3' crashed while running 'test/utils/test_sliced_data_iterator.py::test_sliced_data_iterator_race_condition[True-20-197-2]'

This PR correct this issue.