### PR TITLE
build python with pyenv

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -58,6 +58,13 @@ RUN eval ${YUM_OPTS} \
         libffi-devel \
         openssl11 \
         openssl11-devel \
+        zlib-devel \
+        bzip2 \
+        readline-devel \
+        sqlite \
+        sqlite-devel \
+        tk-devel \
+        xz-devel \
     && yum group install -y "Development Tools" \
     && yum clean all
 
@@ -153,24 +160,20 @@ ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD python/test_requirements.txt /tmp/deps/
 
-################################################## build python from source
-RUN if [ "${PYVERNAME}" == "3.7" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz; fi \
-	&& if [ "${PYVERNAME}" == "3.8" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz; fi \
-	&& if [ "${PYVERNAME}" == "3.9" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.9.8/Python-3.9.8.tgz; fi \
-	&& if [ "${PYVERNAME}" == "3.10" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz; fi \
-	&& tar -xzf Python-${PYVERNAME}*.tgz \
-	&& cd Python-${PYVERNAME}* \
-	&& if [ "${PYVERNAME}" == "3.10" ]; then sed -i 's/PKG_CONFIG openssl /PKG_CONFIG openssl11 /g' configure; fi \
-	&& ./configure --enable-optimizations \
-	&& make altinstall \
-	&& ln -s -f /usr/local/bin/python${PYVERNAME} /usr/bin/python \
-	&& ln -s /usr/local/bin/pip${PYVERNAME} /usr/local/bin/pip \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/setup_requirements.txt \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/requirements.txt \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/test_requirements.txt \
-	&& cd .. \
-	&& rm -rf Python-${PYVERNAME}* \
-	&& rm -rf /tmp/*
+################################################## build python from pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
+    && pyenv global system \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/setup_requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/test_requirements.txt \
+    && rm -rf ~/.pyenv/.git /tmp/*
 
 ENV PATH /tmp/.local/bin:$PATH
 ENV LD_LIBRARY_PATH /usr/local/lib64:$LD_LIBRARY_PATH

--- a/docker/development/Dockerfile.build-aarch64
+++ b/docker/development/Dockerfile.build-aarch64
@@ -78,7 +78,7 @@ RUN mkdir /tmp/deps \
 
 ARG PYTHON_VERSION_MAJOR=3
 ARG PYTHON_VERSION_MINOR=9
-ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.14
+ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
@@ -87,7 +87,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && eval "$(pyenv init -)" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
-    && python-build ${PYVERNAME} /usr/local/ \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
     && pyenv global system \
     && rm -rf ~/.pyenv/.git
 
@@ -95,12 +95,11 @@ ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD python/test_requirements.txt /tmp/deps/
 
-RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip \
+RUN python3 -m pip install ${PIP_INS_OPTS} --no-cache-dir --upgrade pip \
     && echo "[global]" >/etc/pip.conf \
     && echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf \
-    && pip3 install ${PIP_INS_OPTS} numpy\<1.22 \
-    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/setup_requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -r /tmp/deps/setup_requirements.txt \
     && sed -i '/onnx/d' /tmp/deps/requirements.txt \
-    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/requirements.txt
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -r /tmp/deps/requirements.txt
 
 ENV PATH /tmp/.local/bin:$PATH

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -53,6 +53,21 @@ RUN eval ${YUM_OPTS} \
         gmp-devel \
         openssl11 \
         openssl11-devel \
+        make \
+        build-essential \
+        libssl-dev \
+        zlib1g-dev \
+        libbz2-dev \
+        libreadline-dev \
+        libsqlite3-dev \
+        llvm \
+        libncursesw5-dev \
+        xz-utils \
+        tk-dev \
+        libxml2-dev \
+        libxmlsec1-dev \
+        libffi-dev \
+        liblzma-dev \
     && yum group install -y "Development Tools" \
     && yum clean all
 
@@ -141,30 +156,27 @@ RUN mkdir /tmp/deps \
 
 ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
+ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD python/test_requirements.txt /tmp/deps/
 
-################################################## build python from source
-RUN if [ "${PYVERNAME}" == "3.7" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.7.10/Python-3.7.10.tgz; fi \
-	&& if [ "${PYVERNAME}" == "3.8" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.8.8/Python-3.8.8.tgz; fi \
-	&& if [ "${PYVERNAME}" == "3.9" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.9.8/Python-3.9.8.tgz; fi \
-	&& if [ "${PYVERNAME}" == "3.10" ]; then wget ${WGET_OPTS} https://www.python.org/ftp/python/3.10.7/Python-3.10.7.tgz; fi \
-	&& tar -xzf Python-${PYVERNAME}*.tgz \
-	&& cd Python-${PYVERNAME}* \
-	&& if [ "${PYVERNAME}" == "3.10" ]; then sed -i 's/PKG_CONFIG openssl /PKG_CONFIG openssl11 /g' configure; fi \
-	&& ./configure --enable-optimizations \
-	&& make altinstall \
-	&& ln -s -f /usr/local/bin/python${PYVERNAME} /usr/bin/python \
-	&& ln -s /usr/local/bin/pip${PYVERNAME} /usr/local/bin/pip \
-	&& pip install ${PIP_INS_OPTS} -y numpy scipy scikit-image six \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/setup_requirements.txt \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/requirements.txt \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/test_requirements.txt \
-	&& cd .. \
-	&& rm -rf Python-${PYVERNAME}* \
-	&& rm -rf /tmp/*
+################################################## build python from pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
+    && pyenv global system \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -y  scikit-image \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/setup_requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/test_requirements.txt \
+    && rm -rf ~/.pyenv/.git /tmp/*
 
 ENV PATH /tmp/.local/bin:$PATH
 ENV LD_LIBRARY_PATH /usr/local/lib64:$LD_LIBRARY_PATH

--- a/docker/development/Dockerfile.document
+++ b/docker/development/Dockerfile.document
@@ -26,6 +26,7 @@ ARG APT_OPTS
 ENV LC_ALL C
 ENV LANG C
 ENV LANGUAGE C
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN eval ${APT_OPTS} \
     && apt-get update && apt-get install -y --no-install-recommends \
@@ -36,9 +37,6 @@ RUN eval ${APT_OPTS} \
     g++ \
     git \
     make \
-    python3.7-dev \
-    python3.7 \
-    python3-setuptools \
     unzip \
     zip \
     zlib1g-dev \
@@ -46,13 +44,6 @@ RUN eval ${APT_OPTS} \
     libarchive-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-RUN curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python3.7 get-pip.py ${PIP_INS_OPTS} \
-    && rm get-pip.py
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3.7 0
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 0
 
 RUN apt-get -yqq update \
     && apt-get -yqq install --no-install-recommends \
@@ -85,9 +76,55 @@ RUN apt-get -yqq update \
     && rm -rf /var/lib/apt/lists/*
 
 ADD python/setup_requirements.txt /tmp/deps/
-RUN pip3 install ${PIP_INS_OPTS} -U -r /tmp/deps/setup_requirements.txt
 ADD python/requirements.txt /tmp/deps/
-RUN pip3 install ${PIP_INS_OPTS} -U -r /tmp/deps/requirements.txt
-ADD doc/requirements.txt /tmp/deps/
-RUN sed -i '/nnabla==/d' /tmp/deps/requirements.txt \
-    && pip3 install ${PIP_INS_OPTS} -U -r /tmp/deps/requirements.txt
+ADD doc/requirements.txt /tmp/deps_doc/
+
+ENV PYVERNAME=3.7
+RUN eval ${APT_OPTS} \
+    && apt update \
+    && apt install -y --no-install-recommends \
+       git \
+       libssl-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libsqlite3-dev \
+       wget \
+       llvm \
+       libncursesw5-dev \
+       xz-utils \
+       tk-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       libffi-dev \
+       liblzma-dev \
+    && git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
+    && pyenv global system \
+    && rm -rf ~/.pyenv \
+    && apt autoremove --purge -y \
+       git \
+       libssl-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libsqlite3-dev \
+       wget \
+       llvm \
+       libncursesw5-dev \
+       xz-utils \
+       tk-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       libffi-dev \
+       liblzma-dev \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/setup_requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/requirements.txt \
+    && sed -i '/nnabla==/d' /tmp/deps_doc/requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps_doc/requirements.txt \
+    && rm -rf /tmp/*
+
+

--- a/docker/development/Dockerfile.nnabla-test
+++ b/docker/development/Dockerfile.nnabla-test
@@ -62,21 +62,11 @@ RUN eval ${APT_OPTS} && apt-get update \
        unzip \
        wget \
        zip \
-       python${PYVERNAME}-dev \
-       python3-venv \
-       python${PYVERNAME} \
-       python${PYVERNAME}-venv \
-    && apt-get install -y --no-install-recommends \
-       python${PYVERNAME}-distutils || echo "skip install python-distutils" \
+       patch \
+       libffi-dev \
+       libbz2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-RUN if [ "${PYVERNAME}" = "3.6" ]; then curl ${CURL_OPTS} https://bootstrap.pypa.io/pip/${PYVERNAME}/get-pip.py -o get-pip.py; else \
-    curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py; fi \
-    && python${PYVERNAME} get-pip.py ${PIP_INS_OPTS} \
-    && rm get-pip.py
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYVERNAME} 0
 
 ################################################## protobuf
 RUN mkdir /tmp/deps \
@@ -125,11 +115,20 @@ ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD python/test_requirements.txt /tmp/deps/
 
-RUN pip install ${PIP_INS_OPTS} numpy \
-    && pip install ${PIP_INS_OPTS} -U -r /tmp/deps/setup_requirements.txt \
-    && pip install ${PIP_INS_OPTS} -U -r /tmp/deps/requirements.txt \
-    && pip install ${PIP_INS_OPTS} -U -r /tmp/deps/test_requirements.txt \
-    && rm -rf /tmp/*
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
+    && pyenv global system \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U setuptools \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/setup_requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/test_requirements.txt \
+    && rm -rf ~/.pyenv/.git /tmp/*
 
 ENV PATH /tmp/.local/bin:$PATH
 ENV LD_LIBRARY_PATH /usr/local/lib64:/usr/local/lib:$LD_LIBRARY_PATH

--- a/docker/development/Dockerfile.nnabla-test-aarch64
+++ b/docker/development/Dockerfile.nnabla-test-aarch64
@@ -100,7 +100,7 @@ RUN mkdir /tmp/deps \
 
 ARG PYTHON_VERSION_MAJOR=3
 ARG PYTHON_VERSION_MINOR=9
-ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.14
+ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 # Install pyenv
 RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
@@ -109,7 +109,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && eval "$(pyenv init -)" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
-    && python-build ${PYVERNAME} /usr/local/ \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
     && pyenv global system \
     && rm -rf ~/.pyenv/.git
 
@@ -120,10 +120,9 @@ ADD python/test_requirements.txt /tmp/deps/
 RUN python3 -m pip install ${PIP_INS_OPTS} --upgrade pip \
     && echo "[global]" >/etc/pip.conf \
     && echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf \
-    && pip3 install ${PIP_INS_OPTS} 'numpy>=1.20.0,<1.22' \
-    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/setup_requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -r /tmp/deps/setup_requirements.txt \
     && sed -i '/onnx/d' /tmp/deps/requirements.txt \
-    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/requirements.txt \
-    && pip3 install ${PIP_INS_OPTS} -r /tmp/deps/test_requirements.txt
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -r /tmp/deps/requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -r /tmp/deps/test_requirements.txt
 
 ENV PATH /tmp/.local/bin:$PATH

--- a/docker/development/Dockerfile.nnabla-test-ppc64le
+++ b/docker/development/Dockerfile.nnabla-test-ppc64le
@@ -64,23 +64,10 @@ RUN eval ${APT_OPTS} && apt-get update \
        unzip \
        wget \
        zip \
-       python${PYVERNAME}-dev \
-       python3-venv \
-       python${PYVERNAME} \
-       python${PYVERNAME}-venv \
        libsndfile1 \
        liblzma-dev \
-    && apt-get install -y --no-install-recommends \
-       python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-RUN if [ "${PYVERNAME}" = "3.6" ]; then curl ${CURL_OPTS} https://bootstrap.pypa.io/pip/${PYVERNAME}/get-pip.py -o get-pip.py; else \
-    curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py; fi \
-    && python${PYVERNAME} get-pip.py ${PIP_INS_OPTS} \
-    && rm get-pip.py
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYVERNAME} 0
 
 ################################################## libarchive
 RUN cd /tmp \
@@ -140,13 +127,20 @@ ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD python/test_requirements.txt /tmp/deps/
 
-################################################## requirements
-RUN pip install ${PIP_INS_OPTS} -y -U numpy \
-	&& pip install ${PIP_INS_OPTS} scipy\<1.4 \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/setup_requirements.txt \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/requirements.txt \
-	&& pip install ${PIP_INS_OPTS} -U -r /tmp/deps/test_requirements.txt \
-	&& rm -rf /tmp/*
+################################################## build python from pyenv
+RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
+    && pyenv global system \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/setup_requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/requirements.txt \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir -U -r /tmp/deps/test_requirements.txt \
+    && rm -rf ~/.pyenv/.git /tmp/*
 
 ENV PATH /tmp/.local/bin:$PATH
 ENV LD_LIBRARY_PATH /usr/local/lib64:$LD_LIBRARY_PATH

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -35,23 +35,64 @@ RUN eval ${APT_OPTS} && apt-get update \
        curl \
        libglib2.0-0 \
        libgl1-mesa-glx \
-       python${PYTHON_VER} \
-       python${PYTHON_VER}-distutils \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python${PYTHON_VER} 0
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYTHON_VER} 0
-
-RUN curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py \
-    && python${PYTHON_VER} get-pip.py ${PIP_INS_OPTS} \
-    && rm get-pip.py
-
-RUN pip install ${PIP_INS_OPTS} wheel setuptools
-RUN pip install ${PIP_INS_OPTS} opencv-python || true
 
 ARG NNABLA_VER
-RUN pip install ${PIP_INS_OPTS} nnabla==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
+RUN eval ${APT_OPTS} \
+    && apt update \
+    && apt install -y --no-install-recommends \
+       git \
+       make \
+       build-essential \
+       libssl-dev \
+       zlib1g-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libsqlite3-dev \
+       wget \
+       llvm \
+       libncursesw5-dev \
+       xz-utils \
+       tk-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       libffi-dev \
+       liblzma-dev \
+    && git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && PYTHON_VERSION_MINOR=${PYTHON_VER#*.} \
+    && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYTHON_VER}` /usr/local \
+    && pyenv global system \
+    && rm -rf ~/.pyenv \
+    && apt autoremove --purge -y \
+       git \
+       make \
+       build-essential \
+       libssl-dev \
+       zlib1g-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libsqlite3-dev \
+       wget \
+       llvm \
+       libncursesw5-dev \
+       xz-utils \
+       tk-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       libffi-dev \
+       liblzma-dev \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir --upgrade pip \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir wheel setuptools \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir opencv-python || true \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir nnabla==${NNABLA_VER} nnabla_converter==${NNABLA_VER}
 
 # Entrypoint
 COPY .entrypoint.sh /opt/.entrypoint.sh

--- a/docker/release/Dockerfile.py39-aarch64
+++ b/docker/release/Dockerfile.py39-aarch64
@@ -12,56 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM multiarch/debian-debootstrap:arm64-bullseye as python
-
-ARG PIP_INS_OPTS
-ARG PYTHONWARNINGS
-ARG CURL_OPTS
-ARG WGET_OPTS
-
-ENV DEBIAN_FRONTEND noninteractive
-
-ENV LC_ALL C
-ENV LANG C
-ENV LANGUAGE C
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    build-essential \
-    curl \
-    git \
-    make \
-    wget \
-    llvm \
-    xz-utils \
-    tk-dev \
-    zlib1g-dev \
-    libxml2-dev \
-    libxmlsec1-dev \
-    liblzma-dev \
-    libbz2-dev \
-    libreadline-dev \
-    libncursesw5-dev \
-    libsqlite3-dev \
-    libffi-dev \
-    libssl-dev
-
-ARG PYTHON_VERSION_MAJOR=3
-ARG PYTHON_VERSION_MINOR=9
-ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}.14
-
-# Install pyenv
-RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
-    && export PYENV_ROOT="$HOME/.pyenv" \
-    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
-    && eval "$(pyenv init -)" \
-    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
-    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
-    && python-build ${PYVERNAME} /usr/local/ \
-    && pyenv global system \
-    && rm -rf ~/.pyenv/.git
-
-
 FROM multiarch/debian-debootstrap:arm64-bullseye
 
 ARG PIP_INS_OPTS
@@ -83,18 +33,68 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libhdf5-dev \
     libopenblas-dev \
     liblapack-dev \
+    pkg-config \
     curl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# python installation
-COPY --from=python /usr/local /usr/local
-
 ARG NNABLA_VER
-RUN echo "[global]" >/etc/pip.conf \
+ARG PYTHON_VERSION_MAJOR=3
+ARG PYTHON_VERSION_MINOR=9
+ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
+
+RUN eval ${APT_OPTS} \
+    && apt update \
+    && apt install -y --no-install-recommends \
+       build-essential \
+       git \
+       make \
+       wget \
+       llvm \
+       xz-utils \
+       tk-dev \
+       zlib1g-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       liblzma-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libncursesw5-dev \
+       libsqlite3-dev \
+       libffi-dev \
+       libssl-dev \
+    && git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
+    && pyenv global system \
+    && rm -rf ~/.pyenv \
+    && apt autoremove --purge -y \
+       git \
+       build-essential \
+       git \
+       make \
+       wget \
+       llvm \
+       xz-utils \
+       tk-dev \
+       zlib1g-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       liblzma-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libncursesw5-dev \
+       libsqlite3-dev \
+       libffi-dev \
+       libssl-dev \
+    && echo "[global]" >/etc/pip.conf \
     && echo "extra-index-url=https://www.piwheels.org/simple" >> /etc/pip.conf \
     && python3 -m pip install ${PIP_INS_OPTS} --no-cache-dir \
-       numpy\<1.22 \
+       numpy \
        scipy \
        boto3 \
        cython \

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -18,6 +18,7 @@ ARG PYTHONWARNINGS
 ARG CURL_OPTS
 ARG WGET_OPTS
 ARG APT_OPTS
+ENV DEBIAN_FRONTEND noninteractive
 
 ARG PYTHON_VERSION_MAJOR
 ARG PYTHON_VERSION_MINOR
@@ -35,25 +36,64 @@ RUN eval ${APT_OPTS} && apt-get update \
        curl \
        libglib2.0-0 \
        libgl1-mesa-glx \
-       python${PYVERNAME} \
-    && apt-get install -y --no-install-recommends \
-       python${PYVERNAME}-distutils || echo "skip install python-distutils" \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-RUN if [ "${PYVERNAME}" = "3.6" ]; then curl ${CURL_OPTS} https://bootstrap.pypa.io/pip/${PYVERNAME}/get-pip.py -o get-pip.py; else \
-    curl ${CURL_OPTS} https://bootstrap.pypa.io/get-pip.py -o get-pip.py; fi \
-    && python${PYVERNAME} get-pip.py ${PIP_INS_OPTS}
-
-RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python${PYVERNAME} 0
-
-RUN pip install ${PIP_INS_OPTS} wheel
-RUN pip install ${PIP_INS_OPTS} protobuf
-RUN pip install ${PIP_INS_OPTS} opencv-python || true
-
+################################################## build python from pyenv
 ARG WHL_PATH
 ADD $WHL_PATH/*.whl /tmp/
 
-RUN pip install ${PIP_INS_OPTS} /tmp/*.whl && rm -rf /tmp/*
+RUN eval ${APT_OPTS} \
+    && apt update \
+    && apt install -y --no-install-recommends \
+       git \
+       make \
+       build-essential \
+       libssl-dev \
+       zlib1g-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libsqlite3-dev \
+       wget \
+       llvm \
+       libncursesw5-dev \
+       xz-utils \
+       tk-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       libffi-dev \
+       liblzma-dev \
+    && git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
+    && export PYENV_ROOT="$HOME/.pyenv" \
+    && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
+    && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
+    && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
+    && eval "$(pyenv init -)" \
+    && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
+    && pyenv global system \
+    && rm -rf ~/.pyenv \
+    && apt autoremove --purge -y \
+       git \
+       make \
+       build-essential \
+       libssl-dev \
+       zlib1g-dev \
+       libbz2-dev \
+       libreadline-dev \
+       libsqlite3-dev \
+       wget \
+       llvm \
+       libncursesw5-dev \
+       xz-utils \
+       tk-dev \
+       libxml2-dev \
+       libxmlsec1-dev \
+       libffi-dev \
+       liblzma-dev \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir wheel protobuf \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir opencv-python || true \
+    && pip install ${PIP_INS_OPTS} --no-cache-dir /tmp/*.whl \
+    && rm -rf /tmp/*
 
 ENV LD_LIBRARY_PATH /usr/lib64:$LD_LIBRARY_PATH

--- a/docker/tutorial/Dockerfile
+++ b/docker/tutorial/Dockerfile
@@ -18,6 +18,7 @@ ARG PIP_INS_OPTS
 ARG PYTHONWARNINGS
 ARG CURL_OPTS
 ARG WGET_OPTS
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-pip python3-setuptools python3-wheel git\


### PR DESCRIPTION
On Mac and aarch64 environment, we faced python issue: `<frozen importlib._bootstrap>:110: KeyError`
This seems to be caused by a bug: https://bugs.python.org/issue43546 , and this is fixed by latest.

But distributed packages on each environment are not upgraded as of now,
so we have decided to use pyenv to use latest python version and for easy to migrate to new version.
