### PR TITLE
Options to scale gradients and to keep dtype in allreduce callback

### DIFF
--- a/include/nbla/communicator.hpp
+++ b/include/nbla/communicator.hpp
@@ -173,20 +173,30 @@ public:
   @param ndarray_list Vector of NdArrayPtr
   @param pack_size The number of values contained in the packed data.
   @param division Divide the reduced value.
+  @param scale_grad Scaling gradient before allreduce. See Python documentation
+  for more details.
+  @param keep_dtype Keep dtype of arrays unchanged. See Python documentation for
+  more details.
    */
   virtual CommunicatorBackwardCallbackPtr
   all_reduce_callback(const vector<NdArrayPtr> &ndarray_list, size_t pack_size,
-                      bool division = false, const string &group = "world");
+                      bool division = false, const string &group = "world",
+                      float scale_grad = 1.0, bool keep_dtype = false);
 
   /** all_reduce over parameters added.
 
   @param ndarray NdArrayPtr
   @param pack_size The number of values contained in the packed data.
   @param division Divide the reduced value.
+  @param scale_grad Scaling gradient before allreduce. See Python documentation
+  for more details.
+  @param keep_dtype Keep dtype of arrays unchanged. See Python documentation for
+  more details.
    */
   virtual CommunicatorBackwardCallbackPtr
   all_reduce_callback(NdArrayPtr ndarray, size_t pack_size,
-                      bool division = false, const string &group = "world");
+                      bool division = false, const string &group = "world",
+                      float scale_grad = 1.0, bool keep_dtype = false);
 
   /** reducescatter.
 

--- a/python/src/nnabla/communicator.pxd
+++ b/python/src/nnabla/communicator.pxd
@@ -50,8 +50,8 @@ cdef extern from "nbla/communicator.hpp" namespace "nbla":
         void allreduce(cpp_bool division, cpp_bool inplace) nogil except +
         void all_reduce(const vector[shared_ptr[CNdArray]] & ndarray_list, cpp_bool division, cpp_bool inplace, const string & group) nogil except +
         void all_reduce(shared_ptr[CNdArray] data, cpp_bool division, cpp_bool inplace, const string & group) nogil except +
-        CommunicatorBackwardCallbackPtr all_reduce_callback(const vector[shared_ptr[CNdArray]] & ndarray_list, size_t pack_size, cpp_bool division, const string & group) except +
-        CommunicatorBackwardCallbackPtr all_reduce_callback(shared_ptr[CNdArray] data, size_t pack_size, cpp_bool division, const string & group) except +
+        CommunicatorBackwardCallbackPtr all_reduce_callback(const vector[shared_ptr[CNdArray]] & ndarray_list, size_t pack_size, cpp_bool division, const string & group, float scale_grad, cpp_bool keep_dtype) except +
+        CommunicatorBackwardCallbackPtr all_reduce_callback(shared_ptr[CNdArray] data, size_t pack_size, cpp_bool division, const string & group, float scale_grad, cpp_bool keep_dtype) except +
         void reduce_scatter(const vector[shared_ptr[CNdArray]] & ndarray_list, shared_ptr[CNdArray] ndarray, cpp_bool division, const string & group) nogil except +
         void bcast(const vector[shared_ptr[CNdArray]] & ndarray_list, int src, cpp_bool inplace, const string & group) nogil except +
         void bcast(shared_ptr[CNdArray] ndarray, int src, cpp_bool inplace, const string & group) nogil except +

--- a/python/test/communicator/test_all_reduce_callback.py
+++ b/python/test/communicator/test_all_reduce_callback.py
@@ -74,3 +74,121 @@ def test_all_reduce_callback(seed, pack_size, division, comm_nccl_opts):
     # Check
     for x, ref in zip(x_list1, x_list2):
         assert_allclose(x.g, ref.g)
+
+
+@pytest.mark.parametrize("scale_grad", [1, 0.1])
+@pytest.mark.parametrize("division", [False, True])
+@pytest.mark.parametrize("keep_dtype", [False, True])
+def test_all_reduce_callback_narrow(comm_nccl_opts, scale_grad, division, keep_dtype):
+    from nnabla.function import PythonFunction
+
+    class ConstantGrad(PythonFunction):
+        def __init__(self, ctx, value, dtype):
+            super(ConstantGrad, self).__init__(ctx)
+            self.value = value
+            self.dtype = dtype
+
+        @property
+        def name(self):
+            return 'ConstantGrad'
+
+        def min_outputs(self):
+            return 1
+
+        def grad_depends_output_data(self, i, o):
+            return False
+
+        def grad_depends_input_data(self, i, j):
+            return False
+
+        def setup_impl(self, inputs, outputs):
+            assert len(inputs) == 2
+            outputs[0].reset_shape(inputs[0].shape, True)
+
+        def forward_impl(self, inputs, outputs):
+            outputs[0].data.fill(0)
+            outputs[0].data.cast(self.dtype, self.ctx)
+
+        def backward_impl(self, inputs, outputs, propagate_down, accum):
+            x0, x1 = inputs
+            x0.grad.fill(self.value)
+            x0.grad.cast(self.dtype, self.ctx)
+            x1.grad.fill(self.value)
+            x1.grad.cast(self.dtype, self.ctx)
+
+    def constant_grad(a, b, value, dtype):
+        c = ConstantGrad(comm_nccl_opts.ctx, value, dtype)
+        return c(a, b)
+
+    if comm_nccl_opts is None:
+        pytest.skip(
+            "Communicator test is disabled. You can turn it on by an option `--test-communicator`.")
+    if len(comm_nccl_opts.devices) < 2:
+        pytest.skip(
+            "Communicator test is disabled. Use more than 1 gpus.")
+
+    comm = comm_nccl_opts.comm
+    device_id = int(comm_nccl_opts.device_id)
+    nn.set_default_context(comm_nccl_opts.ctx)
+
+    x = nn.Variable((4,))
+    a = nn.Variable((2, 3, 4), need_grad=True)
+    b = nn.Variable((5, 1), need_grad=True)
+    c = nn.Variable(tuple(), need_grad=True)
+    d = nn.Variable((1, 3), need_grad=True)
+
+    import nnabla.solvers as S
+    solver = S.Sgd()
+    param_dict = dict(a=a, b=b, c=c, d=d)
+    grad_list = list(v.grad for v in param_dict.values())
+    solver.set_parameters(param_dict)
+    dtype_list = [np.float32, np.float16, np.float32, np.float16]
+    h = constant_grad(x, a, 0.1 * (comm.rank + 1), np.float32)
+    h = constant_grad(h, b, 0.2 * (comm.rank + 1), np.float16)
+    h = constant_grad(h, c, 0.3 * (comm.rank + 1), np.float32)
+    y = constant_grad(h, d, 0.4 * (comm.rank + 1), np.float16)
+    y.forward()
+
+    # 1. standard all-reduce
+    y.backward()
+    solver.scale_grad(scale_grad)
+    comm.all_reduce(grad_list, inplace=True, division=division)
+    ref_list = [g.get_data('r').copy() for g in grad_list]
+
+    # 2. all-reduce with callback
+    pack_size = 8
+    cb = comm.all_reduce_callback(
+        grad_list, pack_size, division=division, scale_grad=scale_grad, keep_dtype=keep_dtype)
+    y.backward(communicator_callbacks=cb)
+    out_list = [g.get_data('r').copy() for g in grad_list]
+    for ref, out, dt in zip(ref_list, out_list, dtype_list):
+        if out.dtype == np.float16:
+            ref = ref.astype(np.float16)
+        assert_allclose(out, ref)
+        if keep_dtype:
+            assert out.dtype == dt, "Data types must be kept."
+        else:
+            assert out.dtype == ref.dtype, "Data type must be the same as dtype of communicator's output."
+
+    # 3. all-reduce with callback and narrow
+    ac = nn.NdArray((a.size + c.size,))
+    bd = nn.NdArray((b.size + d.size,))
+    a.grad = ac.narrow(0, 0, a.size).view(a.shape)
+    b.grad = bd.narrow(0, 0, b.size).view(b.shape)
+    c.grad = ac.narrow(0, a.size, c.size).view(c.shape)
+    d.grad = bd.narrow(0, b.size, d.size).view(d.shape)
+    grad_list = list(v.grad for v in param_dict.values())
+    cb = comm.all_reduce_callback(
+        grad_list, pack_size, division=division, scale_grad=scale_grad, keep_dtype=keep_dtype)
+    if keep_dtype:
+        y.backward(communicator_callbacks=cb)
+        out_list = [g.get_data('r').copy() for g in grad_list]
+        for ref, out, dt in zip(ref_list, out_list, dtype_list):
+            if out.dtype == np.float16:
+                ref = ref.astype(np.float16)
+            assert_allclose(out, ref)
+            assert out.dtype == dt, "Data types must be kept."
+    else:
+        with pytest.raises(RuntimeError):
+            # Type casting of narrowed arrays is prohibited.
+            y.backward(communicator_callbacks=cb)

--- a/src/nbla/communicator.cpp
+++ b/src/nbla/communicator.cpp
@@ -132,16 +132,16 @@ void Communicator::all_reduce(NdArrayPtr ndarray, bool division, bool inplace,
   NBLA_ERROR(error_code::not_implemented, "CPU all_reduce is not implemented.")
 }
 
-CommunicatorBackwardCallbackPtr
-Communicator::all_reduce_callback(const vector<NdArrayPtr> &ndarray_list,
-                                  size_t pack_size, bool division,
-                                  const string &group) {
+CommunicatorBackwardCallbackPtr Communicator::all_reduce_callback(
+    const vector<NdArrayPtr> &ndarray_list, size_t pack_size, bool division,
+    const string &group, float scale_grad, bool keep_dtype) {
   NBLA_ERROR(error_code::not_implemented,
              "CPU all_reduce_callback is not implemented")
 }
 CommunicatorBackwardCallbackPtr
 Communicator::all_reduce_callback(NdArrayPtr ndarray, size_t pack_size,
-                                  bool division, const string &group) {
+                                  bool division, const string &group,
+                                  float scale_grad, bool keep_dtype) {
   return this->all_reduce_callback(vector<NdArrayPtr>{ndarray}, pack_size,
                                    division, group);
 }


### PR DESCRIPTION
Add scale_grad and keep_dtype option to allreduce callback to perform it for narrowed arrays.