### PR TITLE
Added ca-certificates to Dockerfiles

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -33,6 +33,7 @@ RUN eval ${YUM_OPTS} \
        epel-release \
        yum-utils \
     && yum install -y \
+        ca-certificates \
         curl \
         freetype-devel \
         git \

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -32,6 +32,7 @@ RUN eval ${YUM_OPTS} \
        epel-release \
        yum-utils \
     && yum install -y \
+        ca-certificates \
         curl \
         freetype-devel \
         git \

--- a/docker/development/Dockerfile.nnabla-test
+++ b/docker/development/Dockerfile.nnabla-test
@@ -38,9 +38,8 @@ RUN eval ${APT_OPTS} && apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        ccache \
@@ -68,6 +67,7 @@ RUN apt-get install -y --no-install-recommends \
        python3-venv \
        python${PYVERNAME} \
        python${PYVERNAME}-venv \
+    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/development/Dockerfile.nnabla-test
+++ b/docker/development/Dockerfile.nnabla-test
@@ -33,10 +33,12 @@ ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN eval ${APT_OPTS} && apt-get update
-RUN apt install -y software-properties-common
-RUN add-apt-repository -y ppa:deadsnakes/ppa
-RUN apt-get update
+RUN eval ${APT_OPTS} && apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update
 
 RUN apt-get install -y --no-install-recommends \
        bzip2 \
@@ -66,11 +68,6 @@ RUN apt-get install -y --no-install-recommends \
        python3-venv \
        python${PYVERNAME} \
        python${PYVERNAME}-venv \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/development/Dockerfile.nnabla-test-ppc64le
+++ b/docker/development/Dockerfile.nnabla-test-ppc64le
@@ -36,9 +36,8 @@ RUN eval ${APT_OPTS} && apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        build-essential \
        bzip2 \
        ca-certificates \
@@ -71,6 +70,7 @@ RUN apt-get install -y --no-install-recommends \
        python${PYVERNAME}-venv \
        libsndfile1 \
        liblzma-dev \
+    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/development/Dockerfile.nnabla-test-ppc64le
+++ b/docker/development/Dockerfile.nnabla-test-ppc64le
@@ -31,10 +31,12 @@ ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
-RUN eval ${APT_OPTS} && apt-get update
-RUN apt install -y software-properties-common
-RUN add-apt-repository -y ppa:deadsnakes/ppa
-RUN apt-get update
+RUN eval ${APT_OPTS} && apt-get update \
+    && apt-get install -y software-properties-common \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update
 
 RUN apt-get install -y --no-install-recommends \
        build-essential \
@@ -69,11 +71,6 @@ RUN apt-get install -y --no-install-recommends \
        python${PYVERNAME}-venv \
        libsndfile1 \
        liblzma-dev \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -28,9 +28,8 @@ RUN eval ${APT_OPTS} && apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        curl \

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -23,17 +23,14 @@ ARG PYTHON_VER
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN eval ${APT_OPTS} \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends \
-    software-properties-common \
+RUN eval ${APT_OPTS} && apt-get update \
+    && apt-get install -y software-properties-common \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update
 
-RUN add-apt-repository ppa:deadsnakes/ppa
-
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        curl \
@@ -42,6 +39,7 @@ RUN apt-get update \
        python${PYTHON_VER} \
        python3-pip \
        python${PYTHON_VER}-distutils \
+    && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VER} 0

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -23,22 +23,20 @@ ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
-RUN eval ${APT_OPTS} && apt-get update
-RUN apt install -y software-properties-common
-RUN add-apt-repository ppa:deadsnakes/ppa
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
-        bzip2 \
-        ca-certificates \
-        curl \
-        libglib2.0-0 \
-        libgl1-mesa-glx \
-        python${PYVERNAME} \
+RUN eval ${APT_OPTS} && apt-get update \
+    && apt-get install -y software-properties-common \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt-get update
 
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+RUN apt-get install -y --no-install-recommends \
+       bzip2 \
+       ca-certificates \
+       curl \
+       libglib2.0-0 \
+       libgl1-mesa-glx \
+       python${PYVERNAME} \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -28,15 +28,15 @@ RUN eval ${APT_OPTS} && apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* \
     && add-apt-repository -y ppa:deadsnakes/ppa \
-    && apt-get update
-
-RUN apt-get install -y --no-install-recommends \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends \
        bzip2 \
        ca-certificates \
        curl \
        libglib2.0-0 \
        libgl1-mesa-glx \
        python${PYVERNAME} \
+    && apt-get install -y --no-install-recommends \
        python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
to avoid certificate expiration issue in patchelf:

```
 ---> 3c3d8132b0a6
Step 18/29 : RUN mkdir /tmp/deps     && cd /tmp/deps     && wget ${WGET_OPTS} http://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2     && tar xfa patchelf-0.9.tar.bz2     && cd patchelf-0.9     && ./configure     && make     && make install     && cd /     && rm -rf /tmp/*
 ---> Running in d5c47e8f003f
--2022-10-19 01:35:12--  http://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
Resolving nixos.org (nixos.org)... ****, ...
Connecting to nixos.org (nixos.org)|***|:80... connected.
HTTP request sent, awaiting response... 301 Moved Permanently
Location: https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2 [following]
--2022-10-19 01:35:12--  https://nixos.org/releases/patchelf/patchelf-0.9/patchelf-0.9.tar.bz2
Connecting to nixos.org (nixos.org)|***|:443... connected.
ERROR: cannot verify nixos.org's certificate, issued by '/C=US/O=Let\'s Encrypt/CN=R3':
  Issued certificate has expired.
To connect to nixos.org insecurely, use `--no-check-certificate'.
```