### PR TITLE
Fix a potential bug in memory-release behavior in auto forward mode

### DIFF
--- a/include/nbla/synced_array.hpp
+++ b/include/nbla/synced_array.hpp
@@ -150,6 +150,10 @@ public:
     return head_.dtype;
   };
 
+  /** Returns true if this SyncedArray has the head array.
+   */
+  bool has_head_array() { return !head_.key.empty() && !array_.empty(); }
+
   /** Get the array class of the head.
    *
    */
@@ -262,10 +266,6 @@ private:
   /** Get offset of the Array.
    */
   Size_t offset() const { return offset_; }
-
-  /** Returns true if this SyncedArray has the head array.
-   */
-  bool has_head_array() { return !head_.key.empty() && !array_.empty(); }
 
   /** Get root of parent-child SyncedArrays.
    */

--- a/python/test/function/test_top_k_grad.py
+++ b/python/test/function/test_top_k_grad.py
@@ -53,16 +53,17 @@ def ref_top_k_grad_bw(x, g, k, abs, base_axis, **kw):
 def test_forward_backward(seed, ishape, k, abs, base_axis, ctx, fname):
     rng = np.random.RandomState(seed)
     inputs = [rng.randn(*ishape).astype(np.float32)]
+    grad_unstable = False
     if fname.endswith('Cuda'):
         # TopKGradCuda backward use unstable sort, so the result will change each run.
-        disable_clear_no_need_grad_test = True
-    else:
-        disable_clear_no_need_grad_test = False
+        grad_unstable = True
+
     function_tester(rng, F.top_k_grad, ref_top_k_grad_fw, inputs, ctx=ctx,
                     func_name=fname, ref_grad=ref_top_k_grad_bw,
                     func_args=[k, abs, base_axis],
                     disable_half_test=k > 10,
-                    disable_clear_no_need_grad_test=disable_clear_no_need_grad_test)
+                    disable_clear_no_need_grad_test=grad_unstable,
+                    disable_auto_forward_backward_tester=grad_unstable)
 
     # Note: FP16 has too many duplicate value for larger K to get the
     # same sort order as FP32 and this makes the function tester fail

--- a/python/test/test_nd_array.py
+++ b/python/test/test_nd_array.py
@@ -55,6 +55,11 @@ def test_copy_from():
     from nnabla.ext_utils import get_extension_context
     with nn.context_scope(get_extension_context('cpu', dtype='float')):
         dst.copy_from(src, use_current_context=True)
+    assert dst.dtype == np.uint8
+
+    src.zero()
+    with nn.context_scope(get_extension_context('cpu', dtype='float')):
+        dst.copy_from(src, use_current_context=True)
     assert dst.dtype == np.float32
 
 

--- a/src/nbla/computation_graph/variable.cpp
+++ b/src/nbla/computation_graph/variable.cpp
@@ -1090,25 +1090,27 @@ CgVariablePtr CgVariable::create_deep_copy(Context ctx, bool copy_grad) {
 
 // the vec is the inputs or outputs of a Function. If the target is found in the
 // vec, grad_depends_on_inputs/outputs is checked.
-bool find_grad_dependency(const CgVariable *const target,
+bool find_grad_dependency(int target_idx, 
                           const vector<CgVariablePtr> &vec,
                           std::function<bool(int, int)> grad_depends) {
-  const auto found =
-      std::find_if(vec.cbegin(), vec.cend(), [target](const CgVariablePtr v) {
-        return target == v.get();
-      });
-
-  if (found != vec.cend()) {
-    const size_t j = std::distance(vec.cbegin(), found);
-    for (size_t i = 0; i < vec.size(); i++) {
-      if (grad_depends(i, j)) {
-        return true;
-      }
+  for (size_t i = 0; i < vec.size(); i++) {
+    if (grad_depends(i, target_idx)) {
+      return true;
     }
   }
 
   return false;
 }
+
+int get_variable_index(const CgVariable *const var,
+                       const vector<CgVariablePtr> &vec) {
+  const auto found = 
+      std::find_if(vec.cbegin(), vec.cend(), [var](const CgVariablePtr v) {
+        return var == v.get();
+      });
+  
+  return std::distance(vec.cbegin(), found);
+} 
 
 bool CgVariable::has_grad_dependency() {
   // Check the grad dependency for the parent Function as an output.
@@ -1118,7 +1120,9 @@ bool CgVariable::has_grad_dependency() {
       return (f->grad_depends_output_data(i, o) ||
               f->auto_grad_depends_output_data(i, o));
     };
-    if (find_grad_dependency(this, parent_->outputs(), grad_depends)) {
+    int o = get_variable_index(this, parent_->outputs());
+    if (o < parent_->outputs().size()
+         && find_grad_dependency(o, parent_->inputs(), grad_depends)) {
       return true;
     }
   }
@@ -1133,7 +1137,9 @@ bool CgVariable::has_grad_dependency() {
         }
         return false;
       };
-      if (find_grad_dependency(this, func->inputs(), grad_depends)) {
+      int i = get_variable_index(this, func->inputs());
+      if (i < func->inputs().size()
+           && find_grad_dependency(i, func->inputs(), grad_depends)) {
         return true;
       }
     }

--- a/src/nbla/function/generic/identity.cpp
+++ b/src/nbla/function/generic/identity.cpp
@@ -34,8 +34,15 @@ void Identity<T>::setup_impl(const Variables &inputs,
 template <class T>
 void Identity<T>::forward_impl(const Variables &inputs,
                                const Variables &outputs) {
-  const Array *x = inputs[0]->data()->get(get_dtype<T>(), this->ctx_);
-  Array *y = outputs[0]->data()->cast(get_dtype<T>(), this->ctx_, true);
+  dtypes dtype = get_dtype<T>();
+#if 1
+  auto arr = inputs[0]->data()->array();
+  if (arr->has_head_array()) {
+    dtype = arr->dtype();
+  }
+#endif
+  const Array *x = inputs[0]->data()->get(dtype, this->ctx_);
+  Array *y = outputs[0]->data()->cast(dtype, this->ctx_, true);
   y->copy_from(x);
 }
 


### PR DESCRIPTION
There was a potential bug which causes an error in memory-release behavior during auto-forward execution. It became an error depending on implementation of `grad_depends_*` and `auto_grad_depnds_*` in a Function class. (Fortunatly, there was no Function which caused an actual runtime error in the current main branch.)
This PR fixes the potential issue along with an addition of a test case for deteting an error due to this bug.