### PR TITLE
add a new subcommand for optimization of nnp model in proto graph

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -9,3 +9,4 @@ pyyaml
 scipy
 six
 tqdm
+ply

--- a/python/setup.py
+++ b/python/setup.py
@@ -46,7 +46,8 @@ install_requires = setup_requires + [
     'six',
     'tqdm',
     'imageio',
-    'pillow'
+    'pillow',
+    'ply'
 ]
 
 if sys.platform == 'win32':

--- a/python/src/nnabla/utils/cli/cli.py
+++ b/python/src/nnabla/utils/cli/cli.py
@@ -85,8 +85,8 @@ def main():
     from nnabla.utils.cli.func_info import add_function_info_command
     add_function_info_command(subparsers)
 
-    from nnabla.utils.cli.optimize_pb_model import add_optimize_pb_model_command
-    add_optimize_pb_model_command(subparsers)
+    from nnabla.utils.cli.optimize_model import add_optimize_command
+    add_optimize_command(subparsers)
 
     from nnabla.utils.cli.plot import (
         add_plot_series_command, add_plot_timer_command)

--- a/python/src/nnabla/utils/converter/nnabla/opt_graph.py
+++ b/python/src/nnabla/utils/converter/nnabla/opt_graph.py
@@ -1,0 +1,213 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import nnabla as nn
+
+
+class Token:
+    tokens = (
+        'Reshape',
+        'BatchMatmul',
+        'Add2',
+        'CommonFunc'
+    )
+
+    def __init__(self, op):
+        if op.type in Token.tokens:
+            self.type = op.type
+            self.value = op
+        else:
+            self.type = 'CommonFunc'
+            self.value = op
+        self.lineno = 0
+        self.lexpos = 0
+
+    def __repr__(self):
+        if self.value:
+            return "{}:{}".format(self.type, self.value.name)
+        else:
+            return "{}:{}".format(self.type, "None")
+
+
+class Branch:
+    pass
+
+
+class Resolver:
+    def resolve(self, old_graph, new_graph):
+        pass
+
+
+class AffineResolver(Resolver):
+    def __init__(self, branch):
+        self.branch = branch
+
+    def resolve(self, ob):
+        ob.clone_func(self.branch.batchmatmul.x)
+        ob.clone_variable(self.branch.batchmatmul.w.inputs[0])
+        if self.branch.add2 is not None:
+            ob.clone_func(self.branch.add2.bias)
+        func_name = ob.get_unique_name("MatmulAddToAffine")
+        affine = nn.graph_def.ProtoFunction(None,
+                                            'Affine',
+                                            {'base_axis': 1},
+                                            func_name,
+                                            ob.new_graph)
+        x = self.branch.batchmatmul.x.outputs[0]
+        w = self.branch.batchmatmul.w.inputs[0]
+        affine.inputs = [x, w]
+        if self.branch.add2:
+            b = self.branch.add2.bias.inputs[0]
+            affine.inputs.append(b)
+        affine.outputs = self.branch.outputs
+        for n in affine.outputs:
+            ob.clone_variable(n)
+        ob.new_graph.functions[func_name] = affine
+
+
+class OptimizerBuilder:
+    """
+    This class handles the parser event from opt_parser.
+    When a target statement is matched, an event is triggered,
+    we collected necessary information from this event and construct
+    the branches as what we want to understand.
+    """
+
+    def __init__(self, nnp_graph):
+        self.nnp_graph = nnp_graph
+        self.token_list = []
+        self.new_graph = nn.graph_def.ProtoNetwork(
+            self.nnp_graph.owner(), self.nnp_graph.name, self.nnp_graph.batch_size)
+        self.names = {}
+
+    def get_unique_name(self, name):
+        if name in self.names:
+            ret_name = f"{name}_{self.names[name]}"
+            self.names[name] += 1
+        else:
+            self.names[name] = 1
+            ret_name = name
+        return ret_name
+
+    def prepare(self):
+        for pf in self.nnp_graph.forward_sequence():
+            self.token_list.append(Token(pf))
+
+    def output(self):
+        return self.new_graph
+
+    def token(self):
+        if self.token_list:
+            tok = self.token_list.pop(0)
+            return tok
+        return None
+
+    def rf_affine(self, op_list):
+        """
+        This function constructs branches from op_list.
+        The knowledge of how to construct branches is known according
+        to what we want to optimize.
+        """
+        def set_op(branch, attr, op):
+            if getattr(branch, attr) is None:
+                setattr(branch, attr, op)
+            else:
+                raise ValueError("Incorrect branch!")
+
+        op_list = [op_list[0], *op_list[1], op_list[2]]
+        op_list = [op_list[0],
+                   op_list[1],
+                   self.rf_mul_add_resolve([
+                       self.rf_mul([op_list[2], op_list[3]]),
+                       self.rf_add([op_list[4], op_list[5]])
+                   ])
+                   ]
+
+        branch = op_list[2]
+        for op in op_list[:2]:
+            if branch.batchmatmul.batchmatmul.inputs[0] in op.outputs:
+                set_op(branch.batchmatmul, "x", op)
+            elif branch.batchmatmul.batchmatmul.inputs[1] in op.outputs:
+                set_op(branch.batchmatmul, "w", op)
+            if branch.add2 is not None:
+                if branch.add2.add2.inputs[0] in op.outputs:
+                    set_op(branch.add2, "x", op)
+                elif branch.add2.add2.inputs[1] in op.outputs:
+                    set_op(branch.add2, "bias", op)
+        return AffineResolver(branch)
+
+    def rf_mul(self, op_list):
+        branch = Branch()
+        branch.x = None
+        branch.w = None
+        branch.batchmatmul = op_list[1]
+        reshape = op_list[0]
+        if reshape.outputs[0] == branch.batchmatmul.inputs[0]:
+            branch.x = reshape
+        elif reshape.outputs[0] == branch.batchmatmul.inputs[1]:
+            branch.w = reshape
+        branch.outputs = branch.batchmatmul.outputs
+        return branch
+
+    def rf_add(self, op_list):
+        branch = Branch()
+        branch.x = None
+        branch.bias = None
+        branch.add2 = op_list[1]
+        reshape = op_list[0]
+        if reshape.outputs[0] == branch.add2.inputs[0]:
+            branch.x = reshape
+        elif reshape.outputs[0] == branch.add2.inputs[1]:
+            branch.bias = reshape
+        branch.outputs = branch.add2.outputs
+        return branch
+
+    def rf_mul_add_resolve(self, op_list):
+        branch = Branch()
+        branch.batchmatmul = op_list[0]
+        branch.outputs = branch.batchmatmul.outputs
+        branch.add2 = None
+        if len(op_list) == 2:
+            branch.add2 = op_list[1]
+            branch.outputs = branch.add2.outputs
+        return branch
+
+    def rf_mul_add(self, op_list):
+        return op_list
+
+    def clone_variable(self, vname):
+        self.get_unique_name(vname)
+        if vname in self.nnp_graph.variables:
+            self.new_graph.variables[vname] = self.nnp_graph.variables[vname].clone(
+            )
+        elif vname in self.nnp_graph.parameters:
+            self.new_graph.parameters[vname] = self.nnp_graph.parameters[vname].clone(
+            )
+
+    def clone_func(self, op):
+        for i in op.inputs:
+            self.clone_variable(i)
+        for o in op.outputs:
+            self.clone_variable(o)
+        self.get_unique_name(op.name)
+        self.new_graph.functions[op.name] = op.clone(self.new_graph)
+
+    def accept_layer(self, op):
+        if isinstance(op, nn.graph_def.ProtoFunction):
+            self.clone_func(op)
+        elif isinstance(op, Resolver):
+            op.resolve(self)
+        elif isinstance(op, list):
+            op_list = op
+            for op in op_list:
+                self.clone_func(op)

