### PR TITLE
change protobuf3.19.4 to protobuf3.19.6

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -32,8 +32,8 @@ You can also use another distribution (e.g. [Pyenv](https://github.com/pyenv/pye
 [Google Protocol Buffer](https://github.com/google/protobuf) compiler is also required to create NNabla's neural network format serializer/desrializer in Python or C++.
 
 ```shell
-curl -L https://github.com/google/protobuf/releases/download/v3.1.0/protoc-3.1.0-linux-x86_64.zip -o /tmp/protoc-3.1.0-linux-x86_64.zip
-sudo unzip -d /usr/local /tmp/protoc-3.1.0-linux-x86_64.zip && sudo chmod 755 /usr/local/bin/protoc
+curl -L https://github.com/google/protobuf/releases/download/v3.19.6/protoc-3.19.6-linux-x86_64.zip -o /tmp/protoc-3.19.6-linux-x86_64.zip
+sudo unzip -d /usr/local /tmp/protoc-3.19.6-linux-x86_64.zip && sudo chmod 755 /usr/local/bin/protoc
 ```
 
 ### Build and installation

--- a/doc/build/build_android.md
+++ b/doc/build/build_android.md
@@ -62,12 +62,12 @@ Following build dependencies needs to be installed by the user manually.
 Unlike [Python Package compilation](./build.md) which requires
 `protoc` compiler only, the NNabla C++ utility library requires
 protobuf C++ library too.  The following snippet running on your
-terminal will build and install protobuf-3.19.4 from source.
+terminal will build and install protobuf-3.19.6 from source.
 
 ```shell
-curl -L https://github.com/google/protobuf/archive/v3.19.4.tar.gz -o protobuf-v3.19.4.tar.gz
-tar xvf protobuf-v3.19.4.tar.gz
-cd protobuf-3.19.4
+curl -L https://github.com/google/protobuf/archive/v3.19.6.tar.gz -o protobuf-v3.19.6.tar.gz
+tar xvf protobuf-v3.19.6.tar.gz
+cd protobuf-3.19.6
 mkdir build build-android
 cd build
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_CXX_STANDARD=14 ../cmake

--- a/doc/build/build_cpp_utils.md
+++ b/doc/build/build_cpp_utils.md
@@ -37,9 +37,9 @@ protobuf C++ library too.  The following snippet running on your
 terminal will build and install protobuf-3.1.0 from source.
 
 ```shell
-curl -L https://github.com/google/protobuf/archive/v3.1.0.tar.gz -o protobuf-v3.1.0.tar.gz
-tar xvf protobuf-v3.1.0.tar.gz
-cd protobuf-3.1.0
+curl -L https://github.com/google/protobuf/archive/v3.19.6.tar.gz -o protobuf-v3.19.6.tar.gz
+tar xvf protobuf-v3.19.6.tar.gz
+cd protobuf-3.19.6
 mkdir build && cd build
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF ../cmake
 make

--- a/docker/development/Dockerfile.android
+++ b/docker/development/Dockerfile.android
@@ -93,7 +93,7 @@ ARG ANDROID_EABI=arm64-v8a
 
 
 ##### Install protobuf for host and target #####
-ARG PROTOVER=3.19.4
+ARG PROTOVER=3.19.6
 
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \

--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -100,7 +100,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ############################################################ protobuf
-ARG PROTOVER=3.19.4
+ARG PROTOVER=3.19.6
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.build-aarch64
+++ b/docker/development/Dockerfile.build-aarch64
@@ -57,7 +57,7 @@ RUN eval ${APT_OPTS} \
     libssl-dev
 
 ############################################################ protobuf
-ENV PROTOVER=3.19.4
+ENV PROTOVER=3.19.6
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.build-ppc64le
+++ b/docker/development/Dockerfile.build-ppc64le
@@ -103,7 +103,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ################################################## protobuf
-ENV PROTOVER=3.19.4
+ENV PROTOVER=3.19.6
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.nnabla-test
+++ b/docker/development/Dockerfile.nnabla-test
@@ -71,7 +71,7 @@ RUN eval ${APT_OPTS} && apt-get update \
 ################################################## protobuf
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
-    && PROTOVER=3.19.4 \
+    && PROTOVER=3.19.6 \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \
     && tar xvf protobuf-v${PROTOVER}.tar.gz \
     && cd protobuf-${PROTOVER} \

--- a/docker/development/Dockerfile.nnabla-test-aarch64
+++ b/docker/development/Dockerfile.nnabla-test-aarch64
@@ -58,7 +58,7 @@ RUN eval ${APT_OPTS} \
     libssl-dev
 
 ############################################################ protobuf
-ENV PROTOVER=3.19.4
+ENV PROTOVER=3.19.6
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \

--- a/docker/development/Dockerfile.nnabla-test-ppc64le
+++ b/docker/development/Dockerfile.nnabla-test-ppc64le
@@ -106,7 +106,7 @@ RUN cd /tmp \
 ################################################## protobuf
 RUN mkdir /tmp/deps \
     && cd /tmp/deps \
-    && PROTOVER=3.19.4 \
+    && PROTOVER=3.19.6 \
     && curl ${CURL_OPTS} -L https://github.com/google/protobuf/archive/v${PROTOVER}.tar.gz -o protobuf-v${PROTOVER}.tar.gz \
     && tar xvf protobuf-v${PROTOVER}.tar.gz \
     && cd protobuf-${PROTOVER} \

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -4,7 +4,7 @@ h5py
 imageio
 numpy
 pillow>=9.1.0
-protobuf<=3.19.4
+protobuf<=3.19.6
 pyyaml
 scipy
 six

--- a/python/setup.py
+++ b/python/setup.py
@@ -40,7 +40,7 @@ install_requires = setup_requires + [
     'contextlib2',
     'h5py',
     'protobuf<=3.20.1;platform_system=="Windows"',
-    'protobuf<=3.19.4;platform_system!="Windows"',
+    'protobuf<=3.19.6;platform_system!="Windows"',
     'pyyaml',
     'scipy',
     'six',


### PR DESCRIPTION
Google Colab environment was updated, and this caused conflicts in the installation of nnabla and nnabla-ext-cuda.
To overcome this, we update protobuf to the latest on the v3.19 line.