### PR TITLE
Add 8 operators to ONNX importer

### DIFF
--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -4332,7 +4332,7 @@ class OnnxImporter:
         assert len(n.output) == 1
 
         axes = []
-        keep_dims = False
+        keep_dims = True
         for attr in n.attribute:
             if attr.name == "axes":
                 check_attr_ints_type(attr, n)

--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -695,6 +695,7 @@ class OnnxImporter:
             "Compress": self.Compress,
             "NonZero": self.NonZero,
             "OneHot": self.OneHot,
+            "Scatter": self.ScatterElements_13,
         }
         self.table_op_set_9 = dict(self.table_op_set_7, **self.table_op_set_9)
 

--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -409,10 +409,12 @@ def check_attr_int_type(attr, node):
         raise ValueError(
             f"Only INT is supported for {attr.name} in {node.op_type} op_type")
 
+
 def check_attr_ints_type(attr, node):
     if attr.type != AttributeProto.INTS:
         raise ValueError(
             f"Only INTS is supported for {attr.name} in {node.op_type} op_type")
+
 
 def check_attr_string_type(attr, node):
     if attr.type != AttributeProto.STRING:
@@ -3524,7 +3526,7 @@ class OnnxImporter:
         func_param.keep_dims = True
         if func_name == "ReduceL1":
             func_param.p = 1.0
-        elif  func_name == "ReduceL2":
+        elif func_name == "ReduceL2":
             func_param.p = 2.0
         for attr in n.attribute:
             if attr.name == "axes":
@@ -4347,7 +4349,7 @@ class OnnxImporter:
             axes.extend(list(range(len(input_shape))))
         if keep_dims:
             reduced_shape = [1 if i in axes else input_shape[i]
-                            for i in range(len(input_shape))]
+                             for i in range(len(input_shape))]
         else:
             reduced_shape = [input_shape[i] for i in range(
                 len(input_shape)) if i not in axes]
@@ -4355,20 +4357,20 @@ class OnnxImporter:
          # Exp
         expout_x = fork_name(n.input[0]) + "_exp"
         exp_func = generate_unary("Exp", n.name, n.input[0], expout_x,
-                            self._graph.name, self._func_counter)
+                                  self._graph.name, self._func_counter)
         self._shape_output[expout_x] = input_shape
         func_list.append(exp_func)
 
         # Sum
         sumout_x = fork_name(expout_x) + "_sum"
         sum_func = generate_reduction("Sum", n.name, expout_x, sumout_x,
-                                axes, keep_dims, self._graph.name, self._func_counter)
+                                      axes, keep_dims, self._graph.name, self._func_counter)
         self._shape_output[sumout_x] = reduced_shape
         func_list.append(sum_func)
 
         # Log
         log_func = generate_unary("Log", n.name, sumout_x, n.output[0],
-                            self._graph.name, self._func_counter)
+                                  self._graph.name, self._func_counter)
         self._shape_output[n.output[0]] = reduced_shape
         func_list.append(log_func)
 
@@ -4405,7 +4407,8 @@ class OnnxImporter:
         func = self.generate_default_function("Arange", n)
         func_param = func.arange_param
 
-        warning_types = [TensorProto.INT16, TensorProto.INT32, TensorProto.INT64]
+        warning_types = [TensorProto.INT16,
+                         TensorProto.INT32, TensorProto.INT64]
 
         start_info = self.get_input_raw_data_with_info(n.input[0])
         if start_info is None:
@@ -4449,7 +4452,7 @@ class OnnxImporter:
             matrix_dims = input_shape[-2:]
             det_x_shape = [int(np.prod(batch_dims))] + matrix_dims
         reshape_func0 = generate_reshape(n.name, n.input[0], reshape_out,
-            det_x_shape, self._graph.name, self._func_counter)
+                                         det_x_shape, self._graph.name, self._func_counter)
         self._shape_output[reshape_out] = det_x_shape
         func_list.append(reshape_func0)
 
@@ -4467,7 +4470,7 @@ class OnnxImporter:
         else:
             det_y_shape = batch_dims
         reshape_func1 = generate_reshape(n.name, det_out, n.output[0],
-            det_y_shape, self._graph.name, self._func_counter)
+                                         det_y_shape, self._graph.name, self._func_counter)
         self._shape_output[n.output[0]] = det_y_shape
         func_list.append(reshape_func1)
 

--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -3521,6 +3521,7 @@ class OnnxImporter:
 
         func = self.generate_default_function("Norm", n)
         func_param = func.norm_param
+        func_param.keep_dims = True
         if func_name == "ReduceL1":
             func_param.p = 1.0
         elif  func_name == "ReduceL2":

--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -696,6 +696,7 @@ class OnnxImporter:
             "NonZero": self.NonZero,
             "OneHot": self.OneHot,
             "Scatter": self.ScatterElements_13,
+            "Erf": partial(self.GeneralOperator, 'Erf'),
         }
         self.table_op_set_9 = dict(self.table_op_set_7, **self.table_op_set_9)
 


### PR DESCRIPTION
This PR adds the following 8 ONNX operators to ONNX importer:

* ReduceL1, ReduceL2, ReduceLogSumExp
* CumSum
* Range
* Det
* Scatter
* Erf

# Implementation Overview

## ReduceL1

Convert ONNX `reduced = ReduceL1(data, axes, keepdims)` to the following nnabla representation:

```
reduced = F.norm(data, p = 1.0 , axes, keepdims)
```


## ReduceL2

Convert ONNX `reduced = ReduceL2(data, axes, keepdims)` to the following nnabla representation:

```
y = F.norm(data, p = 2.0 , axes, keepdims)
```


## ReduceLogSumExp

Convert ONNX `reduced = ReduceLogSumExp(data, axes, keepdims)` to the following nnabla representation:

```
reduced = F.log(F.sum(F.exp(x), axes, keepdims))
```


## CumSum

Convert ONNX `y = CumSum(x, axis, exclusive, reverse)` to the following nnabla representation:

```
y = F.cumsum(x, axis, exclusive, reverse)
```

### Limitation

* The input variable axis of ONNX CumSum must be constant or initializer variable in the current implementation.


## Range

Convert ONNX `output = Range(start, limit, delta)` to the following nnabla representation:

```
output = F.arange(start, limit, delta)
```

### Limitation

* The input variables start, limit and delta of ONNX Range must be constant or initializer variable in the current implementation.

## Det

Convert ONNX `y = Det(x)` to the following nnabla representation:

```
if len(x.shape) == 2:
    ishape = [1] + x.shape
    oshape = []
else:
    ishape = [int(np.prod(x.shape[:-2]))] + x.shape[-2:]
    oshape = x.shape[:-2]
h = F.reshape(x, ishape)
h = F.batch_det(h)
y = F.reshape(h, oshape)
```

* Reshape is required to bridge the gap between ONNX and nnabla.
  * ONNX
    * The input shape of ONNX Det is `[*, M, M]`. (N-D tensor)
    * The output shape is `[*]`. 
    * When the input is 2-D, the output shape is a scalar (the shape is empty `[]`).
  * nnabla
    * The input shape of nnabla batch_det is `[B, M, M]`. (3-D tensor)
    * The output shape is `[B]`.

## Scatter

This PR implements Scatter in the same way as ScatterElements because
Scatter-11 is equivalent to ScatterElements-13.

## Erf

Convert ONNX `output = Erf(input)` to the following nnabla representation:

```
output = F.erf(input)
```