### PR TITLE
Faster LayerNormCuda::setup_impl (GN and IN as well) by removing unnecessary function creation

### DIFF
--- a/include/nbla/function/group_normalization.hpp
+++ b/include/nbla/function/group_normalization.hpp
@@ -82,6 +82,10 @@ public:
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
                                    const Variables &outputs);
+  NBLA_API virtual void setup_shapes(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void setup_functions(const Variables &inputs,
+                                        const Variables &outputs);
   NBLA_API virtual void forward_impl(const Variables &inputs,
                                      const Variables &outputs);
   NBLA_API virtual void backward_impl(const Variables &inputs,

--- a/include/nbla/function/instance_normalization.hpp
+++ b/include/nbla/function/instance_normalization.hpp
@@ -78,6 +78,10 @@ public:
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
                                    const Variables &outputs);
+  NBLA_API virtual void setup_shapes(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void setup_functions(const Variables &inputs,
+                                        const Variables &outputs);
   NBLA_API virtual void forward_impl(const Variables &inputs,
                                      const Variables &outputs);
   NBLA_API virtual void backward_impl(const Variables &inputs,

--- a/include/nbla/function/layer_normalization.hpp
+++ b/include/nbla/function/layer_normalization.hpp
@@ -79,6 +79,10 @@ public:
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
                                    const Variables &outputs);
+  NBLA_API virtual void setup_shapes(const Variables &inputs,
+                                     const Variables &outputs);
+  NBLA_API virtual void setup_functions(const Variables &inputs,
+                                        const Variables &outputs);
   NBLA_API virtual void forward_impl(const Variables &inputs,
                                      const Variables &outputs);
   NBLA_API virtual void backward_impl(const Variables &inputs,


### PR DESCRIPTION
Resolve performance issue of LayerNormCuda::setup_impl by skipping unnecessary function (TensorNorm) creation and setup. Also, same optimization is made for GN and IN.