--- a/python/src/nnabla/utils/converter/nnabla/opt_parser.py
+++ b/python/src/nnabla/utils/converter/nnabla/opt_parser.py
@@ -1,0 +1,68 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from ply import yacc
+
+from .opt_graph import Token
+
+
+class OptimizerParser:
+    def __init__(self, graph):
+        self.graph = graph
+        self.tokens = Token.tokens
+        self.parser = yacc.yacc(module=self,
+                                start='rf_net',
+                                debug=False)
+        self.layer_num = 0
+
+    def parse(self):
+        return self.parser.parse(input=None,
+                                 lexer=self.graph,
+                                 debug=False,
+                                 tracking=False
+                                 )
+
+    def p_rf_net(self, p):
+        """ rf_net   :    rf_layers
+        """
+        pass
+
+    def p_rf_layers(self, p):
+        """ rf_layers   :    rf_layers rf_layer_stmt
+                        |    rf_layer_stmt
+        """
+        pass
+
+    def p_rf_layer_stmt(self, p):
+        """ rf_layer_stmt   :  rf_affine
+                         |     rf_mul_add
+                         |     BatchMatmul
+                         |     Reshape
+                         |     Add2
+                         |     CommonFunc
+
+        """
+        self.graph.accept_layer(p[1])
+
+    def p_rf_mul_add(self, p):
+        """ rf_mul_add   :     Reshape Reshape BatchMatmul Reshape
+         """
+        p[0] = self.graph.rf_mul_add(p[1:])
+
+    def p_rf_affine(self, p):
+        """ rf_affine    :    Reshape rf_mul_add Add2
+        """
+        p[0] = self.graph.rf_affine(p[1:])
+
+    def p_error(self, p):
+        raise ValueError("Failed to optimize the model.")

