### PR TITLE
Change python version to 3.9.14 in aarch64 environment

### DIFF
--- a/docker/development/Dockerfile.build-aarch64
+++ b/docker/development/Dockerfile.build-aarch64
@@ -24,31 +24,37 @@ ENV LC_ALL C
 ENV LANG C
 ENV LANGUAGE C
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN eval ${APT_OPTS} \
     && apt-get update && apt-get install -y --no-install-recommends \
-    bzip2 \
     ca-certificates \
+    build-essential \
     ccache \
     cmake \
     curl \
     g++ \
     git \
+    make \
+    unzip \
+    wget \
+    bzip2 \
+    zip \
+    llvm \
+    xz-utils \
+    tk-dev \
     libarchive-dev \
     libatlas-base-dev \
     libhdf5-dev \
     libopenblas-dev \
     liblapack-dev \
-    make \
-    pkg-config \
-    python3 \
-    python3-dev \
-    python3-pip \
-    python3-setuptools \
-    python3-wheel \
-    unzip \
-    wget \
-    zip \
-    liblzma-dev
+    liblzma-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libncursesw5-dev \
+    libsqlite3-dev \
+    libffi-dev \
+    libssl-dev
 
 ############################################################ protobuf
 ENV PROTOVER=3.19.4
@@ -70,20 +76,31 @@ RUN mkdir /tmp/deps \
     && cd / \
     && rm -rf /tmp/*
 
+ARG PYTHON_VERSION_MAJOR=3
+ARG PYTHON_VERSION_MINOR=9
+ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.14
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && eval "$(pyenv init -)" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && python-build ${PYVERNAME} /usr/local/ \
+    && pyenv global system \
+    && rm -rf ~/.pyenv/.git
+
 ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD python/test_requirements.txt /tmp/deps/
 
-RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip
-
-RUN echo "[global]" >/etc/pip.conf
-RUN echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
-
-RUN pip3 install ${PIP_INS_OPTS} numpy\<1.22
-
-RUN pip3 install ${PIP_INS_OPTS} -r /tmp/deps/setup_requirements.txt
-
-RUN sed -i '/onnx/d' /tmp/deps/requirements.txt \
+RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip \
+    && echo "[global]" >/etc/pip.conf \
+    && echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf \
+    && pip3 install ${PIP_INS_OPTS} numpy\<1.22 \
+    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/setup_requirements.txt \
+    && sed -i '/onnx/d' /tmp/deps/requirements.txt \
     && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/requirements.txt
 
 ENV PATH /tmp/.local/bin:$PATH

--- a/docker/development/Dockerfile.nnabla-test-aarch64
+++ b/docker/development/Dockerfile.nnabla-test-aarch64
@@ -24,15 +24,25 @@ ENV LC_ALL C
 ENV LANG C
 ENV LANGUAGE C
 
+ENV DEBIAN_FRONTEND noninteractive
+
 RUN eval ${APT_OPTS} \
     && apt-get update && apt-get install -y --no-install-recommends \
-    bzip2 \
     ca-certificates \
+    build-essential \
     ccache \
     cmake \
     curl \
     g++ \
     git \
+    make \
+    unzip \
+    wget \
+    bzip2 \
+    zip \
+    llvm \
+    xz-utils \
+    tk-dev \
     libarchive-dev \
     libatlas-base-dev \
     libhdf5-dev \
@@ -40,18 +50,14 @@ RUN eval ${APT_OPTS} \
     liblapack-dev \
     libsndfile1 \
     liblzma-dev \
-    make \
-    pkg-config \
-    python3 \
-    python3-dev \
-    python3-pip \
-    python3-setuptools \
-    python3-wheel \
-    python3-venv \
-    unzip \
-    wget \
-    zip
+    libbz2-dev \
+    libreadline-dev \
+    libncursesw5-dev \
+    libsqlite3-dev \
+    libffi-dev \
+    libssl-dev
 
+############################################################ protobuf
 ENV PROTOVER=3.19.4
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
@@ -92,22 +98,32 @@ RUN mkdir /tmp/deps \
     && cd / \
     && rm -rf /tmp/*
 
+ARG PYTHON_VERSION_MAJOR=3
+ARG PYTHON_VERSION_MINOR=9
+ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.14
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && eval "$(pyenv init -)" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && python-build ${PYVERNAME} /usr/local/ \
+    && pyenv global system \
+    && rm -rf ~/.pyenv/.git
+
 ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD python/test_requirements.txt /tmp/deps/
 
-RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip
-
-RUN echo "[global]" >/etc/pip.conf
-RUN echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
-
-RUN pip3 install ${PIP_INS_OPTS} 'numpy>=1.20.0,<1.22'
-
-RUN pip3 install ${PIP_INS_OPTS} -r /tmp/deps/setup_requirements.txt
-
-RUN sed -i '/onnx/d' /tmp/deps/requirements.txt \
-    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/requirements.txt
-
-RUN pip3 install ${PIP_INS_OPTS} -r /tmp/deps/test_requirements.txt
+RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip \
+    && echo "[global]" >/etc/pip.conf \
+    && echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf \
+    && pip3 install ${PIP_INS_OPTS} 'numpy>=1.20.0,<1.22' \
+    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/setup_requirements.txt \
+    && sed -i '/onnx/d' /tmp/deps/requirements.txt \
+    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/requirements.txt \
+    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/test_requirements.txt
 
 ENV PATH /tmp/.local/bin:$PATH

--- a/docker/release/Dockerfile.py39-aarch64
+++ b/docker/release/Dockerfile.py39-aarch64
@@ -12,6 +12,56 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+FROM multiarch/debian-debootstrap:arm64-bullseye as python
+
+ARG PIP_INS_OPTS
+ARG PYTHONWARNINGS
+ARG CURL_OPTS
+ARG WGET_OPTS
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV LC_ALL C
+ENV LANG C
+ENV LANGUAGE C
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    build-essential \
+    curl \
+    git \
+    make \
+    wget \
+    llvm \
+    xz-utils \
+    tk-dev \
+    zlib1g-dev \
+    libxml2-dev \
+    libxmlsec1-dev \
+    liblzma-dev \
+    libbz2-dev \
+    libreadline-dev \
+    libncursesw5-dev \
+    libsqlite3-dev \
+    libffi-dev \
+    libssl-dev
+
+ARG PYTHON_VERSION_MAJOR=3
+ARG PYTHON_VERSION_MINOR=9
+ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.14
+
+# Install pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && eval "$(pyenv init -)" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && python-build ${PYVERNAME} /usr/local/ \
+    && pyenv global system \
+    && rm -rf ~/.pyenv/.git
+
+
 FROM multiarch/debian-debootstrap:arm64-bullseye
 
 ARG PIP_INS_OPTS
@@ -33,36 +83,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libhdf5-dev \
     libopenblas-dev \
     liblapack-dev \
-    pkg-config \
-    python3 \
-    python3-dev \
-    python3-setuptools \
-    python3-wheel \
     curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3 get-pip.py ${PIP_INS_OPTS} \
-    && rm get-pip.py
-
-RUN echo "[global]" >/etc/pip.conf
-RUN echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf
-RUN python3 -m pip install ${PIP_INS_OPTS} --no-cache-dir numpy\<1.22
-RUN python3 -m pip install ${PIP_INS_OPTS} --no-cache-dir scipy
-RUN python3 -m pip install ${PIP_INS_OPTS} --no-cache-dir \
-    boto3 \
-    cython \
-    h5py \
-    pillow \
-    protobuf \
-    pyyaml \
-    tqdm
-
-RUN python3 -m pip install ${PIP_INS_OPTS} ipython
+# python installation
+COPY --from=python /usr/local /usr/local
 
 ARG NNABLA_VER
-RUN pip install ${PIP_INS_OPTS} nnabla==${NNABLA_VER}
+RUN echo "[global]" >/etc/pip.conf \
+    && echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf \
+    && python3 -m pip install ${PIP_INS_OPTS} --no-cache-dir \
+       numpy\<1.22 \
+       scipy \
+       boto3 \
+       cython \
+       h5py \
+       pillow \
+       protobuf \
+       pyyaml \
+       tqdm \
+       ipython \
+       nnabla==${NNABLA_VER}
 
 # Entrypoint
 COPY .entrypoint.sh /opt/.entrypoint.sh


### PR DESCRIPTION
In our CI system, grad test sometimes has failure on python 3.9 environment by `KeyError`.
We think this was python issue, so update python version to 3.9.14.

This PR introduces python 3.9.14 environment in aarch64 environments.
