### PR TITLE
Release unused memory in auto forward mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@
 /python/src/nnabla/_variable.cpp
 /python/src/nnabla/_dropout_workaround.cpp
 /python/src/nnabla/_version.py
+/python/src/nnabla/auto_forward.cpp
 /python/src/nnabla/backward_functions.py
 /python/src/nnabla/clibtest
 /python/src/nnabla/communicator.cpp

--- a/include/nbla/function/batch_normalization.hpp
+++ b/include/nbla/function/batch_normalization.hpp
@@ -175,6 +175,13 @@ protected:
     }
     return false;
   }
+
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // batch_normalization_backward recomputes the forward. Therefore the all
+    // inputs must be kept.
+    return true;
+  }
+
   virtual bool overwrite_input_data_in_forward_impl(int i) const {
     if (i == m_idx_ || i == v_idx_) {
       return true;

--- a/include/nbla/function/bool_scatter.hpp
+++ b/include/nbla/function/bool_scatter.hpp
@@ -71,6 +71,13 @@ protected:
       return true;
     return false;
   }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // bool_scatter_backward requires inputs[1].
+    if (j == 1) {
+      return true;
+    }
+    return false;
+  }
 
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
 };

--- a/include/nbla/function/dropout.hpp
+++ b/include/nbla/function/dropout.hpp
@@ -103,6 +103,12 @@ protected:
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     return false;
   }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // dropout_backward requires the dropout_mask and inputs[0] can be cleared.
+    // However, in the current implementation using workaround, it is passed
+    // via inputs[0]. Therefore inputs[0] must be kept unexpectedly.
+    return true;
+  }
 };
 }
 #endif

--- a/include/nbla/function/fused_batch_normalization.hpp
+++ b/include/nbla/function/fused_batch_normalization.hpp
@@ -153,6 +153,13 @@ protected:
     }
     return false;
   }
+
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // fused_batch_normalization_backward recomputes the forward. Therefore
+    // the all inputs must be kept.
+    return true;
+  }
+
   virtual bool overwrite_input_data_in_forward_impl(int i) const {
     if (i == 3 || i == 4) {
       return true;

--- a/include/nbla/function/gru.hpp
+++ b/include/nbla/function/gru.hpp
@@ -113,6 +113,10 @@ protected:
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     return false;
   }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // gru_backward requires the all inputs for recomputation.
+    return true;
+  }
 
 private:
   vector<vector<CgVariablePtr>> create_fixed_length_gru_graph(

--- a/include/nbla/function/lstm.hpp
+++ b/include/nbla/function/lstm.hpp
@@ -112,6 +112,10 @@ protected:
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     return false;
   }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // lstm_backward requires the all inputs for recomputation.
+    return true;
+  }
 
 private:
   vector<vector<CgVariablePtr>> create_fixed_length_lstm_graph(

--- a/include/nbla/function/max.hpp
+++ b/include/nbla/function/max.hpp
@@ -53,6 +53,11 @@ public:
   }
   virtual string name() { return "Max"; }
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
+  virtual bool auto_grad_depends_output_data(int i, int o) const {
+    // max_backward requires outputs[0] because index_buff_ cannot be accessed
+    // there.
+    return true;
+  }
 
 protected:
   NBLA_API virtual void setup_impl(const Variables &inputs,
@@ -65,6 +70,11 @@ protected:
                                              int reduction_size, bool accum);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     return false;
+  }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // max_backward requires inputs[0] because index_buff_ cannot be accessed
+    // there.
+    return true;
   }
 };
 }

--- a/include/nbla/function/max_pooling.hpp
+++ b/include/nbla/function/max_pooling.hpp
@@ -74,6 +74,11 @@ protected:
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     return false;
   }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // max_pooling_backward requires inputs[0] because this->index_buff_ cannot
+    // be accessed there.
+    return true;
+  }
 };
 }
 #endif

--- a/include/nbla/function/min.hpp
+++ b/include/nbla/function/min.hpp
@@ -47,12 +47,22 @@ public:
   }
   virtual string name() { return "Min"; }
   virtual bool grad_depends_output_data(int i, int o) const { return false; }
+  virtual bool auto_grad_depends_output_data(int i, int o) const {
+    // min_backward requires outputs[0] because this->index_buff_ cannot be
+    // accessed there.
+    return true;
+  }
 
 protected:
   NBLA_API virtual void forward_impl_reduce(const T *x, T *y, int outer_size,
                                             int reduction_size);
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     return false;
+  }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // min_backward requires inputs[0] because this->index_buff_ cannot be
+    // accessed there.
+    return true;
   }
 };
 }

--- a/include/nbla/function/rnn.hpp
+++ b/include/nbla/function/rnn.hpp
@@ -113,6 +113,10 @@ protected:
   virtual bool grad_depends_input_data_impl(int i, int j) const {
     return false;
   }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // rnn_backward requires the all inputs for recomputation.
+    return true;
+  }
 
 private:
   vector<vector<CgVariablePtr>> create_fixed_length_rnn_graph(

--- a/include/nbla/function/softmax_cross_entropy.hpp
+++ b/include/nbla/function/softmax_cross_entropy.hpp
@@ -94,6 +94,10 @@ protected:
       return true;
     return false;
   }
+  virtual bool auto_grad_depends_input_data_impl(int i, int j) const {
+    // softmax_cross_entropy_backward always uses inputs[0] and inputs[1].
+    return true;
+  }
 };
 }
 #endif