--- a/python/src/nnabla/utils/converter/nnabla/optimizer.py
+++ b/python/src/nnabla/utils/converter/nnabla/optimizer.py
@@ -1,0 +1,35 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .opt_graph import OptimizerBuilder
+from .opt_parser import OptimizerParser
+
+
+def optimize_nnp(graph_def):
+    opt_graph = OptimizerBuilder(graph_def.default_graph())
+    opt_parser = OptimizerParser(opt_graph)
+    opt_graph.prepare()
+    opt_parser.parse()
+    return opt_graph.output()
+
+
+if __name__ == '__main__':
+    import nnabla as nn
+    # Define when do unittest
+    input_file = ''
+    output_file = ''
+    g = nn.graph_def.load(input_file)
+    network = optimize_nnp(g)
+    g.networks[network.name] = network
+    g.save(output_file)

--- a/python/src/nnabla/utils/converter/setup.py
+++ b/python/src/nnabla/utils/converter/setup.py
@@ -37,7 +37,6 @@ if __name__ == '__main__':
         __email__ = a['__email__']
 
     install_requires = [
-        'ply',
         'tensorboard>=2.6.0, <=2.9.0',
         'tensorflow~=2.8.0;platform_system!="Windows"',
         'tensorflow>=2.8.0, <=2.8.1;platform_system=="Windows"',

--- a/python/test/utils/conversion/common.py
+++ b/python/test/utils/conversion/common.py
@@ -1,0 +1,168 @@
+import io
+import os
+import tempfile
+import warnings
+import numpy
+import nnabla as nn
+import numpy as np
+from shutil import rmtree
+from contextlib import contextmanager
+from nnabla.utils import nnabla_pb2
+from nnabla.utils.image_utils import imsave
+import google.protobuf.text_format as text_format
+from nnabla.utils.nnp_format import nnp_version
+from nnabla.parameter import get_parameter_or_create
+from nnabla.utils.get_file_handle import get_file_handle_save
+from nnabla.utils.converter.nnabla import NnpExpander
+from nnabla.initializer import (
+    NormalInitializer, UniformInitializer, ConstantInitializer, RangeInitializer,
+    calc_normal_std_he_forward, calc_normal_std_he_backward, calc_normal_std_glorot, calc_uniform_lim_glorot)
+
+
+@contextmanager
+def create_temp_with_dir(filename):
+    tmpdir = tempfile.mkdtemp()
+    print('created {}'.format(tmpdir))
+    csvfilename = os.path.join(tmpdir, filename)
+    yield csvfilename
+    rmtree(tmpdir, ignore_errors=True)
+    print('deleted {}'.format(tmpdir))
+
+
+def proto_from_str(nntxt_str):
+    proto = nnabla_pb2.NNablaProtoBuf()
+    text_format.Merge(nntxt_str, proto)
+    return proto
+
+
+@contextmanager
+def generate_csv_png(num_of_data, img_size):
+    with create_temp_with_dir('test.csv') as csvfilename:
+        imgdir = os.path.dirname(csvfilename)
+        with open(csvfilename, 'w') as f:
+            f.write('x:image,y\n')
+            for n in range(0, num_of_data):
+                x = np.identity(img_size).astype(numpy.uint8) * n
+                img_name = 'image_{}.png'.format(n)
+                with warnings.catch_warnings():
+                    warnings.simplefilter("ignore")
+                    imsave(os.path.join(imgdir, img_name), x)
+                f.write('{}, {}\n'.format(img_name, n % 10))
+        yield csvfilename
+
+
+def get_input_size(proto):
+    # TODO:
+    return 28
+
+
+def _create_variable(v, name, shape, rng):
+    # Create and initialize variables
+    class Variable:
+        pass
+
+    parameter = v.type == "Parameter"
+    variable_instance = None
+    if parameter:
+        if v.initializer.type == 'Normal':
+            initializer = NormalInitializer(v.initializer.multiplier, rng=rng)
+        elif v.initializer.type == 'NormalAffineHe' or v.initializer.type == 'NormalAffineHeForward':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_forward(
+                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalAffineHeBackward':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_backward(
+                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalAffineGlorot':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_glorot(
+                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalConvolutionHe' or v.initializer.type == 'NormalConvolutionHeForward':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_forward(
+                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalConvolutionHeBackward':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_backward(
+                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalConvolutionGlorot':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_glorot(
+                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalCLConvHe' or v.initializer.type == 'NormalCLConvHeForward':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_forward(
+                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalCLConvHeBackward':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_backward(
+                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'NormalCLConvGlorot':
+            initializer = (lambda shape: NormalInitializer(calc_normal_std_glorot(
+                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'Uniform':
+            initializer = UniformInitializer(
+                lim=[-v.initializer.multiplier, v.initializer.multiplier], rng=rng)
+        elif v.initializer.type == 'UniformAffineGlorot':
+            initializer = (lambda shape: UniformInitializer(calc_uniform_lim_glorot(
+                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'UniformConvolutionGlorot':
+            initializer = (lambda shape: UniformInitializer(calc_uniform_lim_glorot(
+                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'UniformCLConvGlorot':
+            initializer = (lambda shape: UniformInitializer(calc_uniform_lim_glorot(
+                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'Range':
+            initializer = (lambda shape: RangeInitializer(0, 1)
+                           (shape) * v.initializer.multiplier)
+        elif v.initializer.type == 'Constant':
+            initializer = ConstantInitializer(value=v.initializer.multiplier)
+        else:
+            initializer = None
+        variable_instance = get_parameter_or_create(name, shape, initializer)
+    else:
+        # create empty variable, memory will be allocated in network.setup()
+        # after network optimization
+        variable_instance = nn.Variable()
+
+    variable = Variable()
+    variable.name = name
+    variable.parameter = parameter
+    variable.shape = shape
+    variable.variable_instance = variable_instance
+
+    return variable
+
+
+def prepare_parameters(nntxt_str):
+    proto = proto_from_str(nntxt_str)
+    proto = NnpExpander(proto).execute()
+    rng = np.random.RandomState(0)
+    for n in proto.network:
+        for v in n.variable:
+            shape = tuple(
+                [d if d >= 1 else n.batch_size for d in v.shape.dim])
+            variable = _create_variable(v, v.name, shape, rng)
+
+
+@contextmanager
+def generate_case_from_nntxt_str(nntxt_str, nnp_filename, param_format, dataset_sample_num, batch_size=None):
+    proto = proto_from_str(nntxt_str)
+    with generate_csv_png(dataset_sample_num, get_input_size(proto)) as dataset_csv_file:
+        # To test dataset, we create a randomly generated dataset.
+        for ds in proto.dataset:
+            ds.batch_size = batch_size if batch_size else ds.batch_size
+            ds.uri = dataset_csv_file
+            ds.cache_dir = os.path.join(
+                os.path.dirname(dataset_csv_file), "data.cache")
+        nntxt_io = io.StringIO()
+        text_format.PrintMessage(proto, nntxt_io)
+        nntxt_io.seek(0)
+
+        version = io.StringIO()
+        version.write('{}\n'.format(nnp_version()))
+        version.seek(0)
+
+        param = io.BytesIO()
+        prepare_parameters(nntxt_str)
+        nn.parameter.save_parameters(param, extension=param_format)
+
+        with create_temp_with_dir(nnp_filename) as temp_nnp_file_name:
+            with get_file_handle_save(temp_nnp_file_name, ".nnp") as nnp:
+                nnp.writestr('nnp_version.txt', version.read())
+                nnp.writestr('network.nntxt', nntxt_io.read())
+                nnp.writestr('parameter{}'.format(param_format), param.read())
+            yield temp_nnp_file_name

--- a/python/test/utils/conversion/nnp_optimizer_test.py
+++ b/python/test/utils/conversion/nnp_optimizer_test.py
@@ -1,0 +1,67 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import numpy as np
+
+
+def generate_pb_with_dense_layer():
+    from tensorflow import keras
+    import tensorflow as tf
+    from tensorflow.python.framework.convert_to_constants import convert_variables_to_constants_v2
+
+    def get_model():
+        # Create a simple model.
+        inputs = keras.Input(shape=(32,))
+        outputs = keras.layers.Dense(1, use_bias=True)(inputs)
+        model = keras.Model(inputs, outputs)
+        model.compile(optimizer="adam", loss="mean_squared_error")
+        return model
+
+    model = get_model()
+
+    test_input = np.random.random((128, 32))
+    test_target = np.random.random((128, 1))
+    model.fit(test_input, test_target)
+
+    full_model = tf.function(lambda x: model(x))
+    full_model = full_model.get_concrete_function(
+        tf.TensorSpec(model.inputs[0].shape, model.inputs[0].dtype)
+    )
+    frozen_func = convert_variables_to_constants_v2(full_model)
+    frozen_func.graph.as_graph_def()
+    layers = [op.name for op in frozen_func.graph.get_operations()]
+    print("-" * 60)
+    print("Frozen model layers: ")
+    for layer in layers:
+        print(layer)
+    print("-" * 60)
+    print("Frozen model inputs: ")
+    print(frozen_func.inputs)
+    print("Frozen model outputs: ")
+    print(frozen_func.outputs)
+    # Save frozen graph to disk
+    frozen_graph_filename = "frozen_graph"
+    frozen_out_path = ''
+    tf.io.write_graph(graph_or_graph_def=frozen_func.graph,
+                      logdir=frozen_out_path,
+                      name=f"{frozen_graph_filename}.pb",
+                      as_text=False)
+    # Save its text representation
+    tf.io.write_graph(graph_or_graph_def=frozen_func.graph,
+                      logdir=frozen_out_path,
+                      name=f"{frozen_graph_filename}.pbtxt",
+                      as_text=True)
+
+
+if __name__ == '__main__':
+    generate_pb_with_dense_layer()

--- a/python/test/utils/conversion/nntxt.py
+++ b/python/test/utils/conversion/nntxt.py
@@ -3650,3 +3650,421 @@ executor {
   }
 }
 '''
+
+N0006 = r'''
+network {
+  name: "tf2onnx"
+  variable {
+    name: "model/dense/MatMul/ReadVariableOp:0"
+    type: "Parameter"
+    shape {
+      dim: 32
+      dim: 1
+    }
+    initializer {
+      type: "Constant"
+      multiplier: 1.0
+    }
+  }
+  variable {
+    name: "x:0"
+    type: "Buffer"
+    shape {
+      dim: -1
+      dim: 32
+    }
+  }
+  variable {
+    name: "Identity:0"
+    type: "Buffer"
+    shape {
+      dim: -1
+      dim: 1
+    }
+  }
+  variable {
+    name: "x:0_0001_reshape"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+      dim: 32
+    }
+  }
+  variable {
+    name: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 32
+      dim: 1
+    }
+  }
+  variable {
+    name: "Identity:0_0003_batchmatmul"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+      dim: 1
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_0"
+    type: "Reshape"
+    input: "x:0"
+    output: "x:0_0001_reshape"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 1
+        dim: 32
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_1"
+    type: "Reshape"
+    input: "model/dense/MatMul/ReadVariableOp:0"
+    output: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 32
+        dim: 1
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/BatchMatmul_0"
+    type: "BatchMatmul"
+    input: "x:0_0001_reshape"
+    input: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    output: "Identity:0_0003_batchmatmul"
+    batch_matmul_param {
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_2"
+    type: "Reshape"
+    input: "Identity:0_0003_batchmatmul"
+    output: "Identity:0"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 1
+      }
+    }
+  }
+}
+executor {
+  name: "exec_0"
+  network_name: "tf2onnx"
+  data_variable {
+    variable_name: "x:0"
+    data_name: "x:0"
+  }
+  output_variable {
+    variable_name: "Identity:0"
+    data_name: "Identity:0"
+  }
+  parameter_variable {
+    variable_name: "model/dense/MatMul/ReadVariableOp:0"
+  }
+}
+'''
+
+N0007 = r'''
+network {
+  name: "tf2onnx"
+  variable {
+    name: "model/dense/MatMul/ReadVariableOp:0"
+    type: "Parameter"
+    shape {
+      dim: 32
+      dim: 1
+    }
+    initializer {
+      type: "Constant"
+      multiplier: 1.0
+    }
+  }
+  variable {
+    name: "x:0"
+    type: "Buffer"
+    shape {
+      dim: -1
+      dim: 32
+    }
+  }
+  variable {
+    name: "Identity:0"
+    type: "Buffer"
+    shape {
+      dim: -1
+      dim: 1
+    }
+  }
+  variable {
+    name: "x:0_0001_reshape"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+      dim: 32
+    }
+  }
+  variable {
+    name: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 32
+      dim: 1
+    }
+  }
+  variable {
+    name: "Identity:0_0003_batchmatmul"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+      dim: 1
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_0"
+    type: "Reshape"
+    input: "x:0"
+    output: "x:0_0001_reshape"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 1
+        dim: 32
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_1"
+    type: "Reshape"
+    input: "model/dense/MatMul/ReadVariableOp:0"
+    output: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 32
+        dim: 1
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/BatchMatmul_0"
+    type: "BatchMatmul"
+    input: "x:0_0001_reshape"
+    input: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    output: "Identity:0_0003_batchmatmul"
+    batch_matmul_param {
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_2"
+    type: "Reshape"
+    input: "Identity:0_0003_batchmatmul"
+    output: "Identity:0"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 1
+      }
+    }
+  }
+}
+executor {
+  name: "exec_0"
+  network_name: "tf2onnx"
+  data_variable {
+    variable_name: "x:0"
+    data_name: "x:0"
+  }
+  output_variable {
+    variable_name: "Identity:0"
+    data_name: "Identity:0"
+  }
+  parameter_variable {
+    variable_name: "model/dense/MatMul/ReadVariableOp:0"
+  }
+}
+'''
+
+N0008 = r'''
+network {
+  name: "tf2onnx"
+  variable {
+    name: "model/dense/MatMul/ReadVariableOp:0"
+    type: "Parameter"
+    shape {
+      dim: 32
+      dim: 1
+    }
+    initializer {
+      type: "Constant"
+      multiplier: 1.0
+    }
+  }
+  variable {
+    name: "model/dense/BiasAdd/ReadVariableOp:0"
+    type: "Parameter"
+    shape {
+      dim: 1
+    }
+    initializer {
+      type: "Constant"
+      multiplier: 1.0
+    }
+  }
+  variable {
+    name: "x:0"
+    type: "Buffer"
+    shape {
+      dim: -1
+      dim: 32
+    }
+  }
+  variable {
+    name: "Identity:0"
+    type: "Buffer"
+    shape {
+      dim: -1
+      dim: 1
+    }
+  }
+  variable {
+    name: "x:0_0001_reshape"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+      dim: 32
+    }
+  }
+  variable {
+    name: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 32
+      dim: 1
+    }
+  }
+  variable {
+    name: "model/dense/MatMul:0_0003_batchmatmul"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+      dim: 1
+    }
+  }
+  variable {
+    name: "model/dense/MatMul:0"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+    }
+  }
+  variable {
+    name: "model/dense/BiasAdd/ReadVariableOp:0_0004_shape"
+    type: "Buffer"
+    shape {
+      dim: 1
+      dim: 1
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_0"
+    type: "Reshape"
+    input: "x:0"
+    output: "x:0_0001_reshape"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 1
+        dim: 32
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_1"
+    type: "Reshape"
+    input: "model/dense/MatMul/ReadVariableOp:0"
+    output: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 32
+        dim: 1
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/BatchMatmul_0"
+    type: "BatchMatmul"
+    input: "x:0_0001_reshape"
+    input: "model/dense/MatMul/ReadVariableOp:0_0002_reshape"
+    output: "model/dense/MatMul:0_0003_batchmatmul"
+    batch_matmul_param {
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/MatMul/Reshape_2"
+    type: "Reshape"
+    input: "model/dense/MatMul:0_0003_batchmatmul"
+    output: "model/dense/MatMul:0"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 1
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/BiasAdd/Reshape_3"
+    type: "Reshape"
+    input: "model/dense/BiasAdd/ReadVariableOp:0"
+    output: "model/dense/BiasAdd/ReadVariableOp:0_0004_shape"
+    reshape_param {
+      shape {
+        dim: 1
+        dim: 1
+      }
+    }
+  }
+  function {
+    name: "tf2onnx/model/dense/BiasAdd/Add2_0"
+    type: "Add2"
+    input: "model/dense/MatMul:0"
+    input: "model/dense/BiasAdd/ReadVariableOp:0_0004_shape"
+    output: "Identity:0"
+  }
+}
+executor {
+  name: "exec_0"
+  network_name: "tf2onnx"
+  data_variable {
+    variable_name: "x:0"
+    data_name: "x:0"
+  }
+  output_variable {
+    variable_name: "Identity:0"
+    data_name: "Identity:0"
+  }
+  parameter_variable {
+    variable_name: "model/dense/MatMul/ReadVariableOp:0"
+  }
+  parameter_variable {
+    variable_name: "model/dense/BiasAdd/ReadVariableOp:0"
+  }
+}
+'''

--- a/python/test/utils/conversion/test_nnp_optimizer.py
+++ b/python/test/utils/conversion/test_nnp_optimizer.py
@@ -1,0 +1,65 @@
+# Copyright 2022 Sony Group Corporation.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pytest
+import numpy as np
+import nnabla as nn
+import nnabla.utils.cli.optimize_model as opt_cli
+from .nntxt import (N0007, N0008)
+from .common import generate_case_from_nntxt_str
+from nnabla.utils import load
+
+
+cases = {
+    'without_bias': N0007,
+    'with_bias': N0008
+}
+
+
+inputs = [np.random.random((1, 32))]
+
+
+def forward(info):
+    for e in info.executors.values():
+        for v, d in zip(e.dataset_assign.keys(), inputs):
+            v.variable_instance.d = d
+
+    for v, generator in e.generator_assign.items():
+        v.variable_instance.d = generator(v.variable_instance.d.shape)
+
+    e.forward_target.forward(clear_buffer=True)
+
+    for o in e.output_assign.keys():
+        yield o.variable_instance.d
+
+
+@pytest.mark.parametrize("case_name", ["without_bias", "with_bias"])
+def test_nnp_optimizer_affine(case_name):
+    class Args:
+        pass
+    args = Args()
+    nnp_file_name = f"{case_name}.nnp"
+    with generate_case_from_nntxt_str(cases[case_name], nnp_file_name, ".h5", 32) as nnp_file:
+        args.input_file = [nnp_file]
+        opt_nnp_file = os.path.join(
+            os.path.dirname(nnp_file), f"{case_name}-opt.nnp")
+        args.output_file = [opt_nnp_file]
+        opt_cli.optimization_command(args)
+
+        info_expected = load.load(nnp_file, batch_size=1)
+        info_actual = load.load(opt_nnp_file, batch_size=1)
+
+        for expected, actual in zip(forward(info_expected), forward(info_actual)):
+            assert np.allclose(expected, actual)

--- a/python/test/utils/conversion/test_nnp_to_nnp_with_version.py
+++ b/python/test/utils/conversion/test_nnp_to_nnp_with_version.py
@@ -13,183 +13,17 @@
 # limitations under the License.
 
 import os
-import io
-import tempfile
-import warnings
 import pytest
-import numpy
-import numpy as np
-from shutil import rmtree
-from contextlib import contextmanager
 import nnabla as nn
 import nnabla.utils.converter as cvt
-from nnabla.utils import nnabla_pb2
-from nnabla.utils.image_utils import imsave
-import google.protobuf.text_format as text_format
-from nnabla.utils.nnp_format import nnp_version
-from nnabla.parameter import get_parameter_or_create
-from nnabla.utils.get_file_handle import get_file_handle_save
-from nnabla.utils.converter.nnabla import NnpExpander
-from nnabla.initializer import (
-    NormalInitializer, UniformInitializer, ConstantInitializer, RangeInitializer,
-    calc_normal_std_he_forward, calc_normal_std_he_backward, calc_normal_std_glorot, calc_uniform_lim_glorot)
 from .nntxt import (N0001, N0002, N0003, N0004, N0005)
-
+from .common import generate_case_from_nntxt_str
 
 N_ARRAY = [N0001, N0002, N0003, N0004, N0005]
 
 
-@contextmanager
-def create_temp_with_dir(filename):
-    tmpdir = tempfile.mkdtemp()
-    print('created {}'.format(tmpdir))
-    csvfilename = os.path.join(tmpdir, filename)
-    yield csvfilename
-    rmtree(tmpdir, ignore_errors=True)
-    print('deleted {}'.format(tmpdir))
-
-
-def proto_from_str(nntxt_str):
-    proto = nnabla_pb2.NNablaProtoBuf()
-    text_format.Merge(nntxt_str, proto)
-    return proto
-
-
-@contextmanager
-def generate_csv_png(num_of_data, img_size):
-    with create_temp_with_dir('test.csv') as csvfilename:
-        imgdir = os.path.dirname(csvfilename)
-        with open(csvfilename, 'w') as f:
-            f.write('x:image,y\n')
-            for n in range(0, num_of_data):
-                x = np.identity(img_size).astype(numpy.uint8) * n
-                img_name = 'image_{}.png'.format(n)
-                with warnings.catch_warnings():
-                    warnings.simplefilter("ignore")
-                    imsave(os.path.join(imgdir, img_name), x)
-                f.write('{}, {}\n'.format(img_name, n % 10))
-        yield csvfilename
-
-
-def get_input_size(proto):
-    # TODO:
-    return 28
-
-
-def _create_variable(v, name, shape, rng):
-    # Create and initialize variables
-    class Variable:
-        pass
-
-    parameter = v.type == "Parameter"
-    variable_instance = None
-    if parameter:
-        if v.initializer.type == 'Normal':
-            initializer = NormalInitializer(v.initializer.multiplier, rng=rng)
-        elif v.initializer.type == 'NormalAffineHe' or v.initializer.type == 'NormalAffineHeForward':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_forward(
-                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalAffineHeBackward':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_backward(
-                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalAffineGlorot':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_glorot(
-                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalConvolutionHe' or v.initializer.type == 'NormalConvolutionHeForward':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_forward(
-                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalConvolutionHeBackward':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_backward(
-                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalConvolutionGlorot':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_glorot(
-                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalCLConvHe' or v.initializer.type == 'NormalCLConvHeForward':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_forward(
-                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalCLConvHeBackward':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_he_backward(
-                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'NormalCLConvGlorot':
-            initializer = (lambda shape: NormalInitializer(calc_normal_std_glorot(
-                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'Uniform':
-            initializer = UniformInitializer(
-                lim=[-v.initializer.multiplier, v.initializer.multiplier], rng=rng)
-        elif v.initializer.type == 'UniformAffineGlorot':
-            initializer = (lambda shape: UniformInitializer(calc_uniform_lim_glorot(
-                shape[0], numpy.prod(shape[1:])), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'UniformConvolutionGlorot':
-            initializer = (lambda shape: UniformInitializer(calc_uniform_lim_glorot(
-                shape[-3], shape[0], kernel=shape[-2:]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'UniformCLConvGlorot':
-            initializer = (lambda shape: UniformInitializer(calc_uniform_lim_glorot(
-                shape[-1], shape[0], kernel=shape[1:3]), rng=rng)(shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'Range':
-            initializer = (lambda shape: RangeInitializer(0, 1)
-                           (shape) * v.initializer.multiplier)
-        elif v.initializer.type == 'Constant':
-            initializer = ConstantInitializer(value=v.initializer.multiplier)
-        else:
-            initializer = None
-        variable_instance = get_parameter_or_create(name, shape, initializer)
-    else:
-        # create empty variable, memory will be allocated in network.setup()
-        # after network optimization
-        variable_instance = nn.Variable()
-
-    variable = Variable()
-    variable.name = name
-    variable.parameter = parameter
-    variable.shape = shape
-    variable.variable_instance = variable_instance
-
-    return variable
-
-
-def prepare_parameters(nntxt_str):
-    proto = proto_from_str(nntxt_str)
-    proto = NnpExpander(proto).execute()
-    rng = np.random.RandomState(0)
-    for n in proto.network:
-        for v in n.variable:
-            shape = tuple(
-                [d if d >= 1 else n.batch_size for d in v.shape.dim])
-            variable = _create_variable(v, v.name, shape, rng)
-
-
 def nnp_file_name():
     return f"{nn.__version__}.nnp"
-
-
-@contextmanager
-def generate_case_from_nntxt_str(nntxt_str, param_format, dataset_sample_num, batch_size=None):
-    proto = proto_from_str(nntxt_str)
-    with generate_csv_png(dataset_sample_num, get_input_size(proto)) as dataset_csv_file:
-        # To test dataset, we create a randomly generated dataset.
-        for ds in proto.dataset:
-            ds.batch_size = batch_size if batch_size else ds.batch_size
-            ds.uri = dataset_csv_file
-            ds.cache_dir = os.path.join(
-                os.path.dirname(dataset_csv_file), "data.cache")
-        nntxt_io = io.StringIO()
-        text_format.PrintMessage(proto, nntxt_io)
-        nntxt_io.seek(0)
-
-        version = io.StringIO()
-        version.write('{}\n'.format(nnp_version()))
-        version.seek(0)
-
-        param = io.BytesIO()
-        prepare_parameters(nntxt_str)
-        nn.parameter.save_parameters(param, extension=param_format)
-
-        with create_temp_with_dir(nnp_file_name()) as temp_nnp_file_name:
-            with get_file_handle_save(temp_nnp_file_name, ".nnp") as nnp:
-                nnp.writestr('nnp_version.txt', version.read())
-                nnp.writestr('network.nntxt', nntxt_io.read())
-                nnp.writestr('parameter{}'.format(param_format), param.read())
-            yield temp_nnp_file_name
 
 
 def set_default_value(args):
@@ -226,7 +60,7 @@ def test_nnp_to_nnp_with_version_unsupported(nn_version, nntxt_str):
     args = Args()
     set_default_value(args)
     with pytest.raises(ValueError) as e:
-        with generate_case_from_nntxt_str(nntxt_str, ".h5", 32) as nnp_file:
+        with generate_case_from_nntxt_str(nntxt_str, nnp_file_name(), ".h5", 32) as nnp_file:
             dirname = os.path.dirname(nnp_file)
             out_file = os.path.join(dirname, f"{nn_version}.nnp")
             args.files = [nnp_file]
@@ -246,7 +80,7 @@ def test_nnp_to_nnp_with_version_supported(nn_version, nntxt_idx):
     args = Args()
     set_default_value(args)
     nntxt_str = N_ARRAY[nntxt_idx]
-    with generate_case_from_nntxt_str(nntxt_str, ".h5", 32) as nnp_file:
+    with generate_case_from_nntxt_str(nntxt_str, nnp_file_name(), ".h5", 32) as nnp_file:
         dirname = os.path.dirname(nnp_file)
         out_file = os.path.join(dirname, f"{nn_version}.nnp")
         args.files = [nnp_file]


### PR DESCRIPTION
This PR tends to add a subcommand for the optimization of nnp model in protograph level.
Currently, this feature is only for the optimization of the output from tensorflow importer, which break tf.dense() into pieces.
This feature can collect them and fuse them to an Affine().
