### PR TITLE
Enable FFT/IFFT pytests run on win32 when CUDA>=11.4

### DIFF
--- a/python/test/function/test_fft.py
+++ b/python/test/function/test_fft.py
@@ -60,12 +60,6 @@ def ref_grad_fft(x, dy, signal_ndim, normalized, **kw):
 @pytest.mark.parametrize("normalized", [True, False])
 def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
                               signal_ndim, dims, normalized):
-
-    if func_name == "FFTCuda" and sys.platform == 'win32':
-        from nnabla_ext import cuda
-        if float(cuda._version.__cuda_version__) >= 11.4:
-            pytest.skip("Skip win32 + CUDA>=114 tests")
-
     if func_name == "FFT":
         pytest.skip("Not implemented in CPU.")
 
@@ -97,12 +91,6 @@ def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
 @pytest.mark.parametrize("normalized", [True, False])
 def test_fft_double_backward(seed, ctx, func_name, batch_dims,
                              signal_ndim, dims, normalized):
-
-    if func_name == "FFTCuda" and sys.platform == 'win32':
-        from nnabla_ext import cuda
-        if float(cuda._version.__cuda_version__) >= 11.4:
-            pytest.skip("Skip win32 + CUDA>=114 tests")
-
     if func_name == "FFT":
         pytest.skip("Not implemented in CPU.")
 

--- a/python/test/function/test_ifft.py
+++ b/python/test/function/test_ifft.py
@@ -61,12 +61,6 @@ def ref_grad_ifft(x, dy, signal_ndim, normalized, **kw):
 @pytest.mark.parametrize("normalized", [True, False])
 def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
                               signal_ndim, dims, normalized):
-
-    if func_name == "IFFTCuda" and sys.platform == 'win32':
-        from nnabla_ext import cuda
-        if float(cuda._version.__cuda_version__) >= 11.4:
-            pytest.skip("Skip win32 + CUDA>=114 tests")
-
     if func_name == "IFFT":
         pytest.skip("Not implemented in CPU.")
 
@@ -98,12 +92,6 @@ def test_fft_forward_backward(seed, ctx, func_name, batch_dims,
 @pytest.mark.parametrize("normalized", [True, False])
 def test_fft_double_backward(seed, ctx, func_name, batch_dims,
                              signal_ndim, dims, normalized):
-
-    if func_name == "IFFTCuda" and sys.platform == 'win32':
-        from nnabla_ext import cuda
-        if float(cuda._version.__cuda_version__) >= 11.4:
-            pytest.skip("Skip win32 + CUDA>=114 tests")
-
     if func_name == "IFFT":
         pytest.skip("Not implemented in CPU.")
 


### PR DESCRIPTION
FFT/IFFT test is fixed by https://github.com/sony/nnabla-ext-cuda/pull/460, so we would like to run these test on win+cuda11.6 environment by this PR.