--- a/include/nbla/nd_array.hpp
+++ b/include/nbla/nd_array.hpp
@@ -22,13 +22,43 @@
 
 namespace nbla {
 
+using std::make_shared;
+
+// This class is used to keep secure the memory reference, and to keep
+// that accessibility restricted to the setter method.
+class BaseNdArray {
+  SyncedArrayPtr array_;
+
+  // The number of Variables (Python API) to refer data instance.
+  int python_user_reference_counts = 0;
+
+protected:
+  Size_t size_;
+
+public:
+  virtual NBLA_API ~BaseNdArray();
+
+  /** Update the refernce counts from a Python user.
+   */
+  virtual void update_python_user_reference_counts(const int diff) final;
+
+  /** Replace SyncedArray instance with previously created another one.
+   */
+  virtual NBLA_API void set_array(SyncedArrayPtr array) final;
+
+  /** Get SyncedArray instance held by this instance.
+
+      @note This is not copying data. Modifying content affects this.
+   */
+  virtual NBLA_API SyncedArrayPtr array() final;
+};
+
 /** Dtype and backend agnostic multi-dimensional array.
  */
-class NdArray {
-  SyncedArrayPtr array_;
+class NdArray : public BaseNdArray,
+                public std::enable_shared_from_this<NdArray> {
   Shape_t shape_;
   Shape_t strides_;
-  Size_t size_;
   Size_t ndim_;
 
   /** Update shape info by shape.
@@ -92,16 +122,6 @@ public:
   /** Get number of dimensions.
    */
   NBLA_API Size_t ndim() const;
-
-  /** Get SyncedArray instance held by this instance.
-
-      @note This is not copying data. Modifying content affects this.
-   */
-  NBLA_API SyncedArrayPtr array();
-
-  /** Replace SyncedArray instance with previously created another one.
-   */
-  NBLA_API void set_array(SyncedArrayPtr array);
 
   /** Set all value to zero.
 

--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -208,6 +208,20 @@ public:
    */
   bool is_narrowed() const { return parent_ != nullptr; }
 
+  /** Returns true if this SyncedArray has the Parent.
+   */
+  inline bool is_child() const { return parent_ != nullptr; }
+
+  /** Returns true if this SyncedArray has not the Parent.
+   */
+  inline bool is_root() const { return parent_ == nullptr; }
+
+  /** Returns true if this SyncedArray has a parent or child SyncedArrays.
+   */
+  bool has_family() const {
+    return static_cast<bool>(parent_ || children_.size() > 0);
+  }
+
   /** Get the refernce counts from a Python user.
    */
   int get_python_user_reference_counts() const;
@@ -248,20 +262,6 @@ private:
   /** Get offset of the Array.
    */
   Size_t offset() const { return offset_; }
-
-  /** Returns true if this SyncedArray has the Parent.
-   */
-  inline bool is_child() { return parent_ != nullptr; }
-
-  /** Returns true if this SyncedArray has not the Parent.
-   */
-  inline bool is_root() { return parent_ == nullptr; }
-
-  /** Returns true if this SyncedArray has a parent or child SyncedArrays.
-   */
-  bool has_family() {
-    return static_cast<bool>(parent_ || children_.size() > 0);
-  }
 
   /** Returns true if this SyncedArray has the head array.
    */

--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -61,6 +61,9 @@ class NBLA_API SyncedArray : public enable_shared_from_this<SyncedArray> {
   std::vector<weak_ptr<SyncedArray>>
       children_; ///< list of pointers of child SyncedArrays
 
+  // Reference counts of this instance from Python user
+  int python_user_reference_counts = 0;
+
 public:
   SyncedArray(const Size_t size);
   SyncedArray(shared_ptr<SyncedArray> parent, const Size_t size,
@@ -204,6 +207,14 @@ public:
   /** Returns true if this SyncedArray is narrowed.
    */
   bool is_narrowed() const { return parent_ != nullptr; }
+
+  /** Get the refernce counts from a Python user.
+   */
+  int get_python_user_reference_counts() const;
+
+  /** Update the refernce counts from a Python user.
+   */
+  void update_python_user_reference_counts(const int diff);
 
 private:
   ArrayDesc sync(dtypes dtype, const Context &ctx, bool write_only = false,

--- a/python/setup.py
+++ b/python/setup.py
@@ -186,7 +186,8 @@ if __name__ == '__main__':
         'testing/clear_called_flag_recorder',
         'recompute',
         'lms',
-        '_dropout_workaround']
+        '_dropout_workaround',
+        'auto_forward']
 
     ext_modules = [Extension('nnabla.{}'.format(mname.replace('/', '.')),
                              [os.path.join(path_pkg,

--- a/python/src/nnabla/_computation_graph.pyx
+++ b/python/src/nnabla/_computation_graph.pyx
@@ -83,6 +83,6 @@ def forward_all(variables,
     size = len(variables)
     cg_variables.resize(size)
     for i in range(size):
-        cg_variables[i] = (<_Variable?> variables[i]).var
+        cg_variables[i] = (<_Variable?> variables[i]).get_var()
     with nogil:
         cforward_all(cg_variables, clear_buffer, clear_no_need_grad, function_pre_hook_c, function_post_hook_c)

--- a/python/src/nnabla/_dropout_workaround.pyx
+++ b/python/src/nnabla/_dropout_workaround.pyx
@@ -26,7 +26,7 @@ def _get_dropout_mask(dropout_input):
         dropout_input(:class:`nnabla.Variable`): The input variable of
                                                  nnabla.functions.dropout
     """
-    cdef VariablePtr v = (<Variable?>dropout_input).varp.variable()
+    cdef VariablePtr v = (<Variable?>dropout_input).get_varp().variable()
     cdef VariablePtr mask = c_get_dropout_mask(v)
     return Variable.create_from_cvariable(mask)
 

--- a/python/src/nnabla/_nd_array.pxd
+++ b/python/src/nnabla/_nd_array.pxd
@@ -37,6 +37,7 @@ cdef extern from "nbla/synced_array.hpp" namespace "nbla":
         cpp_bool clear_called() except+
         cpp_bool zeroing() const
         void clear() except+
+        int get_python_user_reference_counts() const
 
     ctypedef shared_ptr[CSyncedArray] SyncedArrayPtr
 
@@ -63,6 +64,7 @@ cdef extern from "nbla/nd_array.hpp" namespace "nbla":
         CArray * cast(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
         ArrayPtr cast_sp(dtypes dtype, const CContext & ctx, cpp_bool write_only) nogil except +
         shared_ptr[CNdArray] narrow(const Size_t dim, const Size_t start, const Size_t length) except+
+        int python_user_reference_counts
 
     ctypedef shared_ptr[CNdArray] NdArrayPtr
 

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -207,6 +207,18 @@ cdef class NdArray:
         return tuple(self.arrp.shape())
 
 
+    def view(self, shape):
+        """Create viewd NdArray.
+        Create a new NdArray of sharing same data with specified shape.
+        Args:
+            shape (tuple): Shape of tuple.
+        Returns:
+            nnabla.NdArray
+        """
+        arr = self.arrp.view(shape)
+        return NdArray.create(arr)
+
+
     def data_ptr(self, dtype, ctx=None, cpp_bool write_only=False):
         """Get array's pointer.
 

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -20,6 +20,7 @@ from libcpp.memory cimport make_shared, shared_ptr, const_pointer_cast
 from cpython cimport PyObject, Py_INCREF, Py_DECREF
 cimport _variable
 from _variable cimport CVariable, CContext, Shape_t, dtypes
+from _nd_array cimport CNdArray, CSyncedArray
 cimport function
 from function cimport CgFunction
 
@@ -153,27 +154,44 @@ cdef class Variable:
 
     """
 
+    cdef void set_var(self, CgVariablePtr var):
+        # New CgVariable traces this Variable.
+        var.get().update_python_user_reference_counts(1)
+
+        if self._var:
+            # Old CgVariable purges this Variable.
+            self.get_varp().update_python_user_reference_counts(-1)
+
+        self._var = var
+        self._varp = var.get()
+
+    cdef inline CgVariablePtr get_var(self):
+        return self._var
+
+    cdef inline CgVariable * get_varp(self):
+        return self._varp
+
+    cdef inline CgVariable * get_varp_no_gil(self) nogil:
+        return self._varp
+
     def __cinit__(self, Shape_t shape=[], need_grad=None, info=None):
         self.info = info
         if need_grad is None:
-            self.var = make_shared[CgVariable](shape)
+            self.set_var(make_shared[CgVariable](shape))
         else:
-            self.var = make_shared[CgVariable](shape, < bint?> need_grad)
-        self.varp = self.var.get()
+            self.set_var(make_shared[CgVariable](shape, < bint?> need_grad))
 
     @staticmethod
     cdef create_from_cvariable(shared_ptr[CVariable] varsp):
         cdef shared_ptr[CgVariable] v_sp = make_shared[CgVariable](varsp)
         var = Variable()
-        var.var = v_sp
-        var.varp = v_sp.get()
+        var.set_var(v_sp)
         return var
 
     @staticmethod
     cdef create_from_cg_variable(CgVariablePtr cgv):
         var = Variable()
-        var.var = cgv
-        var.varp = cgv.get()
+        var.set_var(cgv)
         return var
 
     @staticmethod
@@ -209,7 +227,38 @@ cdef class Variable:
         return var
 
     def __dealloc__(self):
-        pass
+        # Clear data when an user releases all the references of this Variable.
+        # This feature is required to release the memory during forward
+        # execution in auto-forward mode.
+        # TODO: Implement this feature as the core design of NNabla and remove
+        #       this workaround.
+        # Dev Note: You must avoid invoking Python operations in Cython 
+        #           __dealloc__. When Cython __dealloc__() method is called,
+        #           Python objects are partially destroyed. In particular,
+        #           at the end of Python process, the invocations of
+        #           __dealloc__() of all Variables during Python object
+        #           destruction could return many errors. 
+        self.get_varp().clear_during_auto_forward()
+
+        # Delete references
+        self.get_varp().update_python_user_reference_counts(-1)
+
+    @property
+    def get_number_of_references(self):
+        """
+        Gets the number of referneces to the same memory objects.
+
+
+        Returns: 
+            `int`
+
+        """
+        # This is mainly used for pytest.
+        cdef CgVariable* cgv = self.get_varp()
+        cdef CVariable* v = cgv.variable().get()
+        cdef CNdArray* ndarr = v.data().get()
+        cdef CSyncedArray* syncarr = ndarr.array().get()
+        return syncarr.get_python_user_reference_counts()
 
     def __repr__(self):
         return "<Variable({}, need_grad={}) at {}>".format(
@@ -219,14 +268,14 @@ cdef class Variable:
         '''Equal operator compares the addresses of underlying C++ objects
         (``nbla::Variable``).
         '''
-        cdef CVariable* v = (< Variable > self).varp.variable().get()
-        cdef CVariable* w = (< Variable ?> other).varp.variable().get()
+        cdef CVariable* v = (< Variable > self).get_varp().variable().get()
+        cdef CVariable* w = (< Variable ?> other).get_varp().variable().get()
         return v == w
 
     def __hash__(self):
         '''Returns hash of the integer address of holding C++ object.
         '''
-        cdef CVariable* v = ( < Variable > self).varp.variable().get()
+        cdef CVariable* v = ( < Variable > self).get_varp().variable().get()
         return hash(< intptr_t > (v))
 
     def apply(self, **kwargs):
@@ -246,7 +295,7 @@ cdef class Variable:
             tuple of :obj:`int`
 
         """
-        return tuple(self.varp.variable().get().shape())
+        return tuple(self.get_varp().variable().get().shape())
 
     @property
     def size(self):
@@ -257,7 +306,7 @@ cdef class Variable:
             :obj:`int`
 
         """
-        return self.varp.variable().get().size(-1)
+        return self.get_varp().variable().get().size(-1)
 
     @property
     def ndim(self):
@@ -268,7 +317,7 @@ cdef class Variable:
             int
 
         """
-        return self.varp.variable().get().ndim()
+        return self.get_varp().variable().get().ndim()
 
     def size_from_axis(self, axis=-1):
         """
@@ -294,7 +343,7 @@ cdef class Variable:
         Returns:
             :obj:`int`        
         """
-        return self.varp.variable().get().size(axis)
+        return self.get_varp().variable().get().size(axis)
 
     def reset_shape(self, shape, force=False):
         """Resizes the shape of the variable to a specified shape.
@@ -310,7 +359,7 @@ cdef class Variable:
             None
 
         """
-        self.varp.variable().get().reshape(shape, force)
+        self.get_varp().variable().get().reshape(shape, force)
 
     def reshape(self, shape, unlink=False):
         """Returns a new variable, where this variable is reshaped to a specified shape.
@@ -326,8 +375,8 @@ cdef class Variable:
         """
         if unlink:
             var = Variable.create_from_cvariable(
-                self.varp.variable().get().view(shape))
-            (< Variable > var).varp.set_need_grad(self.varp.need_grad_state())
+                self.get_varp().variable().get().view(shape))
+            (< Variable > var).get_varp().set_need_grad(self.get_varp().need_grad_state())
             return var
         from nnabla.functions import reshape
         return reshape(self, shape)
@@ -343,11 +392,11 @@ cdef class Variable:
         Returns:
            bool: Whether this variable requires gradient or not.
         """
-        return self.varp.need_grad_state()
+        return self.get_varp().need_grad_state()
 
     @need_grad.setter
     def need_grad(self, b):
-        self.varp.set_need_grad(b)
+        self.get_varp().set_need_grad(b)
 
     @property
     def recompute(self):
@@ -360,11 +409,11 @@ cdef class Variable:
         Returns:
            bool: Whether this variable is recomputed during backward propagation.
         """
-        return self.varp.recompute()
+        return self.get_varp().recompute()
 
     @recompute.setter
     def recompute(self, b):
-        self.varp.set_recompute(b)
+        self.get_varp().set_recompute(b)
 
     def rewire_on(self, var):
         '''Rewire a successor graph of this variable on top of ``var``.
@@ -399,7 +448,7 @@ cdef class Variable:
                 ya.backward()
 
         '''
-        steal_variable_from_to(( < Variable?> var).var, self.var)
+        steal_variable_from_to(( < Variable?> var).get_var(), self.get_var())
 
     @property
     def data(self):
@@ -413,11 +462,11 @@ cdef class Variable:
         Returns:
             :class:`~nnabla.NdArray`
         """
-        return NdArray.create(self.varp.variable().get().data())
+        return NdArray.create(self.get_varp().variable().get().data())
 
     @data.setter
     def data(self, NdArray ndarray):
-        self.varp.variable().get().set_data(ndarray.arr)
+        self.get_varp().variable().get().set_data(ndarray.arr)
 
     @property
     def grad(self):
@@ -431,11 +480,11 @@ cdef class Variable:
         Returns:
             :class:`~nnabla.NdArray`
         """
-        return NdArray.create(self.varp.variable().get().grad())
+        return NdArray.create(self.get_varp().variable().get().grad())
 
     @grad.setter
     def grad(self, NdArray ndarray):
-        self.varp.variable().get().set_grad(ndarray.arr)
+        self.get_varp().variable().get().set_grad(ndarray.arr)
 
     @property
     def d(self):
@@ -513,7 +562,7 @@ cdef class Variable:
             :obj:`nnabla.function.Function`
 
         """
-        cdef CgFunctionPtr cgf = self.varp.parent()
+        cdef CgFunctionPtr cgf = self.get_varp().parent()
         if not cgf:
             return None
         return function.Function.create_from_c(cgf)
@@ -522,7 +571,7 @@ cdef class Variable:
     def parent(self, func):
         cdef CgFunctionPtr cg_func = (< function.Function ?> func).fun
         assert cg_func, "TODO"
-        self.varp.set_parent(cg_func)
+        self.get_varp().set_parent(cg_func)
 
     @property
     def function_references(self):
@@ -534,7 +583,7 @@ cdef class Variable:
             list of `nnabla.function.Function`
 
         """
-        cdef vector[CgFunctionPtr] fs = self.varp.function_references()
+        cdef vector[CgFunctionPtr] fs = self.get_varp().function_references()
 
         return [function.Function.create_from_c(f) for f in fs]
 
@@ -579,7 +628,7 @@ cdef class Variable:
             function_post_hook_c = create_function_hook_with_object(function_post_hook)
 
         with nogil:
-            self.varp.forward(clear_buffer, clear_no_need_grad, NULL, function_pre_hook_c, function_post_hook_c)
+            self.get_varp_no_gil().forward(clear_buffer, clear_no_need_grad, NULL, function_pre_hook_c, function_post_hook_c)
 
 
     def backward(self, grad=1, cpp_bool clear_buffer=False, communicator_callbacks=None,
@@ -824,7 +873,7 @@ cdef class Variable:
             function_post_hook_c = create_function_hook_with_object(function_post_hook)
 
         with nogil:
-            self.varp.backward(p, clear_buffer, callback_list, function_pre_hook_c, function_post_hook_c, clear_initial_grad)
+            self.get_varp_no_gil().backward(p, clear_buffer, callback_list, function_pre_hook_c, function_post_hook_c, clear_initial_grad)
 
     def unlinked(self, need_grad=None):
         """
@@ -879,11 +928,11 @@ cdef class Variable:
                 # None
 
         """
-        var = Variable.create_from_cvariable(self.varp.variable())
+        var = Variable.create_from_cvariable(self.get_varp().variable())
         if need_grad is not None:
             var.need_grad = need_grad
         else:
-            (< Variable > var).varp.set_need_grad(self.varp.need_grad_state())
+            (< Variable > var).get_varp().set_need_grad(self.get_varp().need_grad_state())
         return var
 
     def no_grad(self):
@@ -924,23 +973,23 @@ cdef class Variable:
             bool
 
         """
-        return self.varp.persistent()
+        return self.get_varp().persistent()
 
     @persistent.setter
     def persistent(self, cpp_bool b):
-        self.varp.set_persistent(b)
+        self.get_varp().set_persistent(b)
 
     @property
     def name(self):
-        return self.varp.name()
+        return self.get_varp().name()
 
     @name.setter
     def name(self, string name):
-        self.varp.set_name(name)
+        self.get_varp().set_name(name)
 
     @property
     def rank(self, ):
-        return self.varp.rank()
+        return self.get_varp().rank()
 
     def visit(self, f):
         """
@@ -1098,7 +1147,7 @@ cdef class Variable:
         self.visit(_clear_all_graph_links)
 
     def _clear_parent(self, ):
-        self.varp.set_parent(< CgFunctionPtr?> NULL)
+        self.get_varp().set_parent(< CgFunctionPtr?> NULL)
 
     def __pos__(self):
         return AOP.pos(self)

--- a/python/src/nnabla/auto_forward.pxd
+++ b/python/src/nnabla/auto_forward.pxd
@@ -1,0 +1,20 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from libcpp cimport bool as cpp_bool
+
+
+cdef extern from "nbla/auto_forward.hpp" namespace "nbla":
+    cpp_bool c_get_auto_forward "nbla::SingletonManager::get<nbla::AutoForward>()->get_auto_forward" () except +
+    void c_set_auto_forward "nbla::SingletonManager::get<nbla::AutoForward>()->set_auto_forward" (const cpp_bool autoforward) except +

--- a/python/src/nnabla/auto_forward.pyx
+++ b/python/src/nnabla/auto_forward.pyx
@@ -1,4 +1,5 @@
 # Copyright 2017,2018,2019,2020,2021 Sony Corporation.
+# Copyright 2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 from contextlib import contextmanager
+from .auto_forward cimport c_get_auto_forward, c_set_auto_forward
 
-# State of auto forward computation.
-__auto_forward_state = False
+# State of auto forward computation of Python global variable is integrated to
+# C++ Singleton.
 
 
 @contextmanager
@@ -27,17 +28,13 @@ def auto_forward(auto=True):
     Args:
         auto (bool): Whether forward computation is executed during a
             computation graph construction.
-
-    Returns: bool
-
     """
-    global __auto_forward_state
-    prev = __auto_forward_state
-    __auto_forward_state = auto
+    prev = c_get_auto_forward()
+    c_set_auto_forward(auto)
     try:
         yield
     finally:
-        __auto_forward_state = prev
+        c_set_auto_forward(prev)
 
 
 def get_auto_forward():
@@ -46,11 +43,13 @@ def get_auto_forward():
     When it is true, forward execution is invoked during a computation graph
     definition.
 
+    Returns:
+        bool: Auto-forward flag
+    
     Note:
         This is called by users usually.  
     """
-    global __auto_forward_state
-    return __auto_forward_state
+    return c_get_auto_forward()
 
 
 def set_auto_forward(auto):
@@ -62,8 +61,5 @@ def set_auto_forward(auto):
     Args:
         auto (bool): Whether forward computation is executed when the
             computation graph is updated.
-
-    Returns: bool
     """
-    global __auto_forward_state
-    __auto_forward_state = auto
+    c_set_auto_forward(auto)

--- a/python/src/nnabla/backward_function.py.tmpl
+++ b/python/src/nnabla/backward_function.py.tmpl
@@ -49,15 +49,30 @@ arguments = as_args(func.get('arguments', {}))
 %>
 import nnabla.functions as F
 
-def ${func['snake_name']}_backward(inputs${arguments}):
+def ${func['snake_name']}_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes${arguments}):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    # The inputs and outputs could be cleared by graph engine during forward
+    # propagation before this backward function is called. The grad dependency
+    # defined by C++ Function class can prevent the deletion. To define it,
+    # see Function::grad_depends_input_data, Function::grad_depends_input_data_impl,
+    # Function::grad_depends_output_data, Function::auto_grad_depends_input_data,
+    # Function::auto_grad_depends_output_data, Function::auto_grad_depends_input_data_impl
+    # for more detail.
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("${func['snake_name']}_backward is not implemented.")

--- a/python/src/nnabla/backward_function/abs.py
+++ b/python/src/nnabla/backward_function/abs.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def abs_backward(inputs):
+def abs_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.greater_equal_scalar(x0, 0)
     m1 = 1 - m0
     m01 = m0 - m1

--- a/python/src/nnabla/backward_function/absolute_error.py
+++ b/python/src/nnabla/backward_function/absolute_error.py
@@ -19,18 +19,26 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def absolute_error_backward(inputs):
+def absolute_error_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
 
     m0 = F.greater_equal(x0, x1)
     m1 = 1 - m0

--- a/python/src/nnabla/backward_function/acos.py
+++ b/python/src/nnabla/backward_function/acos.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def acos_backward(inputs):
+def acos_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = - dy * (1 - x0 ** 2) ** (-1.0 / 2)
     return dx0

--- a/python/src/nnabla/backward_function/acosh.py
+++ b/python/src/nnabla/backward_function/acosh.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def acosh_backward(inputs):
+def acosh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * (x0 ** 2 - 1) ** (-1.0 / 2)
     return dx0

--- a/python/src/nnabla/backward_function/adaptive_separable_convolution.py
+++ b/python/src/nnabla/backward_function/adaptive_separable_convolution.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def adaptive_separable_convolution_backward(inputs):
+def adaptive_separable_convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "adaptive_separable_convolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/add2.py
+++ b/python/src/nnabla/backward_function/add2.py
@@ -14,23 +14,31 @@
 # limitations under the License.
 
 
-from .utils import sum_for_arithmetics
+from .utils import sum_for_arithmetics_with_shape
 
 
-def add2_backward(inputs, inplace=False):
+def add2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
+    x1_shape = input_shapes[1]
     dx0 = dy
     dx1 = dy
-    dx0 = sum_for_arithmetics(dx0, x0)
-    dx1 = sum_for_arithmetics(dx1, x1)
+    dx0 = sum_for_arithmetics_with_shape(dx0, x0_shape)
+    dx1 = sum_for_arithmetics_with_shape(dx1, x1_shape)
     return dx0, dx1

--- a/python/src/nnabla/backward_function/add_n.py
+++ b/python/src/nnabla/backward_function/add_n.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def add_n_backward(inputs):
+def add_n_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x_list = inputs[1:]
+    dy = grad_inputs[0]
+    x_list = inputs
     dx_list = [dy for _ in range(len(x_list))]
     return dx_list

--- a/python/src/nnabla/backward_function/add_scalar.py
+++ b/python/src/nnabla/backward_function/add_scalar.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def add_scalar_backward(inputs, val=1, inplace=False):
+def add_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
     dx = dy
     return dx

--- a/python/src/nnabla/backward_function/affine.py
+++ b/python/src/nnabla/backward_function/affine.py
@@ -35,18 +35,26 @@ class AffineFilterGrad(LinearFilterGrad):
         self._linear = _F.Affine(ctx, base_axis)
 
 
-def affine_backward(inputs, base_axis=1):
+def affine_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    w0 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    w0 = inputs[1]
 
     base_axis += inputs[0].ndim*(base_axis < 0)
 
@@ -59,7 +67,7 @@ def affine_backward(inputs, base_axis=1):
     dx0 = dfx(dy, w0)
     dw0 = dfw(dy, x0)
 
-    if len(inputs) == 4:
+    if len(inputs) == 3:
         axes = [i for i in range(0, base_axis)]
         db0 = F.sum(dy, axes, keepdims=False)
         return dx0, dw0, db0
@@ -67,18 +75,26 @@ def affine_backward(inputs, base_axis=1):
         return dx0, dw0
 
 
-def affine_data_grad_backward(inputs, base_axis=1):
+def affine_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
-    dy = inputs[1]
-    w0 = inputs[2]
+    gdx = grad_inputs[0]
+    dy = inputs[0]
+    w0 = inputs[1]
 
     ctx = nn.get_current_context()
     dfw = AffineFilterGrad(ctx, base_axis)
@@ -89,18 +105,26 @@ def affine_data_grad_backward(inputs, base_axis=1):
     return gdy, gw0
 
 
-def affine_filter_grad_backward(inputs, base_axis=1):
+def affine_filter_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdw = inputs[0]
-    dy = inputs[1]
-    x0 = inputs[2]
+    gdw = grad_inputs[0]
+    dy = inputs[0]
+    x0 = inputs[1]
 
     ctx = nn.get_current_context()
     dfx = AffineDataGrad(ctx, base_axis)

--- a/python/src/nnabla/backward_function/affine_grid.py
+++ b/python/src/nnabla/backward_function/affine_grid.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def affine_grid_backward(inputs, size, align_corners=False):
+def affine_grid_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, size, align_corners=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("affine_grid_backward is not implemented.")

--- a/python/src/nnabla/backward_function/arange.py
+++ b/python/src/nnabla/backward_function/arange.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def arange_backward(inputs, start, stop, step=1):
+def arange_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, start, stop, step=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/asin.py
+++ b/python/src/nnabla/backward_function/asin.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def asin_backward(inputs):
+def asin_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * (1 - x0 ** 2) ** (-1.0 / 2)
     return dx0

--- a/python/src/nnabla/backward_function/asinh.py
+++ b/python/src/nnabla/backward_function/asinh.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def asinh_backward(inputs):
+def asinh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * (x0 ** 2 + 1) ** (-1.0 / 2)
     return dx0

--- a/python/src/nnabla/backward_function/assign.py
+++ b/python/src/nnabla/backward_function/assign.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def assign_backward(inputs):
+def assign_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("assign_backward is not implemented.")

--- a/python/src/nnabla/backward_function/atan.py
+++ b/python/src/nnabla/backward_function/atan.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def atan_backward(inputs):
+def atan_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy / (1 + x0 ** 2)
     return dx0

--- a/python/src/nnabla/backward_function/atan2.py
+++ b/python/src/nnabla/backward_function/atan2.py
@@ -14,18 +14,26 @@
 # limitations under the License.
 
 
-def atan2_backward(inputs):
+def atan2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dz = inputs[0]
-    y = inputs[1]
-    x = inputs[2]
+    dz = grad_inputs[0]
+    y = inputs[0]
+    x = inputs[1]
     r2 = x ** 2 + y ** 2
     dy = dz * x / r2
     dx = - dz * y / r2

--- a/python/src/nnabla/backward_function/atanh.py
+++ b/python/src/nnabla/backward_function/atanh.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def atanh_backward(inputs):
+def atanh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy / (1 - x0 ** 2)
     return dx0

--- a/python/src/nnabla/backward_function/average_pooling.py
+++ b/python/src/nnabla/backward_function/average_pooling.py
@@ -30,39 +30,55 @@ class AveragePoolingDataGrad(UnaryDataGrad):
                                        channel_last, including_pad)
 
 
-def average_pooling_backward(inputs, kernel, stride=None,
+def average_pooling_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, stride=None,
                              ignore_border=True, pad=None,
                              channel_last=False, including_pad=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     df = AveragePoolingDataGrad(ctx, kernel, stride, ignore_border, pad,
                                 channel_last, including_pad)
-    df.xshape = x0.shape
+    df.xshape = x0_shape
     dx0 = df(dy)
     return dx0
 
 
-def average_pooling_data_grad_backward(inputs, kernel, stride=None,
+def average_pooling_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, stride=None,
                                        ignore_border=True, pad=None,
                                        channel_last=False, including_pad=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.average_pooling(gdx, kernel, stride, ignore_border, pad,
                             channel_last, including_pad)
     return gdy

--- a/python/src/nnabla/backward_function/batch_cholesky.py
+++ b/python/src/nnabla/backward_function/batch_cholesky.py
@@ -23,15 +23,23 @@
 import nnabla.functions as F
 
 
-def batch_cholesky_backward(inputs):
+def batch_cholesky_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("batch_cholesky_backward is not implemented.")

--- a/python/src/nnabla/backward_function/batch_det.py
+++ b/python/src/nnabla/backward_function/batch_det.py
@@ -16,24 +16,30 @@
 
 import nnabla.functions as F
 
-from .utils import get_output
 
-
-def batch_det_backward(inputs):
+def batch_det_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     x0_inv_T = F.transpose(F.batch_inv(x0), [0, 2, 1])
     b = x0.shape[0]
     dy = F.reshape(dy, [b, 1, 1])
-    y0 = get_output(x0, "BatchDet")
+    y0 = outputs[0]
     y0 = F.reshape(y0, [b, 1, 1], inplace=False)
     dx0 = dy * y0 * x0_inv_T
     return dx0

--- a/python/src/nnabla/backward_function/batch_inv.py
+++ b/python/src/nnabla/backward_function/batch_inv.py
@@ -16,21 +16,26 @@
 
 import nnabla.functions as F
 
-from .utils import get_output
 
-
-def batch_inv_backward(inputs):
+def batch_inv_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x0_inv = get_output(x0, "BatchInv")
+    dy = grad_inputs[0]
+    x0_inv = outputs[0]
     t01 = - F.batch_matmul(x0_inv, dy, True, False)
     dx0 = F.batch_matmul(t01, x0_inv, False, True)
     return dx0

--- a/python/src/nnabla/backward_function/batch_logdet.py
+++ b/python/src/nnabla/backward_function/batch_logdet.py
@@ -21,15 +21,23 @@
 # 3. UPDATE THE MAPPING IF NECESSARY (see function_backward_functions.py.tmpl)
 
 
-def batch_logdet_backward(inputs):
+def batch_logdet_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("batch_logdet_backward is not implemented.")

--- a/python/src/nnabla/backward_function/batch_matmul.py
+++ b/python/src/nnabla/backward_function/batch_matmul.py
@@ -23,18 +23,26 @@ def _sum(dx, x):
     return dx
 
 
-def batch_matmul_backward(inputs, transpose_a=False, transpose_b=False):
+def batch_matmul_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, transpose_a=False, transpose_b=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dc = inputs[0]
-    a = inputs[1]
-    b = inputs[2]
+    dc = grad_inputs[0]
+    a = inputs[0]
+    b = inputs[1]
     if (transpose_a, transpose_b) == (True, True):
         da = F.batch_matmul(b, dc, True, True)
         db = F.batch_matmul(dc, a, True, True)

--- a/python/src/nnabla/backward_function/bc_add2.py
+++ b/python/src/nnabla/backward_function/bc_add2.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def bc_add2_backward(inputs):
+def bc_add2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("bc_add2_backward is not implemented.")

--- a/python/src/nnabla/backward_function/binary_connect_affine.py
+++ b/python/src/nnabla/backward_function/binary_connect_affine.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def binary_connect_affine_backward(inputs, base_axis=1, quantize_zero_to=1.0):
+def binary_connect_affine_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, quantize_zero_to=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "binary_connect_affine_backward is not implemented.")

--- a/python/src/nnabla/backward_function/binary_connect_convolution.py
+++ b/python/src/nnabla/backward_function/binary_connect_convolution.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def binary_connect_convolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, group=1, quantize_zero_to=1.0):
+def binary_connect_convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, group=1, quantize_zero_to=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "binary_connect_convolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/binary_cross_entropy.py
+++ b/python/src/nnabla/backward_function/binary_cross_entropy.py
@@ -14,17 +14,25 @@
 # limitations under the License.
 
 
-def binary_cross_entropy_backward(inputs):
+def binary_cross_entropy_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     dx0 = dy * (x0 - x1) / (x0 * (1 - x0))
     return dx0, None

--- a/python/src/nnabla/backward_function/binary_error.py
+++ b/python/src/nnabla/backward_function/binary_error.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def binary_error_backward(inputs):
+def binary_error_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("binary_error_backward is not implemented.")

--- a/python/src/nnabla/backward_function/binary_sigmoid.py
+++ b/python/src/nnabla/backward_function/binary_sigmoid.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def binary_sigmoid_backward(inputs):
+def binary_sigmoid_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.less_scalar(F.abs(x0), 1.0)
     m0 = no_grad(m0)
     dx0 = dy * m0 * 0.5

--- a/python/src/nnabla/backward_function/binary_tanh.py
+++ b/python/src/nnabla/backward_function/binary_tanh.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def binary_tanh_backward(inputs):
+def binary_tanh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.less_scalar(F.abs(x0), 1.0)
     m0 = no_grad(m0)
     dx0 = dy * m0

--- a/python/src/nnabla/backward_function/binary_weight_affine.py
+++ b/python/src/nnabla/backward_function/binary_weight_affine.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def binary_weight_affine_backward(inputs, base_axis=1, quantize_zero_to=1.0):
+def binary_weight_affine_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, quantize_zero_to=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "binary_weight_affine_backward is not implemented.")

--- a/python/src/nnabla/backward_function/binary_weight_convolution.py
+++ b/python/src/nnabla/backward_function/binary_weight_convolution.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def binary_weight_convolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, group=1, quantize_zero_to=1.0):
+def binary_weight_convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, group=1, quantize_zero_to=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "binary_weight_convolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/bool_fill.py
+++ b/python/src/nnabla/backward_function/bool_fill.py
@@ -17,18 +17,26 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def bool_fill_backward(inputs, value=0):
+def bool_fill_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, value=0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    m0 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    m0 = inputs[1]
     m1 = F.equal_scalar(m0, 0.0)
     m1 = F.broadcast(m1, dy.shape)
     m1 = no_grad(m1)

--- a/python/src/nnabla/backward_function/bool_gather.py
+++ b/python/src/nnabla/backward_function/bool_gather.py
@@ -16,17 +16,25 @@
 import nnabla.functions as F
 
 
-def bool_gather_backward(inputs):
+def bool_gather_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    m0 = inputs[2]
+    dy = grad_inputs[0]
+    m0 = inputs[1]
     dx = F.bool_scatter(dy, m0)
     dm = None
     return dx, dm

--- a/python/src/nnabla/backward_function/broadcast.py
+++ b/python/src/nnabla/backward_function/broadcast.py
@@ -17,18 +17,26 @@
 import nnabla.functions as F
 
 
-def broadcast_backward(inputs, shape):
+def broadcast_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shape):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x0_shape = x0.shape
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x0_shape = input_shapes[0]
     axis = [i for i, s in enumerate(x0_shape) if s == 1]
     dx0 = F.sum(dy, axis=axis, keepdims=True)
     return dx0

--- a/python/src/nnabla/backward_function/broadcast_to.py
+++ b/python/src/nnabla/backward_function/broadcast_to.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def broadcast_to_backward(inputs, axis=None):
+def broadcast_to_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("broadcast_to_backward is not implemented.")

--- a/python/src/nnabla/backward_function/categorical_cross_entropy.py
+++ b/python/src/nnabla/backward_function/categorical_cross_entropy.py
@@ -19,18 +19,26 @@ import nnabla.functions as F
 from .utils import no_grad, positive_axis
 
 
-def categorical_cross_entropy_backward(inputs, axis=None):
+def categorical_cross_entropy_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    t0 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    t0 = inputs[1]
 
     D = len(x0.shape)
     axis = positive_axis(axis, D)

--- a/python/src/nnabla/backward_function/ceil.py
+++ b/python/src/nnabla/backward_function/ceil.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def ceil_backward(inputs):
+def ceil_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy
     return dx0

--- a/python/src/nnabla/backward_function/celu.py
+++ b/python/src/nnabla/backward_function/celu.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad, create_slice
 
 
-def celu_backward(inputs, alpha=1.0, axis=1):
+def celu_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, alpha=1.0, axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
 
     fstart, fstop, fstep = create_slice(dy.shape, axis, True)
     bstart, bstop, bstep = create_slice(dy.shape, axis, False)

--- a/python/src/nnabla/backward_function/clip_grad_by_norm.py
+++ b/python/src/nnabla/backward_function/clip_grad_by_norm.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def clip_grad_by_norm_backward(inputs, clip_norm=None, axes=None):
+def clip_grad_by_norm_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, clip_norm=None, axes=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     assert False, "This function is not called since the function is the composite of other functions."

--- a/python/src/nnabla/backward_function/clip_grad_by_value.py
+++ b/python/src/nnabla/backward_function/clip_grad_by_value.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def clip_grad_by_value_backward(inputs):
+def clip_grad_by_value_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     assert False, "This function is not called since the function is the composite of other functions."

--- a/python/src/nnabla/backward_function/concatenate.py
+++ b/python/src/nnabla/backward_function/concatenate.py
@@ -111,35 +111,51 @@ class ConcatenateDataGrad(PythonFunction):
             self._func.forward(inputs_fwd, outputs_fwd)
 
 
-def concatenate_backward(inputs, axis=None):
+def concatenate_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
     axis = axis if axis is not None else len(dy.shape) - 1
     ctx = nn.get_current_context()
     df = ConcatenateDataGrad(ctx, axis=axis)
-    df.xshapes = [x.shape for x in inputs[1:]]
+    df.xshapes = input_shapes
     dx0 = df(dy)
     return dx0
 
 
-def concatenate_data_grad_backward(inputs, axis=None):
+def concatenate_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[:-1]
-    dy = inputs[-1]
+    gdx = grad_inputs
+    dy = inputs[0]
     axis = axis if axis is not None else len(dy.shape) - 1
     gdy = F.concatenate(*gdx, axis=axis)
     return gdy

--- a/python/src/nnabla/backward_function/confusion_matrix.py
+++ b/python/src/nnabla/backward_function/confusion_matrix.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def confusion_matrix_backward(inputs, axis=None):
+def confusion_matrix_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("confusion_matrix_backward is not implemented.")

--- a/python/src/nnabla/backward_function/constant.py
+++ b/python/src/nnabla/backward_function/constant.py
@@ -14,10 +14,18 @@
 # limitations under the License.
 
 
-def constant_backward(inputs, val=0, shape=[]):
+def constant_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=0, shape=[]):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:

--- a/python/src/nnabla/backward_function/convolution.py
+++ b/python/src/nnabla/backward_function/convolution.py
@@ -38,19 +38,27 @@ class ConvolutionFilterGrad(LinearFilterGrad):
             ctx, base_axis, pad, stride, dilation, group, channel_last)
 
 
-def convolution_backward(inputs, base_axis=1, pad=None, stride=None,
+def convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None,
                          dilation=None, group=1, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    w0 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    w0 = inputs[1]
 
     base_axis += x0.ndim*(base_axis < 0)
 
@@ -65,31 +73,39 @@ def convolution_backward(inputs, base_axis=1, pad=None, stride=None,
     dx0 = dfx(dy, w0)
     dw0 = dfw(dy, x0)
 
-    if len(inputs) == 4:
+    if len(inputs) == 3:
         if channel_last:
             axes = [i for i in range(dy.ndim - 1)]
         else:
             axes = [i for i in range(0, base_axis)] + \
                                      [i for i in range(base_axis + 1, dy.ndim)]
-        db0 = F.sum(dy, axes, keepdims=False) if len(inputs) == 4 else None
+        db0 = F.sum(dy, axes, keepdims=False) if len(inputs) == 3 else None
         return dx0, dw0, db0
     else:
         return dx0, dw0
 
 
-def convolution_data_grad_backward(inputs, base_axis=1, pad=None, stride=None,
+def convolution_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None,
                                    dilation=None, group=1, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
-    dy = inputs[1]
-    w0 = inputs[2]
+    gdx = grad_inputs[0]
+    dy = inputs[0]
+    w0 = inputs[1]
 
     ctx = nn.get_current_context()
     dfw = ConvolutionFilterGrad(
@@ -102,19 +118,27 @@ def convolution_data_grad_backward(inputs, base_axis=1, pad=None, stride=None,
     return gdy, gw0
 
 
-def convolution_filter_grad_backward(inputs, base_axis=1, pad=None, stride=None,
+def convolution_filter_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None,
                                      dilation=None, group=1, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdw = inputs[0]
-    dy = inputs[1]
-    x0 = inputs[2]
+    gdw = grad_inputs[0]
+    dy = inputs[0]
+    x0 = inputs[1]
 
     ctx = nn.get_current_context()
     dfx = ConvolutionDataGrad(

--- a/python/src/nnabla/backward_function/cos.py
+++ b/python/src/nnabla/backward_function/cos.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def cos_backward(inputs):
+def cos_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = - dy * F.sin(x0)
     return dx0

--- a/python/src/nnabla/backward_function/cosh.py
+++ b/python/src/nnabla/backward_function/cosh.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def cosh_backward(inputs):
+def cosh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * F.sinh(x0)
     return dx0

--- a/python/src/nnabla/backward_function/crelu.py
+++ b/python/src/nnabla/backward_function/crelu.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad, create_slice
 
 
-def crelu_backward(inputs, axis=1):
+def crelu_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
 
     fstart, fstop, fstep = create_slice(dy.shape, axis, True)
     bstart, bstop, bstep = create_slice(dy.shape, axis, False)

--- a/python/src/nnabla/backward_function/cumprod.py
+++ b/python/src/nnabla/backward_function/cumprod.py
@@ -23,15 +23,23 @@
 import nnabla.functions as F
 
 
-def cumprod_backward(inputs, axis=None, exclusive=False, reverse=False):
+def cumprod_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None, exclusive=False, reverse=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("cumprod_backward is not implemented.")

--- a/python/src/nnabla/backward_function/cumsum.py
+++ b/python/src/nnabla/backward_function/cumsum.py
@@ -24,15 +24,23 @@
 import nnabla.functions as F
 
 
-def cumsum_backward(inputs, axis=None, exclusive=False, reverse=False):
+def cumsum_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None, exclusive=False, reverse=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
     dx = F.cumsum(dy, axis=axis, exclusive=exclusive, reverse=not reverse)
     return dx

--- a/python/src/nnabla/backward_function/deconvolution.py
+++ b/python/src/nnabla/backward_function/deconvolution.py
@@ -38,21 +38,29 @@ class DeconvolutionFilterGrad(LinearFilterGrad):
             ctx, base_axis, pad, stride, dilation, group, channel_last, output_padding)
 
 
-def deconvolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, group=1, channel_last=False, output_padding=None):
+def deconvolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, group=1, channel_last=False, output_padding=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    w0 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    w0 = inputs[1]
 
     base_axis += x0.ndim*(base_axis < 0)
-    # base_axis += inputs[0].ndim*(base_axis < 0)
+    # base_axis += grad_inputs[0].ndim*(base_axis < 0)
 
     ctx = nn.get_current_context()
     dfx = DeconvolutionDataGrad(
@@ -65,33 +73,41 @@ def deconvolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=
     dx0 = dfx(dy, w0)
     dw0 = dfw(dy, x0)
     axes = [i for i in range(dy.ndim, base_axis)]
-    db0 = F.sum(dy, axes, keepdims=False) if len(inputs) == 4 else None
+    db0 = F.sum(dy, axes, keepdims=False) if len(inputs) == 3 else None
 
-    if len(inputs) == 4:
+    if len(inputs) == 3:
         if channel_last:
             axes = [i for i in range(dy.ndim - 1)]
         else:
             axes = [i for i in range(0, base_axis)] + \
                                      [i for i in range(base_axis + 1, dy.ndim)]
-        db0 = F.sum(dy, axes, keepdims=False) if len(inputs) == 4 else None
+        db0 = F.sum(dy, axes, keepdims=False) if len(inputs) == 3 else None
         return dx0, dw0, db0
     else:
         return dx0, dw0
 
 
-def deconvolution_data_grad_backward(inputs, base_axis=1, pad=None, stride=None,
+def deconvolution_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None,
                                      dilation=None, group=1, channel_last=False, output_padding=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
-    dy = inputs[1]
-    w0 = inputs[2]
+    gdx = grad_inputs[0]
+    dy = inputs[0]
+    w0 = inputs[1]
 
     ctx = nn.get_current_context()
     dfw = DeconvolutionFilterGrad(
@@ -104,19 +120,27 @@ def deconvolution_data_grad_backward(inputs, base_axis=1, pad=None, stride=None,
     return gdy, gw0
 
 
-def deconvolution_filter_grad_backward(inputs, base_axis=1, pad=None, stride=None,
+def deconvolution_filter_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None,
                                        dilation=None, group=1, channel_last=False, output_padding=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdw = inputs[0]
-    dy = inputs[1]
-    x0 = inputs[2]
+    gdw = grad_inputs[0]
+    dy = inputs[0]
+    x0 = inputs[1]
 
     ctx = nn.get_current_context()
     dfx = DeconvolutionDataGrad(

--- a/python/src/nnabla/backward_function/deformable_convolution.py
+++ b/python/src/nnabla/backward_function/deformable_convolution.py
@@ -21,16 +21,24 @@
 # 3. UPDATE THE MAPPING IF NECESSARY (see function_backward_functions.py.tmpl)
 
 
-def deformable_convolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, group=1, deformable_group=1, channel_last=False):
+def deformable_convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, group=1, deformable_group=1, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "deformable_convolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/depthwise_convolution.py
+++ b/python/src/nnabla/backward_function/depthwise_convolution.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def depthwise_convolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, multiplier=1):
+def depthwise_convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, multiplier=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "depthwise_convolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/depthwise_deconvolution.py
+++ b/python/src/nnabla/backward_function/depthwise_deconvolution.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def depthwise_deconvolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, divisor=1):
+def depthwise_deconvolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, divisor=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "depthwise_deconvolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/dequantize_linear.py
+++ b/python/src/nnabla/backward_function/dequantize_linear.py
@@ -14,18 +14,26 @@
 # limitations under the License.
 
 
-def dequantize_linear_backward(inputs):
+def dequantize_linear_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    s0 = inputs[2]
-    z0 = inputs[3]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    s0 = inputs[1]
+    z0 = inputs[2]
     dx0 = dy * s0
     return dx0, None, None

--- a/python/src/nnabla/backward_function/div2.py
+++ b/python/src/nnabla/backward_function/div2.py
@@ -17,18 +17,27 @@
 from .utils import sum_for_arithmetics
 
 
-def div2_backward(inputs, inplace=False):  # Inplacing is obsoleted.
+# Inplacing is obsoleted.
+def div2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     dx0 = dy / x1
     dx1 = -dy * x0 / x1 ** 2
     dx0 = sum_for_arithmetics(dx0, x0)

--- a/python/src/nnabla/backward_function/elu.py
+++ b/python/src/nnabla/backward_function/elu.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def elu_backward(inputs, alpha=1.0):
+def elu_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, alpha=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.greater_scalar(x0, 0)
     m1 = 1 - m0
     m0 = no_grad(m0)

--- a/python/src/nnabla/backward_function/embed.py
+++ b/python/src/nnabla/backward_function/embed.py
@@ -60,38 +60,54 @@ class EmbedFilterGrad(LinearFilterGrad):
             self._linear.forward(inputs_fwd, outputs_fwd)
 
 
-def embed_backward(inputs):
+def embed_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    w0 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    w0_shape = input_shapes[1]
 
     ctx = nn.get_current_context()
     dfw = EmbedFilterGrad(ctx)
-    dfw.wshape = w0.shape
+    dfw.wshape = w0_shape
 
     dw0 = dfw(dy, x0)
     return None, dw0
 
 
-def embed_filter_grad_backward(inputs):
+def embed_filter_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdw = inputs[0]
-    dy = inputs[1]
-    x0 = inputs[2]
+    gdw = grad_inputs[0]
+    dy = inputs[0]
+    x0 = inputs[1]
     gdy = F.embed(x0, gdw)
     return gdy, None

--- a/python/src/nnabla/backward_function/epsilon_insensitive_loss.py
+++ b/python/src/nnabla/backward_function/epsilon_insensitive_loss.py
@@ -19,18 +19,26 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def epsilon_insensitive_loss_backward(inputs, epsilon):
+def epsilon_insensitive_loss_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, epsilon):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     d = x0 - x1
     m0 = F.greater_scalar(F.abs(d), epsilon)
     m1 = 1 - m0

--- a/python/src/nnabla/backward_function/equal.py
+++ b/python/src/nnabla/backward_function/equal.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def equal_backward(inputs):
+def equal_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/equal_scalar.py
+++ b/python/src/nnabla/backward_function/equal_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def equal_scalar_backward(inputs, val=1):
+def equal_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/erf.py
+++ b/python/src/nnabla/backward_function/erf.py
@@ -1,4 +1,4 @@
-# Copyright 2021 Sony Corporation.
+# Copyright 2022 Sony Group Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -24,16 +24,24 @@ import nnabla.functions as F
 import numpy as np
 
 
-def erf_backward(inputs):
+def erf_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = 2.0 / np.sqrt(np.pi) * F.exp(-(x0 ** 2)) * dy
     return dx0

--- a/python/src/nnabla/backward_function/exp.py
+++ b/python/src/nnabla/backward_function/exp.py
@@ -14,19 +14,24 @@
 # limitations under the License.
 
 
-from .utils import get_output
-
-
-def exp_backward(inputs):
+def exp_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "Exp")
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    y0 = outputs[0]
     return dy * y0

--- a/python/src/nnabla/backward_function/fft.py
+++ b/python/src/nnabla/backward_function/fft.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 import numpy as np
 
 
-def fft_backward(inputs, signal_ndim, normalized=False):
+def fft_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, signal_ndim, normalized=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = F.ifft(dy, signal_ndim, normalized)
     if not normalized:
         n = np.prod(dy.shape[- signal_ndim - 1:-1])

--- a/python/src/nnabla/backward_function/fixed_point_quantize.py
+++ b/python/src/nnabla/backward_function/fixed_point_quantize.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def fixed_point_quantize_backward(inputs, sign=True, n=8, delta=0.0625, ste_fine_grained=True):
+def fixed_point_quantize_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, sign=True, n=8, delta=0.0625, ste_fine_grained=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "fixed_point_quantize_backward is not implemented.")

--- a/python/src/nnabla/backward_function/flip.py
+++ b/python/src/nnabla/backward_function/flip.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def flip_backward(inputs, axes=None):
+def flip_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("flip_backward is not implemented.")

--- a/python/src/nnabla/backward_function/floor.py
+++ b/python/src/nnabla/backward_function/floor.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def floor_backward(inputs):
+def floor_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy
     return dx0

--- a/python/src/nnabla/backward_function/fused_convolution.py
+++ b/python/src/nnabla/backward_function/fused_convolution.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def fused_convolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, group=1, channel_last=False, decay_rate=0.9, eps=1e-05, batch_stat=True, nonlinearity='relu', nonlinearity_args=list()):
+def fused_convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, group=1, channel_last=False, decay_rate=0.9, eps=1e-05, batch_stat=True, nonlinearity='relu', nonlinearity_args=list()):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("fused_convolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/gather.py
+++ b/python/src/nnabla/backward_function/gather.py
@@ -21,15 +21,23 @@
 # 3. UPDATE THE MAPPING IF NECESSARY (see function_backward_functions.py.tmpl)
 
 
-def gather_backward(inputs, axis=None, batch_dims=None):
+def gather_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None, batch_dims=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("gather_backward is not implemented.")

--- a/python/src/nnabla/backward_function/gather_nd.py
+++ b/python/src/nnabla/backward_function/gather_nd.py
@@ -17,17 +17,25 @@
 import nnabla.functions as F
 
 
-def gather_nd_backward(inputs):
+def gather_nd_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    idx = inputs[2]
-    dx0 = F.scatter_nd(dy, idx, shape=x0.shape, add=True)
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
+    idx = inputs[1]
+    dx0 = F.scatter_nd(dy, idx, shape=x0_shape, add=True)
     return dx0, None

--- a/python/src/nnabla/backward_function/gelu.py
+++ b/python/src/nnabla/backward_function/gelu.py
@@ -18,17 +18,25 @@ import nnabla.functions as F
 import numpy as np
 
 
-def gelu_backward(inputs):
+def gelu_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     c1 = 0.044715
     c3 = 0.134145
     v = np.sqrt(2 / np.pi) * (x0 + c1 * x0 ** 3)

--- a/python/src/nnabla/backward_function/global_average_pooling.py
+++ b/python/src/nnabla/backward_function/global_average_pooling.py
@@ -28,33 +28,49 @@ class GlobalAveragePoolingDataGrad(UnaryDataGrad):
         self._func = _F.GlobalAveragePooling(ctx)
 
 
-def global_average_pooling_backward(inputs):
+def global_average_pooling_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     pool = GlobalAveragePoolingDataGrad(ctx)
-    pool.xshape = x0.shape
+    pool.xshape = x0_shape
     dx0 = pool(dy)
     return dx0
 
 
-def global_average_pooling_data_grad_backward(inputs):
+def global_average_pooling_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.global_average_pooling(gdx)
     return gdy

--- a/python/src/nnabla/backward_function/greater.py
+++ b/python/src/nnabla/backward_function/greater.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def greater_backward(inputs):
+def greater_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/greater_equal.py
+++ b/python/src/nnabla/backward_function/greater_equal.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def greater_equal_backward(inputs):
+def greater_equal_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/greater_equal_scalar.py
+++ b/python/src/nnabla/backward_function/greater_equal_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def greater_equal_scalar_backward(inputs, val=1):
+def greater_equal_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/greater_scalar.py
+++ b/python/src/nnabla/backward_function/greater_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def greater_scalar_backward(inputs, val=1):
+def greater_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/group_normalization.py
+++ b/python/src/nnabla/backward_function/group_normalization.py
@@ -19,19 +19,27 @@ from functools import partial
 from .tensor_normalization import tensor_normalization_backward
 
 
-def group_normalization_backward(inputs, num_groups=None, channel_axis=None, batch_axis=(0,), eps=1e-05, no_scale=False, no_bias=False):
+def group_normalization_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, num_groups=None, channel_axis=None, batch_axis=(0,), eps=1e-05, no_scale=False, no_bias=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x = inputs[1]
+    dy = grad_inputs[0]
+    x = inputs[0]
     g = num_groups
-    g_idx = 2 if no_bias else 3
+    g_idx = 1 if no_bias else 2
     if not no_scale:
         gamma = inputs[g_idx]
 
@@ -58,7 +66,8 @@ def group_normalization_backward(inputs, num_groups=None, channel_axis=None, bat
     xg = x.reshape(xg_shape)
 
     axes = list(set(range(xg.ndim)) - set(batch_axis + [channel_axis]))
-    grads, xn = tensor_normalization_backward([dyg, xg], axes, eps, True, True)
+    grads, xn = tensor_normalization_backward(
+        [dyg], [xg], [xg_shape], [None], [None], axes, eps, True, True)
 
     dx = grads[0].reshape(x_shape)  # Restore shape
     res_grads = (dx,)

--- a/python/src/nnabla/backward_function/gru.py
+++ b/python/src/nnabla/backward_function/gru.py
@@ -18,10 +18,18 @@ import nnabla as nn
 from nnabla.utils.rnn import _create_fixed_length_gru
 
 
-def gru_backward(inputs, num_layers=1, dropout=None, bidirectional=False, training=True):
+def gru_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, num_layers=1, dropout=None, bidirectional=False, training=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
@@ -30,18 +38,18 @@ def gru_backward(inputs, num_layers=1, dropout=None, bidirectional=False, traini
     if dropout != 0.0:
         raise ValueError("Dropout must be 0.0")
 
-    dys = inputs[0]
-    dhn = inputs[1]
-    xs0 = inputs[2]
-    h0 = inputs[3]
-    w0 = inputs[4]
+    dys = grad_inputs[0]
+    dhn = grad_inputs[1]
+    xs0 = inputs[0]
+    h0 = inputs[1]
+    w0 = inputs[2]
 
     if num_layers == 1:
         w = None
-        b = inputs[5] if len(inputs) == 6 else None
+        b = inputs[3] if len(inputs) == 4 else None
     else:
-        w = inputs[5]
-        b = inputs[6] if len(inputs) == 7 else None
+        w = inputs[3]
+        b = inputs[4] if len(inputs) == 5 else None
     num_directions = 2 if bidirectional else 1
     with_bias = True if b else False
 

--- a/python/src/nnabla/backward_function/hard_sigmoid.py
+++ b/python/src/nnabla/backward_function/hard_sigmoid.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def hard_sigmoid_backward(inputs):
+def hard_sigmoid_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.greater_scalar(x0, -2.5)
     m1 = F.less_scalar(x0, 2.5)
     m01 = m0 * m1

--- a/python/src/nnabla/backward_function/hard_tanh.py
+++ b/python/src/nnabla/backward_function/hard_tanh.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def hard_tanh_backward(inputs):
+def hard_tanh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.greater_equal_scalar(x0, -1)
     m1 = F.less_equal_scalar(x0, 1)
     m01 = m0 * m1

--- a/python/src/nnabla/backward_function/huber_loss.py
+++ b/python/src/nnabla/backward_function/huber_loss.py
@@ -19,18 +19,26 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def huber_loss_backward(inputs, delta=1.0):
+def huber_loss_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, delta=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     d = x0 - x1
     m0 = F.less_scalar(F.abs(d), delta)
     m1 = 1 - m0

--- a/python/src/nnabla/backward_function/identity.py
+++ b/python/src/nnabla/backward_function/identity.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def identity_backward(inputs):
+def identity_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy
     return dx0

--- a/python/src/nnabla/backward_function/ifft.py
+++ b/python/src/nnabla/backward_function/ifft.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 import numpy as np
 
 
-def ifft_backward(inputs, signal_ndim, normalized=False):
+def ifft_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, signal_ndim, normalized=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = F.fft(dy, signal_ndim, normalized)
     if not normalized:
         n = np.prod(dy.shape[- signal_ndim - 1:-1])

--- a/python/src/nnabla/backward_function/image_augmentation.py
+++ b/python/src/nnabla/backward_function/image_augmentation.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def image_augmentation_backward(inputs, shape=None, pad=(0, 0), min_scale=1.0, max_scale=1.0, angle=0.0, aspect_ratio=1.0, distortion=0.0, flip_lr=False, flip_ud=False, brightness=0.0, brightness_each=False, contrast=1.0, contrast_center=0.0, contrast_each=False, noise=0.0, seed=-1):
+def image_augmentation_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shape=None, pad=(0, 0), min_scale=1.0, max_scale=1.0, angle=0.0, aspect_ratio=1.0, distortion=0.0, flip_lr=False, flip_ud=False, brightness=0.0, brightness_each=False, contrast=1.0, contrast_center=0.0, contrast_each=False, noise=0.0, seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "image_augmentation_backward is not implemented.")

--- a/python/src/nnabla/backward_function/inq_affine.py
+++ b/python/src/nnabla/backward_function/inq_affine.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def inq_affine_backward(inputs, base_axis=1, num_bits=4, inq_iterations=(), selection_algorithm='largest_abs', seed=-1):
+def inq_affine_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, num_bits=4, inq_iterations=(), selection_algorithm='largest_abs', seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("inq_affine_backward is not implemented.")

--- a/python/src/nnabla/backward_function/inq_convolution.py
+++ b/python/src/nnabla/backward_function/inq_convolution.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def inq_convolution_backward(inputs, base_axis=1, pad=None, stride=None, dilation=None, group=1, num_bits=4, inq_iterations=(), selection_algorithm='largest_abs', seed=-1):
+def inq_convolution_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, pad=None, stride=None, dilation=None, group=1, num_bits=4, inq_iterations=(), selection_algorithm='largest_abs', seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("inq_convolution_backward is not implemented.")

--- a/python/src/nnabla/backward_function/interpolate.py
+++ b/python/src/nnabla/backward_function/interpolate.py
@@ -30,37 +30,54 @@ class InterpolateDataGrad(UnaryDataGrad):
                                     half_pixel, half_pixel_for_nn, channel_last)
 
 
-def interpolate_backward(inputs, output_size, mode, align_corners=True,
+def interpolate_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, output_size, mode, align_corners=True,
                          half_pixel=False, half_pixel_for_nn=False, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     df = InterpolateDataGrad(ctx, output_size, mode, align_corners,
                              half_pixel, half_pixel_for_nn, channel_last)
-    df.xshape = x0.shape
+    df.xshape = x0_shape
     dx0 = df(dy)
     return dx0
 
 
-def interpolate_data_grad_backward(inputs, output_size, mode, align_corners=True,
+def interpolate_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes,
+                                   output_size, mode, align_corners=True,
                                    half_pixel=False, half_pixel_for_nn=False, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.interpolate(gdx, None, output_size, mode, align_corners,
                         half_pixel, half_pixel_for_nn, channel_last)
     return gdy

--- a/python/src/nnabla/backward_function/isinf.py
+++ b/python/src/nnabla/backward_function/isinf.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def isinf_backward(inputs):
+def isinf_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/isnan.py
+++ b/python/src/nnabla/backward_function/isnan.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def isnan_backward(inputs):
+def isnan_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/istft.py
+++ b/python/src/nnabla/backward_function/istft.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def istft_backward(inputs, window_size, stride, fft_size, window_type='hanning', center=True, pad_mode='reflect', as_stft_backward=False):
+def istft_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, window_size, stride, fft_size, window_type='hanning', center=True, pad_mode='reflect', as_stft_backward=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
 
     dx_r, dx_i = F.stft(dy, window_size, stride, fft_size, window_type,
                         center, pad_mode, as_istft_backward=not as_stft_backward)

--- a/python/src/nnabla/backward_function/kl_multinomial.py
+++ b/python/src/nnabla/backward_function/kl_multinomial.py
@@ -17,18 +17,26 @@
 import nnabla.functions as F
 
 
-def kl_multinomial_backward(inputs, base_axis=1):
+def kl_multinomial_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    p = inputs[1]
-    q = inputs[2]
+    dy = grad_inputs[0]
+    p = inputs[0]
+    q = inputs[1]
     base_axis += p.ndim*(base_axis < 0)
     reshape = list(dy.shape[:base_axis]) + \
         [1 for _ in range(p.ndim - base_axis)]

--- a/python/src/nnabla/backward_function/layer_normalization.py
+++ b/python/src/nnabla/backward_function/layer_normalization.py
@@ -18,18 +18,26 @@ import nnabla.functions as F
 from .tensor_normalization import tensor_normalization_backward
 
 
-def layer_normalization_backward(inputs, batch_axis=(0,), eps=1e-05, no_scale=False, no_bias=False):
+def layer_normalization_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, batch_axis=(0,), eps=1e-05, no_scale=False, no_bias=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x = inputs[1]
-    g_idx = 2 if no_bias else 3
+    dy = grad_inputs[0]
+    x = inputs[0]
+    g_idx = 1 if no_bias else 2
     if not no_scale:
         gamma = inputs[g_idx]
 
@@ -39,7 +47,7 @@ def layer_normalization_backward(inputs, batch_axis=(0,), eps=1e-05, no_scale=Fa
     axes = list(set(range(x.ndim)) - set(batch_axis))
     dy_tn = dy * gamma if not no_scale else dy
     grads, xn = tensor_normalization_backward(
-        [dy_tn, x], axes, eps, True, True)
+        [dy_tn], [x], [x.shape], [None], [None], axes, eps, True, True)
     dx = grads[0]
     res_grads = (dx,)
 

--- a/python/src/nnabla/backward_function/less.py
+++ b/python/src/nnabla/backward_function/less.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def less_backward(inputs):
+def less_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/less_equal.py
+++ b/python/src/nnabla/backward_function/less_equal.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def less_equal_backward(inputs):
+def less_equal_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/less_equal_scalar.py
+++ b/python/src/nnabla/backward_function/less_equal_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def less_equal_scalar_backward(inputs, val=1):
+def less_equal_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/less_scalar.py
+++ b/python/src/nnabla/backward_function/less_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def less_scalar_backward(inputs, val=1):
+def less_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/linspace.py
+++ b/python/src/nnabla/backward_function/linspace.py
@@ -23,13 +23,21 @@
 import nnabla.functions as F
 
 
-def linspace_backward(inputs, start, stop, num):
+def linspace_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, start, stop, num):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/log.py
+++ b/python/src/nnabla/backward_function/log.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def log_backward(inputs):
+def log_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy / x0
     return dx0

--- a/python/src/nnabla/backward_function/log_sigmoid.py
+++ b/python/src/nnabla/backward_function/log_sigmoid.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def log_sigmoid_backward(inputs):
+def log_sigmoid_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * (1 - F.sigmoid(x0))
     return dx0

--- a/python/src/nnabla/backward_function/log_softmax.py
+++ b/python/src/nnabla/backward_function/log_softmax.py
@@ -15,22 +15,30 @@
 
 
 import nnabla.functions as F
-from .utils import positive_axis, get_output
+from .utils import positive_axis
 
 
-def log_softmax_backward(inputs, axis=None):
+def log_softmax_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "LogSoftmax")
-    D = len(x0.shape)
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
+    y0 = outputs[0]
+    D = len(x0_shape)
     axis = positive_axis(axis, D)
     dx0 = dy - F.exp(y0) * F.sum(dy, axis=axis, keepdims=True)
     return dx0

--- a/python/src/nnabla/backward_function/logical_and.py
+++ b/python/src/nnabla/backward_function/logical_and.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def logical_and_backward(inputs):
+def logical_and_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/logical_and_scalar.py
+++ b/python/src/nnabla/backward_function/logical_and_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def logical_and_scalar_backward(inputs, val):
+def logical_and_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/logical_not.py
+++ b/python/src/nnabla/backward_function/logical_not.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def logical_not_backward(inputs):
+def logical_not_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/logical_or.py
+++ b/python/src/nnabla/backward_function/logical_or.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def logical_or_backward(inputs):
+def logical_or_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/logical_or_scalar.py
+++ b/python/src/nnabla/backward_function/logical_or_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def logical_or_scalar_backward(inputs, val):
+def logical_or_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/logical_xor.py
+++ b/python/src/nnabla/backward_function/logical_xor.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def logical_xor_backward(inputs):
+def logical_xor_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/logical_xor_scalar.py
+++ b/python/src/nnabla/backward_function/logical_xor_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def logical_xor_scalar_backward(inputs, val):
+def logical_xor_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/lstm.py
+++ b/python/src/nnabla/backward_function/lstm.py
@@ -18,10 +18,18 @@ import nnabla as nn
 from nnabla.utils.rnn import _create_fixed_length_lstm
 
 
-def lstm_backward(inputs, num_layers=1, dropout=None, bidirectional=False, training=True):
+def lstm_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, num_layers=1, dropout=None, bidirectional=False, training=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
@@ -30,20 +38,20 @@ def lstm_backward(inputs, num_layers=1, dropout=None, bidirectional=False, train
     if dropout != 0.0:
         raise ValueError("Dropout must be 0.0")
 
-    dys = inputs[0]
-    dhn = inputs[1]
-    dcn = inputs[2]
-    xs0 = inputs[3]
-    h0 = inputs[4]
-    c0 = inputs[5]
-    w0 = inputs[6]
+    dys = grad_inputs[0]
+    dhn = grad_inputs[1]
+    dcn = grad_inputs[2]
+    xs0 = inputs[0]
+    h0 = inputs[1]
+    c0 = inputs[2]
+    w0 = inputs[3]
 
     if num_layers == 1:
         w = None
-        b = inputs[7] if len(inputs) == 8 else None
+        b = inputs[4] if len(inputs) == 5 else None
     else:
-        w = inputs[7]
-        b = inputs[8] if len(inputs) == 9 else None
+        w = inputs[4]
+        b = inputs[5] if len(inputs) == 6 else None
     num_directions = 2 if bidirectional else 1
     with_bias = True if b else False
 

--- a/python/src/nnabla/backward_function/matrix_diag.py
+++ b/python/src/nnabla/backward_function/matrix_diag.py
@@ -17,15 +17,23 @@
 import nnabla.functions as F
 
 
-def matrix_diag_backward(inputs):
+def matrix_diag_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
     dx0 = F.matrix_diag_part(dy)
     return dx0

--- a/python/src/nnabla/backward_function/matrix_diag_part.py
+++ b/python/src/nnabla/backward_function/matrix_diag_part.py
@@ -17,15 +17,23 @@
 import nnabla.functions as F
 
 
-def matrix_diag_part_backward(inputs):
+def matrix_diag_part_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
     dx0 = F.matrix_diag(dy)
     return dx0

--- a/python/src/nnabla/backward_function/max.py
+++ b/python/src/nnabla/backward_function/max.py
@@ -16,21 +16,31 @@
 
 import nnabla.functions as F
 
-from .utils import no_grad, force_list, get_output
+from .utils import no_grad, force_list
 
 
-def max_backward(inputs, axes=None, keep_dims=False, with_index=False, only_index=False):
+def max_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=None, keep_dims=False, with_index=False, only_index=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "Max")
+    # In auto-forward mode, the dynamic clear of inputs[0] and outputs[0] are
+    # blocked by Max::auto_grad_depends_input/output_data.
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    y0 = outputs[0]
     if keep_dims:
         y0 = F.broadcast(y0, x0.shape)
         dy = F.broadcast(dy, x0.shape)

--- a/python/src/nnabla/backward_function/max_pooling.py
+++ b/python/src/nnabla/backward_function/max_pooling.py
@@ -17,21 +17,29 @@ import nnabla as nn
 import nnabla.functions as F
 
 
-def max_pooling_backward(inputs, kernel, stride=None, ignore_border=True, pad=None, channel_last=False):
+def max_pooling_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, stride=None, ignore_border=True, pad=None, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
     # this is ricky to support inputs of both y = f(x) and gdy = gdf(gdx, x0)
-    dy = inputs[0]
-    x0 = inputs[-1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx = F.max_pooling_backward(
         dy, x0, kernel, stride, ignore_border, pad, channel_last)
-    if len(inputs) == 2:  # dx = df(dy, x)
+    if len(grad_inputs) + len(inputs) == 2:  # dx = df(dy, x)
         return dx
     # ddy = ddf(ddx, dy, x) since x is needed to compute max indices
     else:

--- a/python/src/nnabla/backward_function/max_pooling_backward.py
+++ b/python/src/nnabla/backward_function/max_pooling_backward.py
@@ -124,19 +124,27 @@ class MaxPoolingBackwardDataGrad(PythonFunction):
             self._func.forward(inputs_fwd, outputs_fwd)
 
 
-def max_pooling_backward_backward(inputs, kernel, stride=None,
+def max_pooling_backward_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, stride=None,
                                   ignore_border=True, pad=None, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
-    dy = inputs[1]
-    x0 = inputs[2]
+    gdx = grad_inputs[0]
+    dy = inputs[0]
+    x0 = inputs[1]
     ctx = nn.get_current_context()
     df = MaxPoolingBackwardDataGrad(
         ctx, kernel, stride, ignore_border, pad, channel_last)

--- a/python/src/nnabla/backward_function/maximum2.py
+++ b/python/src/nnabla/backward_function/maximum2.py
@@ -19,18 +19,26 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def maximum2_backward(inputs):
+def maximum2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     m0 = F.greater(x0, x1)
     m1 = 1 - m0
     m0 = no_grad(m0)

--- a/python/src/nnabla/backward_function/maximum_scalar.py
+++ b/python/src/nnabla/backward_function/maximum_scalar.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def maximum_scalar_backward(inputs, val=1.0):
+def maximum_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.greater_scalar(x0, val)
     m0 = no_grad(m0)
     dx0 = dy * m0

--- a/python/src/nnabla/backward_function/mean.py
+++ b/python/src/nnabla/backward_function/mean.py
@@ -20,14 +20,15 @@ import numpy as np
 from .utils import force_list
 
 
-def mean_backward(inputs, axes=None, keep_dims=False):
-    dy = inputs[0]
-    x0 = inputs[1]
-    axes = [i for i in range(x0.ndim)] if axes is None else force_list(axes)
-    n = np.prod([s if i in axes else 1 for i, s in enumerate(x0.shape)])
+def mean_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=None, keep_dims=False):
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
+    x0_ndim = len(x0_shape)
+    axes = [i for i in range(x0_ndim)] if axes is None else force_list(axes)
+    n = np.prod([s if i in axes else 1 for i, s in enumerate(x0_shape)])
     if keep_dims:
-        dx0 = F.broadcast(dy, x0.shape)
+        dx0 = F.broadcast(dy, x0_shape)
     else:
-        shape = [1 if i in axes else s for i, s in enumerate(x0.shape)]
-        dx0 = F.broadcast(F.reshape(dy, shape, inplace=False), x0.shape)
+        shape = [1 if i in axes else s for i, s in enumerate(x0_shape)]
+        dx0 = F.broadcast(F.reshape(dy, shape, inplace=False), x0_shape)
     return dx0 / n

--- a/python/src/nnabla/backward_function/mean_subtraction.py
+++ b/python/src/nnabla/backward_function/mean_subtraction.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def mean_subtraction_backward(inputs, base_axis=1, update_running_mean=True):
+def mean_subtraction_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, update_running_mean=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("mean_subtraction_backward is not implemented.")

--- a/python/src/nnabla/backward_function/meshgrid.py
+++ b/python/src/nnabla/backward_function/meshgrid.py
@@ -23,15 +23,23 @@
 import nnabla.functions as F
 
 
-def meshgrid_backward(inputs, ij_indexing=False):
+def meshgrid_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, ij_indexing=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("meshgrid_backward is not implemented.")

--- a/python/src/nnabla/backward_function/min.py
+++ b/python/src/nnabla/backward_function/min.py
@@ -16,21 +16,31 @@
 
 import nnabla.functions as F
 
-from .utils import no_grad, force_list, get_output
+from .utils import no_grad, force_list
 
 
-def min_backward(inputs, axes=None, keep_dims=False, with_index=False, only_index=False):
+def min_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=None, keep_dims=False, with_index=False, only_index=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "Min")
+    # In auto-forward mode, the dynamic clear of inputs[0] and outputs[0] are
+    # blocked by Min::auto_grad_depends_input/output_data.
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    y0 = outputs[0]
     if keep_dims:
         y0 = F.broadcast(y0, x0.shape)
         dy = F.broadcast(dy, x0.shape)

--- a/python/src/nnabla/backward_function/min_max_quantize.py
+++ b/python/src/nnabla/backward_function/min_max_quantize.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def min_max_quantize_backward(inputs, decay=0.999, x_min_max=False, ema=False, ste_fine_grained=True, eps=0.01):
+def min_max_quantize_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, decay=0.999, x_min_max=False, ema=False, ste_fine_grained=True, eps=0.01):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("min_max_quantize_backward is not implemented.")

--- a/python/src/nnabla/backward_function/minimum2.py
+++ b/python/src/nnabla/backward_function/minimum2.py
@@ -19,18 +19,26 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def minimum2_backward(inputs):
+def minimum2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     m0 = F.less(x0, x1)
     m1 = 1 - m0
     m0 = no_grad(m0)

--- a/python/src/nnabla/backward_function/minimum_scalar.py
+++ b/python/src/nnabla/backward_function/minimum_scalar.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def minimum_scalar_backward(inputs, val=1.0):
+def minimum_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.less_scalar(x0, val)
     m0 = no_grad(m0)
     dx = dy * m0

--- a/python/src/nnabla/backward_function/mish.py
+++ b/python/src/nnabla/backward_function/mish.py
@@ -21,15 +21,23 @@
 # 3. UPDATE THE MAPPING IF NECESSARY (see function_backward_functions.py.tmpl)
 
 
-def mish_backward(inputs):
+def mish_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("mish_backward is not implemented.")

--- a/python/src/nnabla/backward_function/mul2.py
+++ b/python/src/nnabla/backward_function/mul2.py
@@ -17,18 +17,27 @@
 from .utils import sum_for_arithmetics
 
 
-def mul2_backward(inputs, inplace=False):  # Inplacing is obsoleted.
+# Inplacing is obsoleted.
+def mul2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     dx0 = dy * x1
     dx1 = dy * x0
     dx0 = sum_for_arithmetics(dx0, x0)

--- a/python/src/nnabla/backward_function/mul_n.py
+++ b/python/src/nnabla/backward_function/mul_n.py
@@ -17,17 +17,25 @@
 import nnabla.functions as F
 
 
-def mul_n_backward(inputs):
+def mul_n_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x_list = inputs[1:]
+    dy = grad_inputs[0]
+    x_list = inputs
     y = F.mul_n(*x_list)
     dx_list = [dy * y / x for x in x_list]
     return dx_list

--- a/python/src/nnabla/backward_function/mul_scalar.py
+++ b/python/src/nnabla/backward_function/mul_scalar.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def mul_scalar_backward(inputs, val=1, inplace=False):
+def mul_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
     dx0 = dy * val
     return dx0

--- a/python/src/nnabla/backward_function/nms_detection2d.py
+++ b/python/src/nnabla/backward_function/nms_detection2d.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def nms_detection2d_backward(inputs, thresh=None, nms=None, nms_per_class=None):
+def nms_detection2d_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, thresh=None, nms=None, nms_per_class=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("nms_detection2d_backward is not implemented.")

--- a/python/src/nnabla/backward_function/norm.py
+++ b/python/src/nnabla/backward_function/norm.py
@@ -18,17 +18,25 @@ import nnabla.functions as F
 from .utils import force_list, no_grad
 
 
-def norm_backward(inputs, p=None, axes=None, keep_dims=False):
+def norm_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, p=None, axes=None, keep_dims=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
 
     if p is None:
         p = 2.0

--- a/python/src/nnabla/backward_function/norm_normalization.py
+++ b/python/src/nnabla/backward_function/norm_normalization.py
@@ -18,17 +18,25 @@ import nnabla.functions as F
 from .utils import force_list, no_grad, sum_for_arithmetics
 
 
-def norm_normalization_backward(inputs, p=None, axes=None, eps=1e-12):
+def norm_normalization_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, p=None, axes=None, eps=1e-12):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
 
     if p is None:
         p = 2.0

--- a/python/src/nnabla/backward_function/not_equal.py
+++ b/python/src/nnabla/backward_function/not_equal.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def not_equal_backward(inputs):
+def not_equal_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/not_equal_scalar.py
+++ b/python/src/nnabla/backward_function/not_equal_scalar.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def not_equal_scalar_backward(inputs, val=1):
+def not_equal_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/one_hot.py
+++ b/python/src/nnabla/backward_function/one_hot.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def one_hot_backward(inputs, shape):
+def one_hot_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shape):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    return [None] * len(inputs)
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/pack_padded_sequence.py
+++ b/python/src/nnabla/backward_function/pack_padded_sequence.py
@@ -21,16 +21,24 @@
 # 3. UPDATE THE MAPPING IF NECESSARY (see function_backward_functions.py.tmpl)
 
 
-def pack_padded_sequence_backward(inputs, batch_first=False):
+def pack_padded_sequence_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, batch_first=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "pack_padded_sequence_backward is not implemented.")

--- a/python/src/nnabla/backward_function/pad.py
+++ b/python/src/nnabla/backward_function/pad.py
@@ -28,10 +28,18 @@ class PadDataGrad(UnaryDataGrad):
         self._func = _F.Pad(ctx, pad_width, mode, constant_value)
 
 
-def pad_backward(inputs, pad_width, mode='constant', constant_value=0):
+def pad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, pad_width, mode='constant', constant_value=0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
@@ -40,20 +48,28 @@ def pad_backward(inputs, pad_width, mode='constant', constant_value=0):
     if mode != "constant":
         raise NotImplementedError(
             "{}_backward (mode!=constant) is not implemented.".format(func['snake_name']))
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     # constant value is always zero after 1st-order derivative
     df = PadDataGrad(ctx, pad_width, mode, constant_value=0)
-    df.xshape = x0.shape
+    df.xshape = x0_shape
     dx0 = df(dy)
     return dx0
 
 
-def pad_data_grad_backward(inputs, pad_width, mode='constant', constant_value=0):
+def pad_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, pad_width, mode='constant', constant_value=0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
@@ -62,6 +78,6 @@ def pad_data_grad_backward(inputs, pad_width, mode='constant', constant_value=0)
     if mode != "constant":
         raise NotImplementedError(
             "{}_backward (mode!=constant) is not implemented.".format(func['snake_name']))
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.pad(gdx, pad_width, mode, constant_value=0)
     return gdy

--- a/python/src/nnabla/backward_function/pad_packed_sequence.py
+++ b/python/src/nnabla/backward_function/pad_packed_sequence.py
@@ -21,16 +21,24 @@
 # 3. UPDATE THE MAPPING IF NECESSARY (see function_backward_functions.py.tmpl)
 
 
-def pad_packed_sequence_backward(inputs, batch_first=False, padding_value=None, total_length=None):
+def pad_packed_sequence_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, batch_first=False, padding_value=None, total_length=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "pad_packed_sequence_backward is not implemented.")

--- a/python/src/nnabla/backward_function/patch_correlation.py
+++ b/python/src/nnabla/backward_function/patch_correlation.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def patch_correlation_backward(inputs, patch=(1, 1), shift=(0, 0), patch_step=(1, 1), shift_step=(1, 1), padding=(0, 0, 0, 0)):
+def patch_correlation_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, patch=(1, 1), shift=(0, 0), patch_step=(1, 1), shift_step=(1, 1), padding=(0, 0, 0, 0)):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("patch_correlation_backward is not implemented.")

--- a/python/src/nnabla/backward_function/pow2.py
+++ b/python/src/nnabla/backward_function/pow2.py
@@ -17,18 +17,27 @@
 import nnabla.functions as F
 
 
-def pow2_backward(inputs, inplace=False):  # Inplacing is obsoleted.
+# Inplacing is obsoleted.
+def pow2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     dx0 = dy * x1 * x0 ** (x1 - 1)
     dx1 = dy * (x0 ** x1) * F.log(x0)
     return dx0, dx1

--- a/python/src/nnabla/backward_function/pow2_quantize.py
+++ b/python/src/nnabla/backward_function/pow2_quantize.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def pow2_quantize_backward(inputs, sign=True, with_zero=True, n=8, m=1, ste_fine_grained=True):
+def pow2_quantize_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, sign=True, with_zero=True, n=8, m=1, ste_fine_grained=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("pow2_quantize_backward is not implemented.")

--- a/python/src/nnabla/backward_function/pow_scalar.py
+++ b/python/src/nnabla/backward_function/pow_scalar.py
@@ -15,16 +15,24 @@
 
 
 # Inplacing is obsoleted.
-def pow_scalar_backward(inputs, val=1, inplace=False):
+def pow_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * val * x0 ** (val - 1)
     return dx0

--- a/python/src/nnabla/backward_function/prelu.py
+++ b/python/src/nnabla/backward_function/prelu.py
@@ -19,18 +19,26 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def prelu_backward(inputs, base_axis=1):
+def prelu_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    w0 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    w0 = inputs[1]
 
     base_axis += x0.ndim*(base_axis < 0)
     m0 = F.greater_scalar(x0, 0)

--- a/python/src/nnabla/backward_function/prod.py
+++ b/python/src/nnabla/backward_function/prod.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import force_list
 
 
-def prod_backward(inputs, axes=None, keep_dims=False):
+def prod_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=None, keep_dims=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     axes = [i for i in range(x0.ndim)] if axes is None else force_list(axes)
     y0 = F.prod(x0, axes, keep_dims)
     if keep_dims:

--- a/python/src/nnabla/backward_function/prune.py
+++ b/python/src/nnabla/backward_function/prune.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def prune_backward(inputs, rate=0.9):
+def prune_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, rate=0.9):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy
     return dx0

--- a/python/src/nnabla/backward_function/quantize_linear.py
+++ b/python/src/nnabla/backward_function/quantize_linear.py
@@ -14,18 +14,26 @@
 # limitations under the License.
 
 
-def quantize_linear_backward(inputs, round_mode='HALF_AWAY_FROM_ZERO', narrow_range=False, dtype=1):
+def quantize_linear_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, round_mode='HALF_AWAY_FROM_ZERO', narrow_range=False, dtype=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    s0 = inputs[2]
-    z0 = inputs[3]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    s0 = inputs[1]
+    z0 = inputs[2]
     dx0 = dy / s0
     return dx0, None, None

--- a/python/src/nnabla/backward_function/r_div_scalar.py
+++ b/python/src/nnabla/backward_function/r_div_scalar.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def r_div_scalar_backward(inputs, val=1):
+def r_div_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = - dy * val / x0 ** 2
     return dx0

--- a/python/src/nnabla/backward_function/r_pow_scalar.py
+++ b/python/src/nnabla/backward_function/r_pow_scalar.py
@@ -17,16 +17,24 @@
 import numpy as np
 
 
-def r_pow_scalar_backward(inputs, val=1):
+def r_pow_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * val ** x0 * np.log(val)
     return dx0

--- a/python/src/nnabla/backward_function/r_sub_scalar.py
+++ b/python/src/nnabla/backward_function/r_sub_scalar.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def r_sub_scalar_backward(inputs, val=1):
+def r_sub_scalar_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = -dy
     return dx0

--- a/python/src/nnabla/backward_function/rand.py
+++ b/python/src/nnabla/backward_function/rand.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def rand_backward(inputs, low=0, high=1, shape=[], seed=-1):
+def rand_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, low=0, high=1, shape=[], seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/rand_beta.py
+++ b/python/src/nnabla/backward_function/rand_beta.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def rand_beta_backward(inputs, alpha=0.5, beta=0.5, shape=[], seed=-1):
+def rand_beta_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, alpha=0.5, beta=0.5, shape=[], seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/rand_binomial.py
+++ b/python/src/nnabla/backward_function/rand_binomial.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def rand_binomial_backward(inputs, n=1, p=0.5, shape=[], seed=-1):
+def rand_binomial_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, n=1, p=0.5, shape=[], seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/rand_gamma.py
+++ b/python/src/nnabla/backward_function/rand_gamma.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def rand_gamma_backward(inputs, k=0.5, theta=1, shape=[], seed=-1):
+def rand_gamma_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, k=0.5, theta=1, shape=[], seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/randint.py
+++ b/python/src/nnabla/backward_function/randint.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def randint_backward(inputs, low=0, high=1, shape=[], seed=-1):
+def randint_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, low=0, high=1, shape=[], seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/randn.py
+++ b/python/src/nnabla/backward_function/randn.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def randn_backward(inputs, mu=0, sigma=1, shape=[], seed=-1):
+def randn_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, mu=0, sigma=1, shape=[], seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/random_choice.py
+++ b/python/src/nnabla/backward_function/random_choice.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def random_choice_backward(inputs, shape=[], replace=True, seed=-1):
+def random_choice_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shape=[], replace=True, seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/random_crop.py
+++ b/python/src/nnabla/backward_function/random_crop.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def random_crop_backward(inputs, shape=None, base_axis=1, seed=-1):
+def random_crop_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shape=None, base_axis=1, seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/random_erase.py
+++ b/python/src/nnabla/backward_function/random_erase.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def random_erase_backward(inputs, prob=0.5, area_ratios=(0.02, 0.4), aspect_ratios=(0.3, 3.3333), replacements=(0.0, 255.0), n=None, share=True, inplace=False, base_axis=1, seed=-1, channel_last=False, ste_fine_grained=True):
+def random_erase_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, prob=0.5, area_ratios=(0.02, 0.4), aspect_ratios=(0.3, 3.3333), replacements=(0.0, 255.0), n=None, share=True, inplace=False, base_axis=1, seed=-1, channel_last=False, ste_fine_grained=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("random_erase_backward is not implemented.")

--- a/python/src/nnabla/backward_function/random_flip.py
+++ b/python/src/nnabla/backward_function/random_flip.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def random_flip_backward(inputs, axes=None, base_axis=1, seed=-1):
+def random_flip_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=None, base_axis=1, seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/random_shift.py
+++ b/python/src/nnabla/backward_function/random_shift.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def random_shift_backward(inputs, shifts=None, border_mode='nearest', base_axis=1, seed=-1):
+def random_shift_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shifts=None, border_mode='nearest', base_axis=1, seed=-1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/reduce_mean.py
+++ b/python/src/nnabla/backward_function/reduce_mean.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def reduce_mean_backward(inputs):
+def reduce_mean_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("reduce_mean_backward is not implemented.")

--- a/python/src/nnabla/backward_function/reduce_sum.py
+++ b/python/src/nnabla/backward_function/reduce_sum.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def reduce_sum_backward(inputs):
+def reduce_sum_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("reduce_sum_backward is not implemented.")

--- a/python/src/nnabla/backward_function/relu.py
+++ b/python/src/nnabla/backward_function/relu.py
@@ -16,22 +16,30 @@
 
 import nnabla.functions as F
 
-from .utils import no_grad, get_output
+from .utils import no_grad
 
 
-def relu_backward(inputs, inplace=False):
+def relu_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x0 = get_output(x0, "ReLU")
-    m0 = F.greater_scalar(x0, 0)  # result is same even if inplace or not
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    y0 = outputs[0]
+    m0 = F.greater_scalar(y0, 0)  # result is same even if inplace or not
     m0 = no_grad(m0)
     dx0 = dy * m0
     return dx0

--- a/python/src/nnabla/backward_function/relu6.py
+++ b/python/src/nnabla/backward_function/relu6.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def relu6_backward(inputs):
+def relu6_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.greater_scalar(x0, 0)
     m1 = F.less_scalar(x0, 6)
     m01 = m0 * m1

--- a/python/src/nnabla/backward_function/reset_inf.py
+++ b/python/src/nnabla/backward_function/reset_inf.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def reset_inf_backward(inputs, val=0):
+def reset_inf_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("reset_inf_backward is not implemented.")

--- a/python/src/nnabla/backward_function/reset_nan.py
+++ b/python/src/nnabla/backward_function/reset_nan.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def reset_nan_backward(inputs, val=0):
+def reset_nan_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, val=0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("reset_nan_backward is not implemented.")

--- a/python/src/nnabla/backward_function/reshape.py
+++ b/python/src/nnabla/backward_function/reshape.py
@@ -17,17 +17,25 @@
 import nnabla.functions as F
 
 
-def reshape_backward(inputs, shape, inplace=True):
+def reshape_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shape, inplace=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x0_shape = x0.shape
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
+    x0_shape = x0_shape
     dx0 = F.reshape(dy, x0_shape, inplace=inplace)
     return dx0

--- a/python/src/nnabla/backward_function/rnn.py
+++ b/python/src/nnabla/backward_function/rnn.py
@@ -18,10 +18,18 @@ import nnabla as nn
 from nnabla.utils.rnn import _create_fixed_length_rnn
 
 
-def rnn_backward(inputs, num_layers=1, nonlinearity='tanh', dropout=None, bidirectional=False, training=True):
+def rnn_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, num_layers=1, nonlinearity='tanh', dropout=None, bidirectional=False, training=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
@@ -30,18 +38,18 @@ def rnn_backward(inputs, num_layers=1, nonlinearity='tanh', dropout=None, bidire
     if dropout != 0.0:
         raise ValueError("Dropout must be 0.0")
 
-    dys = inputs[0]
-    dhn = inputs[1]
-    xs0 = inputs[2]
-    h0 = inputs[3]
-    w0 = inputs[4]
+    dys = grad_inputs[0]
+    dhn = grad_inputs[1]
+    xs0 = inputs[0]
+    h0 = inputs[1]
+    w0 = inputs[2]
 
     if num_layers == 1:
         w = None
-        b = inputs[5] if len(inputs) == 6 else None
+        b = inputs[3] if len(inputs) == 4 else None
     else:
-        w = inputs[5]
-        b = inputs[6] if len(inputs) == 7 else None
+        w = inputs[3]
+        b = inputs[4] if len(inputs) == 5 else None
     num_directions = 2 if bidirectional else 1
     with_bias = True if b else False
 

--- a/python/src/nnabla/backward_function/roi_align.py
+++ b/python/src/nnabla/backward_function/roi_align.py
@@ -23,15 +23,23 @@
 import nnabla.functions as F
 
 
-def roi_align_backward(inputs, output_size=(1, 1), spatial_scale=None, sampling_ratio=None, aligned=None, channel_last=False):
+def roi_align_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, output_size=(1, 1), spatial_scale=None, sampling_ratio=None, aligned=None, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("roi_align_backward is not implemented.")

--- a/python/src/nnabla/backward_function/round.py
+++ b/python/src/nnabla/backward_function/round.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def round_backward(inputs):
+def round_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy
     return dx0

--- a/python/src/nnabla/backward_function/scatter_add.py
+++ b/python/src/nnabla/backward_function/scatter_add.py
@@ -21,15 +21,23 @@
 # 3. UPDATE THE MAPPING IF NECESSARY (see function_backward_functions.py.tmpl)
 
 
-def scatter_add_backward(inputs, axis=None):
+def scatter_add_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("scatter_add_backward is not implemented.")

--- a/python/src/nnabla/backward_function/scatter_nd.py
+++ b/python/src/nnabla/backward_function/scatter_nd.py
@@ -17,17 +17,25 @@
 import nnabla.functions as F
 
 
-def scatter_nd_backward(inputs, shape, add):
+def scatter_nd_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shape, add):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    _ = inputs[1]
-    idx = inputs[2]
+    dy = grad_inputs[0]
+    _ = inputs[0]
+    idx = inputs[1]
     dx0 = F.gather_nd(dy, idx)
     return dx0, None

--- a/python/src/nnabla/backward_function/searchsorted.py
+++ b/python/src/nnabla/backward_function/searchsorted.py
@@ -23,15 +23,23 @@
 import nnabla.functions as F
 
 
-def searchsorted_backward(inputs, right=None):
+def searchsorted_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, right=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("searchsorted_backward is not implemented.")

--- a/python/src/nnabla/backward_function/selu.py
+++ b/python/src/nnabla/backward_function/selu.py
@@ -19,17 +19,25 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def selu_backward(inputs, scale=1.05070098735548, alpha=1.673263242354377):
+def selu_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, scale=1.05070098735548, alpha=1.673263242354377):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.greater_scalar(x0, 0)
     m1 = 1 - m0
     m0 = no_grad(m0)

--- a/python/src/nnabla/backward_function/shift.py
+++ b/python/src/nnabla/backward_function/shift.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def shift_backward(inputs, shifts=None, border_mode='nearest'):
+def shift_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, shifts=None, border_mode='nearest'):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("shift_backward is not implemented.")

--- a/python/src/nnabla/backward_function/sigmoid.py
+++ b/python/src/nnabla/backward_function/sigmoid.py
@@ -14,20 +14,25 @@
 # limitations under the License.
 
 
-from .utils import get_output
-
-
-def sigmoid_backward(inputs):
+def sigmoid_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "Sigmoid")
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    y0 = outputs[0]
     dx0 = dy * y0 * (1 - y0)
     return dx0

--- a/python/src/nnabla/backward_function/sigmoid_cross_entropy.py
+++ b/python/src/nnabla/backward_function/sigmoid_cross_entropy.py
@@ -17,18 +17,26 @@
 import nnabla.functions as F
 
 
-def sigmoid_cross_entropy_backward(inputs):
+def sigmoid_cross_entropy_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     s0 = F.sigmoid(x0)
     dx0 = dy * (s0 - x1)
     return dx0, None

--- a/python/src/nnabla/backward_function/sign.py
+++ b/python/src/nnabla/backward_function/sign.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def sign_backward(inputs, alpha=1.0):
+def sign_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, alpha=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy
     return dx0

--- a/python/src/nnabla/backward_function/sin.py
+++ b/python/src/nnabla/backward_function/sin.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def sin_backward(inputs):
+def sin_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * F.cos(x0)
     return dx0

--- a/python/src/nnabla/backward_function/sinc.py
+++ b/python/src/nnabla/backward_function/sinc.py
@@ -16,25 +16,33 @@
 
 import nnabla.functions as F
 
-from .utils import no_grad, get_output
+from .utils import no_grad
 
 
-def sinc_backward(inputs):
+def sinc_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     m0 = F.not_equal_scalar(x0, 0)
     m0 = no_grad(m0)
-    y0 = get_output(x0, "Sinc")
+    y0 = outputs[0]
 
-    dx0 = dy * (F.cos(x0) - y0) / x0
+    dx0 = dy * (F.cos(x0) - F.sin(x0) / x0) / x0
     c0 = F.constant(0, x0.shape)
     dx0 = F.where(m0, dx0, c0)
     return dx0

--- a/python/src/nnabla/backward_function/sinh.py
+++ b/python/src/nnabla/backward_function/sinh.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def sinh_backward(inputs):
+def sinh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * F.cosh(x0)
     return dx0

--- a/python/src/nnabla/backward_function/sink.py
+++ b/python/src/nnabla/backward_function/sink.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def sink_backward(inputs, one_input_grad=True):
+def sink_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, one_input_grad=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("sink_backward is not implemented.")

--- a/python/src/nnabla/backward_function/slice.py
+++ b/python/src/nnabla/backward_function/slice.py
@@ -32,33 +32,49 @@ class SliceDataGrad(UnaryDataGrad):
         self._func = _F.Slice(ctx, start, stop, step)
 
 
-def slice_backward(inputs, start=None, stop=None, step=None):
+def slice_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, start=None, stop=None, step=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     df = SliceDataGrad(ctx, start, stop, step)
-    df.xshape = x0.shape
+    df.xshape = x0_shape
     dx0 = df(dy)
     return dx0
 
 
-def slice_data_grad_backward(inputs, start=None, stop=None, step=None):
+def slice_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, start=None, stop=None, step=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.slice(gdx, start, stop, step)
     return gdy

--- a/python/src/nnabla/backward_function/softmax.py
+++ b/python/src/nnabla/backward_function/softmax.py
@@ -16,22 +16,30 @@
 
 import nnabla.functions as F
 
-from .utils import get_output, positive_axis
+from .utils import positive_axis
 
 
-def softmax_backward(inputs, axis=None):
+def softmax_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "Softmax")
-    D = len(x0.shape)
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    y0 = outputs[0]
+    D = len(y0.shape)
     axis = positive_axis(axis, D)
     dx0 = dy * y0 - y0 * F.sum(dy * y0, axis=axis, keepdims=True)
     return dx0

--- a/python/src/nnabla/backward_function/softmax_cross_entropy.py
+++ b/python/src/nnabla/backward_function/softmax_cross_entropy.py
@@ -19,23 +19,35 @@ import nnabla.functions as F
 from .utils import no_grad, positive_axis
 
 
-def softmax_cross_entropy_backward(inputs, axis=None):
+def softmax_cross_entropy_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    t0 = inputs[2]
+    # In auto-forward mode, the dynamic clear of inputs[0] and inputs[1] are
+    # blocked by SoftmaxCrossEntropy::auto_grad_depends_input/output_data.
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    t0 = inputs[1]
+    x0_shape = input_shapes[0]
+    t0_shape = input_shapes[1]
 
-    D = len(x0.shape)
+    D = len(x0_shape)
     axis = positive_axis(axis, D)
-    c0 = x0.shape[axis]
-    t0_shape = [s for s in t0.shape if s != 1]
+    c0 = x0_shape[axis]
+    t0_shape = [s for s in t0_shape if s != 1]
     u0 = F.reshape(t0, (-1, 1), inplace=False)
     u1 = F.one_hot(u0, (c0, ))
     to = F.reshape(u1, t0_shape + [c0, ])

--- a/python/src/nnabla/backward_function/softplus.py
+++ b/python/src/nnabla/backward_function/softplus.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def softplus_backward(inputs, beta=1.0):
+def softplus_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, beta=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * F.sigmoid(beta * x0)
     return dx0

--- a/python/src/nnabla/backward_function/softsign.py
+++ b/python/src/nnabla/backward_function/softsign.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def softsign_backward(inputs):
+def softsign_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * (1 / (1 + F.abs(x0)) ** 2)
     return dx0

--- a/python/src/nnabla/backward_function/sort.py
+++ b/python/src/nnabla/backward_function/sort.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def sort_backward(inputs, axis=-1, reverse=False, with_index=False, only_index=False):
+def sort_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=-1, reverse=False, with_index=False, only_index=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("sort_backward is not implemented.")

--- a/python/src/nnabla/backward_function/spectral_norm.py
+++ b/python/src/nnabla/backward_function/spectral_norm.py
@@ -17,7 +17,7 @@
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
-from .utils import get_output, no_grad, sum_for_arithmetics
+from .utils import no_grad, sum_for_arithmetics
 
 
 def _spectral_norm_backward(dw_sn, w, u, dim=0, itr=1, eps=1e-12):
@@ -135,10 +135,18 @@ def _spectral_norm_outer_most_dim_backward(dw_sn, w, u, itr=1, eps=1e-12):
     return dw, None
 
 
-def spectral_norm_backward(inputs, dim=0, itr=1, eps=1e-12, test=False, output_u=False):
+def spectral_norm_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, dim=0, itr=1, eps=1e-12, test=False, output_u=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
@@ -149,9 +157,9 @@ def spectral_norm_backward(inputs, dim=0, itr=1, eps=1e-12, test=False, output_u
         raise ValueError(
             "spectral_norm_backward is supported for output_u=True.")
 
-    dw_sn = inputs[0]
-    w = inputs[2]
-    u = get_output(w, "SpectralNorm", nth_output=1)
+    dw_sn = grad_inputs[0]
+    w = inputs[0]
+    u = outputs[1]
 
     if dim == w.ndim - 1:
         return _spectral_norm_outer_most_dim_backward(dw_sn, w, u, itr, eps)

--- a/python/src/nnabla/backward_function/split.py
+++ b/python/src/nnabla/backward_function/split.py
@@ -20,18 +20,26 @@ import nnabla.functions as F
 from .utils import positive_axis
 
 
-def split_backward(inputs, axis=0):
+def split_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0:-1]
-    x0 = inputs[-1]
-    D = len(x0.shape)
+    dy = grad_inputs
+    x0_shape = input_shapes[0]
+    D = len(x0_shape)
     axis = positive_axis(axis, D)
     dx = F.stack(*dy, axis=axis)
     return dx

--- a/python/src/nnabla/backward_function/squared_error.py
+++ b/python/src/nnabla/backward_function/squared_error.py
@@ -14,18 +14,26 @@
 # limitations under the License.
 
 
-def squared_error_backward(inputs):
+def squared_error_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    x1 = inputs[1]
     dx0 = dy * 2 * (x0 - x1)
     dx1 = -dx0
     return dx0, dx1

--- a/python/src/nnabla/backward_function/stack.py
+++ b/python/src/nnabla/backward_function/stack.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def stack_backward(inputs, axis=0):
+def stack_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
+    dy = grad_inputs[0]
     yshape = dy.shape
     if yshape[axis] == 1:
         reshape = yshape[:axis] + yshape[axis + 1:]

--- a/python/src/nnabla/backward_function/stft.py
+++ b/python/src/nnabla/backward_function/stft.py
@@ -17,17 +17,25 @@
 import nnabla.functions as F
 
 
-def stft_backward(inputs, window_size, stride, fft_size, window_type='hanning', center=True, pad_mode='reflect', as_istft_backward=False):
+def stft_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, window_size, stride, fft_size, window_type='hanning', center=True, pad_mode='reflect', as_istft_backward=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dyr = inputs[0]
-    dyi = inputs[1]
+    dyr = grad_inputs[0]
+    dyi = grad_inputs[1]
 
     dx = F.istft(dyr, dyi, window_size, stride, fft_size,
                  window_type, center, pad_mode, as_stft_backward=not as_istft_backward)

--- a/python/src/nnabla/backward_function/sub2.py
+++ b/python/src/nnabla/backward_function/sub2.py
@@ -14,23 +14,31 @@
 # limitations under the License.
 
 
-from .utils import sum_for_arithmetics
+from .utils import sum_for_arithmetics_with_shape
 
 
-def sub2_backward(inputs, inplace=False):
+def sub2_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, inplace=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    x1 = inputs[2]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
+    x1_shape = input_shapes[1]
     dx0 = dy
     dx1 = -dy
-    dx0 = sum_for_arithmetics(dx0, x0)
-    dx1 = sum_for_arithmetics(dx1, x1)
+    dx0 = sum_for_arithmetics_with_shape(dx0, x0_shape)
+    dx1 = sum_for_arithmetics_with_shape(dx1, x1_shape)
     return dx0, dx1

--- a/python/src/nnabla/backward_function/sum.py
+++ b/python/src/nnabla/backward_function/sum.py
@@ -19,14 +19,15 @@ import nnabla.functions as F
 from .utils import force_list
 
 
-def sum_backward(inputs, axes=None, keep_dims=False):
-    dy = inputs[0]
-    x0 = inputs[1]
-    axes = [i for i in range(x0.ndim)] if axes is None else force_list(axes)
-    axes = [a if a >= 0 else a + x0.ndim for a in axes]  # Negative axis
+def sum_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=None, keep_dims=False):
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
+    x0_ndim = len(x0_shape)
+    axes = [i for i in range(x0_ndim)] if axes is None else force_list(axes)
+    axes = [a if a >= 0 else a + x0_ndim for a in axes]  # Negative axis
     if keep_dims:
-        dx0 = F.broadcast(dy, x0.shape)
+        dx0 = F.broadcast(dy, x0_shape)
     else:
-        shape = [1 if i in axes else s for i, s in enumerate(x0.shape)]
-        dx0 = F.broadcast(F.reshape(dy, shape), x0.shape)
+        shape = [1 if i in axes else s for i, s in enumerate(x0_shape)]
+        dx0 = F.broadcast(F.reshape(dy, shape), x0_shape)
     return dx0

--- a/python/src/nnabla/backward_function/sum_pooling.py
+++ b/python/src/nnabla/backward_function/sum_pooling.py
@@ -30,36 +30,52 @@ class SumPoolingDataGrad(UnaryDataGrad):
                                    channel_last)
 
 
-def sum_pooling_backward(inputs, kernel, stride=None,
+def sum_pooling_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, stride=None,
                          ignore_border=True, pad=None, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     df = SumPoolingDataGrad(ctx, kernel, stride,
                             ignore_border, pad, channel_last)
-    df.xshape = x0.shape
+    df.xshape = x0_shape
     dx0 = df(dy)
     return dx0
 
 
-def sum_pooling_data_grad_backward(inputs, kernel, stride=None,
+def sum_pooling_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, stride=None,
                                    ignore_border=True, pad=None, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.sum_pooling(gdx, kernel, stride, ignore_border, pad, channel_last)
     return gdy

--- a/python/src/nnabla/backward_function/swish.py
+++ b/python/src/nnabla/backward_function/swish.py
@@ -17,17 +17,25 @@
 import nnabla.functions as F
 
 
-def swish_backward(inputs):
+def swish_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     s0 = F.sigmoid(x0)
     dx0 = dy * s0 * (1 + x0 * (1 - s0))
     return dx0

--- a/python/src/nnabla/backward_function/sync_batch_normalization.py
+++ b/python/src/nnabla/backward_function/sync_batch_normalization.py
@@ -14,16 +14,24 @@
 # limitations under the License.
 
 
-def sync_batch_normalization_backward(inputs, comm, group=None, axes=(1,), decay_rate=0.9, eps=1e-05, batch_stat=True):
+def sync_batch_normalization_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, comm, group=None, axes=(1,), decay_rate=0.9, eps=1e-05, batch_stat=True):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError(
         "sync_batch_normalization_backward is not implemented.")

--- a/python/src/nnabla/backward_function/tan.py
+++ b/python/src/nnabla/backward_function/tan.py
@@ -17,16 +17,24 @@
 import nnabla.functions as F
 
 
-def tan_backward(inputs):
+def tan_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     dx0 = dy * F.cos(x0) ** (-2)
     return dx0

--- a/python/src/nnabla/backward_function/tanh.py
+++ b/python/src/nnabla/backward_function/tanh.py
@@ -14,20 +14,25 @@
 # limitations under the License.
 
 
-from .utils import get_output
-
-
-def tanh_backward(inputs):
+def tanh_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
-    y0 = get_output(x0, "Tanh")
+    dy = grad_inputs[0]
+    x0 = inputs[0]
+    y0 = outputs[0]
     dx0 = dy * (1 - y0 ** 2)
     return dx0

--- a/python/src/nnabla/backward_function/tanh_shrink.py
+++ b/python/src/nnabla/backward_function/tanh_shrink.py
@@ -17,17 +17,25 @@
 import nnabla.functions as F
 
 
-def tanh_shrink_backward(inputs):
+def tanh_shrink_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     t0 = F.tanh(x0)
     dx0 = dy * (1 - (1 - t0 ** 2))
     return dx0

--- a/python/src/nnabla/backward_function/tensor_normalization.py
+++ b/python/src/nnabla/backward_function/tensor_normalization.py
@@ -19,19 +19,27 @@ import nnabla.functions as F
 from functools import partial
 
 
-def tensor_normalization_backward(inputs, axes=(1,), eps=1e-05, no_scale=False, no_bias=False):
+def tensor_normalization_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes=(1,), eps=1e-05, no_scale=False, no_bias=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
       Variable: Standardized `x`.
     """
-    dy = inputs[0]
-    x = inputs[1]
-    g_idx = 2 if no_bias else 3
+    dy = grad_inputs[0]
+    x = inputs[0]
+    g_idx = 1 if no_bias else 2
     g = inputs[g_idx] if not no_scale else None  # gamma
 
     # Prerequisite

--- a/python/src/nnabla/backward_function/tile.py
+++ b/python/src/nnabla/backward_function/tile.py
@@ -14,13 +14,21 @@
 # limitations under the License.
 
 
-def tile_backward(inputs, reps):
+def tile_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, reps):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    return [None] * len(inputs)
+    return [None] * (len(grad_inputs) + len(inputs))

--- a/python/src/nnabla/backward_function/top_k_data.py
+++ b/python/src/nnabla/backward_function/top_k_data.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def top_k_data_backward(inputs, k, abs=False, reduce=True, base_axis=1):
+def top_k_data_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, k, abs=False, reduce=True, base_axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("top_k_data_backward is not implemented.")

--- a/python/src/nnabla/backward_function/top_k_grad.py
+++ b/python/src/nnabla/backward_function/top_k_grad.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def top_k_grad_backward(inputs, k, abs=False, base_axis=1):
+def top_k_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, k, abs=False, base_axis=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("top_k_grad_backward is not implemented.")

--- a/python/src/nnabla/backward_function/top_n_error.py
+++ b/python/src/nnabla/backward_function/top_n_error.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def top_n_error_backward(inputs, axis=None, n=1):
+def top_n_error_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axis=None, n=1):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("top_n_error_backward is not implemented.")

--- a/python/src/nnabla/backward_function/transpose.py
+++ b/python/src/nnabla/backward_function/transpose.py
@@ -28,33 +28,49 @@ class TransposeDataGrad(UnaryDataGrad):
         self._func = _F.Transpose(ctx, axes)
 
 
-def transpose_backward(inputs, axes):
+def transpose_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     df = TransposeDataGrad(ctx, axes)
-    df.xshape = x0.shape
+    df.xshape = x0_shape
     dx0 = df(dy)
     return dx0
 
 
-def transpose_data_grad_backward(inputs, axes):
+def transpose_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, axes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.transpose(gdx, axes)
     return gdy

--- a/python/src/nnabla/backward_function/unlink.py
+++ b/python/src/nnabla/backward_function/unlink.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def unlink_backward(inputs):
+def unlink_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("unlink_backward is not implemented.")

--- a/python/src/nnabla/backward_function/unpooling.py
+++ b/python/src/nnabla/backward_function/unpooling.py
@@ -28,33 +28,49 @@ class UnpoolingDataGrad(UnaryDataGrad):
         self._func = _F.Unpooling(ctx, kernel, channel_last)
 
 
-def unpooling_backward(inputs, kernel, channel_last=False):
+def unpooling_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0_shape = input_shapes[0]
     ctx = nn.get_current_context()
     df = UnpoolingDataGrad(ctx, kernel, channel_last)
-    df.xshape = x0.shape
+    df.xshape = x0_shape
     dx0 = df(dy)
     return dx0
 
 
-def unpooling_data_grad_backward(inputs, kernel, channel_last=False):
+def unpooling_data_grad_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, kernel, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    gdx = inputs[0]
+    gdx = grad_inputs[0]
     gdy = F.unpooling(gdx, kernel, channel_last)
     return gdy

--- a/python/src/nnabla/backward_function/utils.py
+++ b/python/src/nnabla/backward_function/utils.py
@@ -64,16 +64,17 @@ def force_tuple(x):
     return x
 
 
-def get_output(x, func_name, nth_output=0):
-    for func in x.function_references:
-        if func.info.type_name == func_name:
-            return func.outputs[nth_output]
-    raise ValueError("{} is not found.".format(func_name))
-
-
 def sum_for_arithmetics(dx, x):
     # F.{add2, sub2, mul2, div2} includes Broadcast internally (C++-level),
     # so we have to do F.sum explicitly
     axes = [a for a in range(len(x.shape)) if x.shape[a] == 1]
+    dx = F.sum(dx, axes, keepdims=True)
+    return dx
+
+
+def sum_for_arithmetics_with_shape(dx, x_shape):
+    # F.{add2, sub2, mul2, div2} includes Broadcast internally (C++-level),
+    # so we have to do F.sum explicitly
+    axes = [a for a in range(len(x_shape)) if x_shape[a] == 1]
     dx = F.sum(dx, axes, keepdims=True)
     return dx

--- a/python/src/nnabla/backward_function/vat_noise.py
+++ b/python/src/nnabla/backward_function/vat_noise.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def vat_noise_backward(inputs, base_axis=1, eps=1.0):
+def vat_noise_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, base_axis=1, eps=1.0):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("vat_noise_backward is not implemented.")

--- a/python/src/nnabla/backward_function/warp_by_flow.py
+++ b/python/src/nnabla/backward_function/warp_by_flow.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def warp_by_flow_backward(inputs):
+def warp_by_flow_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("warp_by_flow_backward is not implemented.")

--- a/python/src/nnabla/backward_function/warp_by_grid.py
+++ b/python/src/nnabla/backward_function/warp_by_grid.py
@@ -14,15 +14,23 @@
 # limitations under the License.
 
 
-def warp_by_grid_backward(inputs, mode='linear', padding_mode='zero', align_corners=False, channel_last=False):
+def warp_by_grid_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, mode='linear', padding_mode='zero', align_corners=False, channel_last=False):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    x0 = inputs[1]
+    dy = grad_inputs[0]
+    x0 = inputs[0]
     raise NotImplementedError("warp_by_grid_backward is not implemented.")

--- a/python/src/nnabla/backward_function/weight_normalization.py
+++ b/python/src/nnabla/backward_function/weight_normalization.py
@@ -17,18 +17,26 @@
 import nnabla.functions as F
 
 
-def weight_normalization_backward(inputs, dim=0, eps=1e-12):
+def weight_normalization_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, dim=0, eps=1e-12):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    w = inputs[1]
-    g = inputs[2]
+    dy = grad_inputs[0]
+    w = inputs[0]
+    g = inputs[1]
     g_shape = g.shape
     dim += w.ndim*(dim < 0)
 

--- a/python/src/nnabla/backward_function/weight_standardization.py
+++ b/python/src/nnabla/backward_function/weight_standardization.py
@@ -17,19 +17,28 @@
 from .tensor_normalization import tensor_normalization_backward
 
 
-def weight_standardization_backward(inputs, channel_axis=None, eps=1e-05):
+def weight_standardization_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes, channel_axis=None, eps=1e-05):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    x = inputs[1]
-    channel_axis += inputs[0].ndim*(channel_axis < 0)
+    x = inputs[0]
+    channel_axis += grad_inputs[0].ndim*(channel_axis < 0)
     axes = list(set(range(x.ndim)) - set([channel_axis]))
     no_scale = True
     no_bias = True
-    dx, _ = tensor_normalization_backward(inputs, axes, eps, no_scale, no_bias)
+    dx, _ = tensor_normalization_backward(
+        grad_inputs, inputs, input_shapes, outputs, output_shapes, axes, eps, no_scale, no_bias)
     return dx

--- a/python/src/nnabla/backward_function/where.py
+++ b/python/src/nnabla/backward_function/where.py
@@ -19,21 +19,29 @@ import nnabla.functions as F
 from .utils import no_grad
 
 
-def where_backward(inputs):
+def where_backward(grad_inputs, inputs, input_shapes, outputs, output_shapes):
     """
     Args:
-      inputs (list of nn.Variable): Incomming grads/inputs to/of the forward function.
+      grad_inputs (list of :obj:`nnabla.Variable`): Propagated grads to this backward function.
+      inputs (list of :obj:`nnabla.Variable` and None): Input Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      input_shapes (list of tuple of :obj:`int`): Input shapes of the forward function.
+          The shapes of the inputs in which None is set can be passed.
+      outputs (list of :obj:`nnabla.Variable` and None): Output Variables of the forward function
+          if this backward function depends on it. Otherwise, None is set instead.
+      output_shapes (list of tuple of :obj:`int`): Output shapes of the forward function.
+          The shapes of the outputs in which None is set can be passed.
       kwargs (dict of arguments): Dictionary of the corresponding function arguments.
 
     Return:
       list of Variable: Return the gradients wrt inputs of the corresponding function.
     """
-    dy = inputs[0]
-    cd = inputs[1]
-    xt = inputs[2]
-    xf = inputs[3]
-    c1 = F.constant(1, xt.shape)
-    c0 = F.constant(0, xf.shape)
+    dy = grad_inputs[0]
+    cd = inputs[0]
+    xt_shape = input_shapes[1]
+    xf_shape = input_shapes[2]
+    c1 = F.constant(1, xt_shape)
+    c0 = F.constant(0, xf_shape)
     m0 = F.where(cd, c1, c0)
     m1 = 1 - m0
     m0 = no_grad(m0)

--- a/python/src/nnabla/communicator.pyx
+++ b/python/src/nnabla/communicator.pyx
@@ -100,7 +100,7 @@ cdef class Communicator:
         cdef _Variable x
         cdef string key
         for key, x in iteritems(ctx_param_dict[1]):
-            cparams.push_back(pair[string, shared_ptr[CVariable]](key, (< _Variable > x).varp.variable()))
+            cparams.push_back(pair[string, shared_ptr[CVariable]](key, (< _Variable > x).get_varp().variable()))
 
         self.communicatorp.add_context_and_parameters(
             pair[CContext, vector[pair[string, shared_ptr[CVariable]]]](ctx_param_dict[0], cparams))

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -51,7 +51,10 @@ cdef extern from "nbla/function.hpp" namespace "nbla":
         int min_outputs()
         string name()
         shared_ptr[CFunction] copy() except +
+        cpp_bool grad_depends_input_data(int i, int j) except+
         cpp_bool grad_depends_output_data(int i, int o) except+
+        cpp_bool auto_grad_depends_input_data(int i, int j) except+
+        cpp_bool auto_grad_depends_output_data(int i, int o) except+
         cpp_bool need_setup_recompute(int o) except+
         int inplace_data(int i) except+
         int inplace_data_with(int i) except+

--- a/python/src/nnabla/function.pyx.tmpl
+++ b/python/src/nnabla/function.pyx.tmpl
@@ -96,7 +96,7 @@ cdef vector[CgVariablePtr] list_to_vector_cg_variable(varlist) except *:
     size = len(varlist)
     vec.resize(size)
     for i in range(size):
-        vec[i] = (<_Variable?> varlist[i]).var
+        vec[i] = (<_Variable?> varlist[i]).get_var()
     return vec
 
 cdef vector[CVariable*] list_to_vector_variable_p(varlist) except *:
@@ -106,7 +106,7 @@ cdef vector[CVariable*] list_to_vector_variable_p(varlist) except *:
     size = len(varlist)
     vec.resize(size)
     for i in range(size):
-        vec[i] = (<_Variable?> varlist[i]).varp.variable().get()
+        vec[i] = (<_Variable?> varlist[i]).get_varp().variable().get()
     return vec
 
 cdef vector[cpp_bool] variables_to_prop_down_flags(varlist) except *:
@@ -114,7 +114,7 @@ cdef vector[cpp_bool] variables_to_prop_down_flags(varlist) except *:
     cdef int size = len(varlist)
     cdef vector[cpp_bool] ret
     for i in range(size):
-        ret.push_back((<_Variable?>varlist[i]).varp.need_grad_state())
+        ret.push_back((<_Variable?>varlist[i]).get_varp().need_grad_state())
     return ret
 
 cdef tuple vector_to_tuple_nd_array(const vector[NdArrayPtr] &vec):
@@ -253,8 +253,17 @@ cdef class Function:
     def min_outputs(self):
         return self.funp.function().get().min_outputs()
 
+    def grad_depends_input_data(self, int i, int j):
+        return self.funp.function().get().grad_depends_input_data(i, j)
+
     def grad_depends_output_data(self, int i, int o):
         return self.funp.function().get().grad_depends_output_data(i, o)
+
+    def auto_grad_depends_input_data(self, int i, int j):
+        return self.funp.function().get().auto_grad_depends_input_data(i, j)
+
+    def auto_grad_depends_output_data(self, int i, int o):
+        return self.funp.function().get().auto_grad_depends_output_data(i, o)
 
     def need_setup_recompute(self, int o):
         return self.funp.function().get().need_setup_recompute(o)

--- a/python/src/nnabla/solver.pyx.tmpl
+++ b/python/src/nnabla/solver.pyx.tmpl
@@ -133,7 +133,7 @@ cdef class Solver:
         cdef string key
         cdef int i
         for key, x in iteritems(param_dict):
-            cparams.push_back(pair[string, shared_ptr[CVariable]](key, (< _Variable > x).varp.variable()))
+            cparams.push_back(pair[string, shared_ptr[CVariable]](key, (< _Variable > x).get_varp().variable()))
         self.solverp.set_parameters(cparams, reset, retain_state)
 
     def remove_parameters(self, vector[string] keys):
@@ -190,7 +190,7 @@ cdef class Solver:
         cdef _Variable pstate
         for pname, src_state in iteritems(states):
             for sname, var in iteritems(src_state.pstate):
-                dst_cstate.pstate[sname] = (< _Variable > var).varp.variable()
+                dst_cstate.pstate[sname] = (< _Variable > var).get_varp().variable()
             dst_cstate.t = src_state.t
             cstates.push_back(pair[string, CSolverState](pname, dst_cstate))
         self.solverp.set_states(cstates)

--- a/python/src/nnabla/utils/image_utils/backend_events/dicom_backend.py
+++ b/python/src/nnabla/utils/image_utils/backend_events/dicom_backend.py
@@ -35,7 +35,7 @@ def _apply_gamma_correction(dicom_dataset):
         win_width = float(dicom_dataset.WindowWidth)
     else:
         win_width = (1 << bpp)
-    ################NCTB#######
+    ################ NCTB #######
     if 'PhotometricInterpretation' in dicom_dataset:
         photo_interpretation = dicom_dataset.PhotometricInterpretation
     else:

--- a/python/test/function/test_dropout.py
+++ b/python/test/function/test_dropout.py
@@ -143,7 +143,8 @@ def test_dropout_double_backward(p, seed, ctx, func_name):
                 dy = nn.Variable.from_numpy_array(
                     init_dy).apply(need_grad=True)
                 # y = F.dropout(x, p, seed)  # Dropout is required to compute mask.
-                dx = registry['Dropout']([dy, x], p, seed)
+                dx = registry['Dropout'](
+                    [dy], [x], [None], [None], [None], p, seed)
 
             # Note: y.forward() is required for dx.forward(). However this test
             #       is skipped because the random results are randomly matched
@@ -157,7 +158,7 @@ def test_dropout_double_backward(p, seed, ctx, func_name):
         x = nn.Variable.from_numpy_array(init_x).apply(need_grad=True)
         dy = nn.Variable.from_numpy_array(init_dy).apply(need_grad=True)
         y = F.dropout(x, p, seed)  # Dropout is required to compute mask.
-        dx = registry['Dropout']([dy, x], p, seed)
+        dx = registry['Dropout']([dy], [x], [None], [None], [None], p, seed)
 
         # Execution
         y.forward()  # Dropout is required to compute mask.

--- a/python/test/nbla_test_utils.py
+++ b/python/test/nbla_test_utils.py
@@ -64,6 +64,32 @@ def randn(rng, *shape):
     return np.asarray(rng.randn(*shape), dtype=np.float32)
 
 
+def quit_with_gc(func_or_gen):
+    '''A decorator function attaching garbage collection
+    at the end of the function.
+
+    Args:
+        func_or_gen (function or int): If an int is given, it returns a decorator with garbage collection with generation=2 for gc.collect(generation) with the specified value as generation.
+
+    '''
+    generation = 2
+
+    def _quit_with_gc(f):
+        def decorated(*args, **kw):
+            import gc
+            ret = f(*args, **kw)
+            gc.collect(generation)
+            return ret
+
+        return decorated
+
+    if isinstance(func_or_gen, int):
+        generation = func_or_gen
+        return _quit_with_gc
+    func = func_or_gen
+    return _quit_with_gc(func)
+
+
 def compute_analytical_and_numerical_grad_graph(terminal, inputs,
                                                 epsilon=1e-3,
                                                 recompute_graph=True):

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -548,6 +548,14 @@ void SyncedArray::remove_child(const SyncedArray *child) {
                   children_.end());
 }
 
+int SyncedArray::get_python_user_reference_counts() const {
+  return python_user_reference_counts;
+}
+
+void SyncedArray::update_python_user_reference_counts(const int diff) {
+  python_user_reference_counts += diff;
+}
+
 // Callback function
 SyncedArrayCallback::SyncedArrayCallback() : callback_func_(nullptr) {}
 

--- a/src/nbla/synced_array.cpp
+++ b/src/nbla/synced_array.cpp
@@ -549,11 +549,17 @@ void SyncedArray::remove_child(const SyncedArray *child) {
 }
 
 int SyncedArray::get_python_user_reference_counts() const {
-  return python_user_reference_counts;
+  if (is_root()) {
+    return python_user_reference_counts;
+  }
+  return parent_->get_python_user_reference_counts();
 }
 
 void SyncedArray::update_python_user_reference_counts(const int diff) {
   python_user_reference_counts += diff;
+  if (is_child()) {
+    parent_->update_python_user_reference_counts(diff);
+  }
 }
 
 // Callback function


### PR DESCRIPTION
# Memory usage is optimized in auto-forward mode.

An user can save the memory by releasing nnabla.Variables which are no longer needed in auto-forward mode.

### Usage examples 1

```python
x = nn.Variable()
with auto_forward():
    y = F.identity(x) # F.identity has no grad dependencies.
    y = F.identity(y) # The rebinding of y releases the previous y and its memory .
```

### Usage examples 2
```python
def local_scope(x):
    h = F.identity(x) # F.identity has no grad dependencies.
    y = F.identity(h)
    return y

x = nn.Variable()
with auto_forward():
    y = local_scope(x) # After exiting local_scope, the local Variable "h" and its memory are released.
```

### Note
Because the timing to release nnabla.Variable depends on the Python GC, the timing of memory release is not determined but is highly expected to be immediate.

### Performance example

The discriminator of StyleGAN2 extracted from nnabla-examples/image-generation/stylegan2-training/ can save the GPU memory usage in auto-forward mode at the almost same level as that in static-graph mode.

| Static | Dynamic (after) | Dynamic (before) |
| ---: | ---: | ---: |
| 3168 MB | 3187 MB |  8143 MB |