### PR TITLE
fix stft test error with fixing librosa version

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -55,7 +55,7 @@ CALL pip install %PIP_INS_OPTS% ^
            boto3 ^
            h5py ^
            ipython ^
-           librosa ^
+           librosa~=0.9.2 ^
            mako ^
            numpy ^
            pip ^

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -2,5 +2,5 @@ ipython
 pytest
 pytest-xdist[psutil]
 scipy
-librosa
+librosa~=0.9.2
 backports.lzma


### PR DESCRIPTION
Due to upstream librosa version change, the test for STFT will fail with using librosa.stft. So we will limit the version of librosa to around 0.9.2 currently.