### PR TITLE
Not to all-reduce gradients of beta and gamma in sync BN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@
 /examples/cpp/nbla_train/*.nnp
 /include/nbla/functions.hpp
 /output/
+/python/src/nnabla/doc/
 /python/setup.cfg
 /python/setup.cfg-Debug
 /python/setup.cfg-MinSizeRel
@@ -61,11 +62,15 @@
 /python/src/nnabla/solver.pyx
 /python/src/nnabla/lms.cpp
 /python/src/nnabla/callback.cpp
-/python/src/nnabla/utils/converter/functions.pkl
+/python/src/nnabla/random.cpp
 /python/src/nnabla/utils/load_function.py
 /python/src/nnabla/utils/nnabla_pb2.py
 /python/src/nnabla/utils/save_function.py
 /python/src/nnabla/utils/dlpack.cpp
+/python/src/nnabla/utils/converter/tflite/flatc_linux
+/python/src/nnabla/utils/converter/tflite/flatc_mac
+/python/src/nnabla/utils/converter/tflite/flatc_windows.exe
+/python/src/nnabla/utils/converter/functions.pkl
 /python/src/nnabla/testing/clear_called_flag_recorder.cpp
 /python/test/Test-error.series.txt
 /python/test/Training-error.series.txt
@@ -87,6 +92,12 @@
 /third_party/libarchive-3.3.2tar.gz
 /third_party/protobuf-3.1.0tar.gz
 /third_party/zlib-1.2.11tar.gz
+/third_party/cmdline-master/
+/third_party/eigen-3.3.5/
+/third_party/flatc_linux
+/third_party/flatc_mac
+/third_party/flatc_windows.exe
+/third_party/googletest-release-1.10.0/
 
 /build/
 /build-android/

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -1986,6 +1986,11 @@ Normalization:
       References:
 
           * Implementing Synchronized Multi-GPU Batch Normalization https://hangzhang.org/PyTorch-Encoding/notes/syncbn.html
+
+      Note:
+          Since v1.32.0, the gradients of beta and gamma are not synchronized after backward computation (they had been synchronized previously).
+          Users are responsible for synchronizing the gradients of beta and gamma by performing all-reduce,
+          which is naturally done by performing all-reduce for gradients of all the parameters as we do usually in data parallel distributed training.
     inputs:
       x:
         doc: N-D array of input.


### PR DESCRIPTION
### Issue

The current SyncBN definition and implementation in nnabla have a potential issue where all-reduce of gradients for beta and gamma are performed twice under a standard data-parallel training pipeline, resulting in unexpectedly larger magnitudes of gradients (multiplied by a factor of number of GPU workers) used for parameter updates.
```python
# Pseudo code
with auto_forward():
  h = F.sync_batch_normalization(x, comm=comm)
# Before this change, all-reduce for the gradients of beta & gamma
# was performed at the backward function call.
h.backward() 
grads = get_grad_arrays()
# All-reduce for the gradients of beta & gamma in sync BN was performed here again
comm.all_reduce(grads)
solver.update()
```

### Change

In this PR, we changed the definition of the backward of sync BN such that it doesn't perform all-reduce operation for the gradients of beta and gamma to avoid duplicate reduce sum operations over the devices.





