### PR TITLE
dynamic numpy version

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -57,7 +57,7 @@ CALL pip install %PIP_INS_OPTS% ^
            ipython ^
            librosa ^
            mako ^
-           "numpy>=1.20.0" ^
+           numpy ^
            pip ^
            protobuf ^
            pytest ^

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,7 +2,7 @@ Cython
 boto3
 h5py
 imageio
-numpy>=1.20.0
+numpy
 pillow
 protobuf<=3.19.4
 pyyaml

--- a/python/setup.py
+++ b/python/setup.py
@@ -20,13 +20,18 @@ from distutils.extension import Extension
 import os
 import shutil
 import sys
+import numpy
 from collections import namedtuple
 
 setup_requires = [
     'setuptools',
-    'numpy>=1.20.0',
     'Cython',  # Requires python-dev.
 ]
+
+numpy_version = ""
+numpy_version += numpy.__version__[0: numpy.__version__.rindex('.') + 1] + "0"
+numpy_requires = "numpy~={}".format(numpy_version)
+setup_requires.append(numpy_requires)
 
 install_requires = setup_requires + [
     'boto3',


### PR DESCRIPTION
Our numpy dependency explains to use `>=1.20.0`, but this does not work correctly.
This PR introduces to use the version of numpy which is used at build time.
