### PR TITLE
change pip installation method

### DIFF
--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -36,7 +36,6 @@ RUN eval ${APT_OPTS} && apt-get update \
        libglib2.0-0 \
        libgl1-mesa-glx \
        python${PYTHON_VER} \
-       python3-pip \
        python${PYTHON_VER}-distutils \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -44,7 +43,10 @@ RUN eval ${APT_OPTS} && apt-get update \
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VER} 0
 RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VER} 0
 
-RUN pip3 install ${PIP_INS_OPTS} --upgrade pip
+RUN curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python${PYTHON_VER} get-pip.py ${PIP_INS_OPTS} \
+    && rm get-pip.py
+
 RUN pip install ${PIP_INS_OPTS} wheel setuptools
 RUN pip install ${PIP_INS_OPTS} opencv-python || true
 

--- a/docker/release/Dockerfile.py39-aarch64
+++ b/docker/release/Dockerfile.py39-aarch64
@@ -36,13 +36,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     pkg-config \
     python3 \
     python3-dev \
-    python3-pip \
     python3-setuptools \
     python3-wheel \
+    curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip
+RUN curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
+    && python3 get-pip.py ${PIP_INS_OPTS} \
+    && rm get-pip.py
+
 RUN echo "[global]" >/etc/pip.conf
 RUN echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
 RUN python3 -m pip install ${PIP_INS_OPTS} --no-cache-dir numpy\<1.22


### PR DESCRIPTION
In previous release, pip shows following error:

```python
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/utils/logging.py", line 177, in emit
    self.console.print(renderable, overflow="ignore", crop=False, style=style)
  File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/rich/console.py", line 1673, in print
    extend(render(renderable, render_options))
  File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/rich/console.py", line 1305, in render
    for render_output in iter_render:
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/utils/logging.py", line 134, in __rich_console__
    for line in lines:
  File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/rich/segment.py", line 249, in split_lines
    for segment in segments:
  File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/rich/console.py", line 1283, in render
    renderable = rich_cast(renderable)
  File "/usr/local/lib/python3.8/dist-packages/pip/_vendor/rich/protocol.py", line 36, in rich_cast
    renderable = cast_method()
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/self_outdated_check.py", line 130, in __rich__
    pip_cmd = get_best_invocation_for_this_pip()
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/utils/entrypoints.py", line 58, in get_best_invocation_for_this_pip
    if found_executable and os.path.samefile(
  File "/usr/lib/python3.8/genericpath.py", line 101, in samefile
    s2 = os.stat(f2)
FileNotFoundError: [Errno 2] No such file or directory: '/usr/bin/pip'
Call stack:
  File "/usr/local/bin/pip", line 11, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/cli/main.py", line 70, in main
    return command.main(cmd_args)
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/cli/base_command.py", line 101, in main
    return self._main(args)
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/cli/base_command.py", line 223, in _main
    self.handle_pip_version_check(options)
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/cli/req_command.py", line 190, in handle_pip_version_check
    pip_self_version_check(session, options)
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/self_outdated_check.py", line 236, in pip_self_version_check
    logger.warning("[present-rich] %s", upgrade_prompt)
  File "/usr/lib/python3.8/logging/__init__.py", line 1458, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 1589, in _log
    self.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1599, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1661, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 954, in handle
    self.emit(record)
  File "/usr/local/lib/python3.8/dist-packages/pip/_internal/utils/logging.py", line 179, in emit
    self.handleError(record)
Message: '[present-rich] %s'
Arguments: (UpgradePrompt(old='22.2.2', new='22.3'),)
```

This problem was issue in pip, and it has been fixed by https://github.com/pypa/pip/pull/11318.
But, this is caused by uniqueness check, so we change pip installation by this PR.

nnabla-ext-cuda part is provided by  https://github.com/sony/nnabla-ext-cuda/pull/441