### PR TITLE
Fix the timing of fill and zero evaluations in narrowed array

### DIFF
--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -337,13 +337,6 @@ SyncedArray::ArrayDesc SyncedArray::sync(dtypes dtype, const Context &ctx_orig,
     array_[desc.key].first->wait_event(ctx, async_flags);
   }
 
-  if (write_only) {
-    return desc;
-  }
-
-  auto ah = array_[desc.key];
-  Array *array = ah.first.get();
-  bool at_head = ah.second;
   if (has_family() && check_zeroing_filling()) {
     // Do lazy evaluation of zero() or fill().
 
@@ -357,6 +350,13 @@ SyncedArray::ArrayDesc SyncedArray::sync(dtypes dtype, const Context &ctx_orig,
     zero_fill_root->traverse_zero_fill();
   }
 
+  if (write_only) {
+    return desc;
+  }
+
+  auto ah = array_[desc.key];
+  Array *array = ah.first.get();
+  bool at_head = ah.second;
   // Not initialized or the array is not at head.
   if (at_head) {
     return desc;


### PR DESCRIPTION
This PR fixes a bug where `SyncedArray::cast` with `write_only == true` returns array **before** fill and zero evaluations for a narrowed array.


```py
import numpy as np
import nnabla as nn
import nnabla.functions as F

size = 4
a = nn.NdArray((size,))
a.fill(3)
b = nn.NdArray((size,))

c = b.narrow(0, 0, size)
# F.identity uses `write_only == true` casting for the destination array
F.identity(a, outputs=[c])

# Before fix: c == [0, 0, 0, 0]
# After fix:  c == [3, 3, 3, 3]
np.testing.assert_equal(c.get_data(mode='r'), a.get_data()) 
```