### PR TITLE
fix alllib wheel dependency in cuda11.6

### DIFF
--- a/build-tools/auditwheel-nnabla
+++ b/build-tools/auditwheel-nnabla
@@ -50,6 +50,7 @@ then
             if [[ "$SOFILE" = *"libcudnn_"* ]]; then
                 patchelf --add-needed $SOFILE $NNABLA_EXT_SO
                 patchelf --set-rpath '$ORIGIN' $NNABLA_EXT_SO
+                patchelf --set-rpath '$ORIGIN' $SOFILE
                 echo "Add dependency $SOFILE to $NNABLA_EXT_SO"
             fi
         done


### PR DESCRIPTION
For supporting cuda11.6, there is additional dependencies to cuDNN libraries.
This will cause a load error when import nnabla-ext-cuda-alllib wheel:

To solve this, the wheel installation path is added to cuDNN libraries's rpath.