### PR TITLE
static linking of python library

### DIFF
--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -166,6 +166,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
     && eval "$(pyenv init -)" \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \

--- a/docker/development/Dockerfile.build-aarch64
+++ b/docker/development/Dockerfile.build-aarch64
@@ -87,6 +87,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && eval "$(pyenv init -)" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \   
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
     && pyenv global system \
     && rm -rf ~/.pyenv/.git

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -168,6 +168,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
     && eval "$(pyenv init -)" \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \

--- a/docker/development/Dockerfile.document
+++ b/docker/development/Dockerfile.document
@@ -102,6 +102,7 @@ RUN eval ${APT_OPTS} \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && eval "$(pyenv init -)" \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
     && pyenv global system \

--- a/docker/development/Dockerfile.nnabla-test
+++ b/docker/development/Dockerfile.nnabla-test
@@ -120,6 +120,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
     && eval "$(pyenv init -)" \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \

--- a/docker/development/Dockerfile.nnabla-test-aarch64
+++ b/docker/development/Dockerfile.nnabla-test-aarch64
@@ -109,6 +109,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && eval "$(pyenv init -)" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
     && pyenv global system \
     && rm -rf ~/.pyenv/.git

--- a/docker/development/Dockerfile.nnabla-test-ppc64le
+++ b/docker/development/Dockerfile.nnabla-test-ppc64le
@@ -133,6 +133,7 @@ RUN git clone https://github.com/pyenv/pyenv.git ~/.pyenv \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
     && eval "$(pyenv init -)" \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \

--- a/docker/release/Dockerfile
+++ b/docker/release/Dockerfile
@@ -65,6 +65,7 @@ RUN eval ${APT_OPTS} \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && PYTHON_VERSION_MINOR=${PYTHON_VER#*.} \
     && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
     && eval "$(pyenv init -)" \

--- a/docker/release/Dockerfile.py39-aarch64
+++ b/docker/release/Dockerfile.py39-aarch64
@@ -68,6 +68,7 @@ RUN eval ${APT_OPTS} \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && eval "$(pyenv init -)" \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \
     && pyenv global system \

--- a/docker/runtime/Dockerfile
+++ b/docker/runtime/Dockerfile
@@ -68,6 +68,7 @@ RUN eval ${APT_OPTS} \
     && export PATH="$PYENV_ROOT/bin:$PYENV_ROOT/plugins/python-build/bin:$PATH" \
     && export PYTHON_BUILD_CURL_OPTS="${CURL_OPTS}" \
     && export PYTHON_BUILD_WGET_OPTS="${WGET_OPTS}" \
+    && export PYTHON_CONFIGURE_OPTS=--disable-shared \
     && if [ ${PYTHON_VERSION_MINOR} -ge 10 ]; then export CPPFLAGS=-I/usr/include/openssl11 && export LDFLAGS=-L/usr/lib64/openssl11; fi \
     && eval "$(pyenv init -)" \
     && python-build `pyenv latest -k ${PYVERNAME}` /usr/local \


### PR DESCRIPTION
We have error log that there is no libpython3.7m.so.1.0 due to https://github.com/pyenv/pyenv/issues/2580
So, this PR add `--disable-shared` option to install/build python by pyenv.
