### PR TITLE
update windows documents

### DIFF
--- a/doc/build/build_cpp_utils_windows.md
+++ b/doc/build/build_cpp_utils_windows.md
@@ -6,17 +6,12 @@
 ### Chocolatey
 
 ```bat
-    choco install cmake git VisualCppBuildTools
+    choco upgrade all
+    choco install cmake git visualstudio2019-workload-vctools visualstudio2019buildtools
 ```
 
-
 ```bat
-    choco install cmake git visualstudio2019-workload-vctools
-```
-
-
-```bat
-    choco install -y python3 --version=3.7.6
+    choco install -y python3 --version=3.10.8
 ```
 
 ## Build
@@ -31,16 +26,6 @@ Then, the following batch script does everything including setting up the rest o
 ```bat
     cmd /c nnabla\build-tools\msvc\test_nbla.bat
 ```
-
-```bat
-    cmd /c nnabla\build-tools\msvc\build_cpplib.bat 2019
-```
-```bat
-    cmd /c nnabla\build-tools\msvc\test_nbla.bat 2019
-```
-
-
-
 
 This will setup the following dependency libraries of the NNabla C++ utility
 

--- a/doc/build/build_windows.md
+++ b/doc/build/build_windows.md
@@ -4,35 +4,43 @@
 
 ### Chocolatey
 
-Install chocolatey with instruction in [Official page](https://chocolatey.org/)
+Install chocolatey with instruction in [Official page](https://chocolatey.org/）
 
 Then, install required tools with following command.
 ```bat
-    choco install cmake git VisualCppBuildTools
-```
-Install python3.6.8 or 3.7.9 or 3.8.8
-```bat
-    choco install -y python3 --version=3.6.8
+    choco install cmake git visualstudio2019-workload-vctools visualstudio2019buildtools
 ```
 
-We use choclatey to make the configuration as easy as possible.
+Note: Please make sure `Microsoft Visual Studio` is installed in the path of `C:\program files (x86)` and the path exists in `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat` and `C:\Program Files "("x86")"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`.
+
+Install python3.7.9 or 3.8.10 or 3.9.13 or 3.10.8. You can refer to the following command.
+```bat
+    choco install -y python3 --version=3.7.9
+```
+
+We use choclatey to make the configuration as easy as possible（recommended).
 If you can't or don't want to use chocolatey, please do so yourself.
 
 - [CMake](https://cmake.org/download/)
 - [Git for windows](https://gitforwindows.org/)
 - [Python3](https://www.python.org/downloads/)
-- [VisualC++ Build Tools 2015](https://www.microsoft.com/en-US/download/details.aspx?id=48159)
+- [VisualC++ Build Tools 2019](https://my.visualstudio.com/Downloads?q=visual%20studio%202019&wt.mc_id=o~msft~vscom~older-downloads)
 
 Install and set the environment variables appropriately.
 
 ### Build python package
 
 You can build windows binary with following command.
+```cmd
+    git clone https://github.com/sony/nnabla.git
+    cd nnabla
+```
+
 ```bat
     build-tools\msvc\build_cpplib.bat
     build-tools\msvc\build_wheel.bat PYTHON_VERSION
 ```
-The python version we tested is 3.7, 3.8 and 3.9.
+The python version we tested is 3.7, 3.8 3.9 and 3.10.
 
 Then you can run test with following.
 ```bat
@@ -42,4 +50,4 @@ Then you can run test with following.
 ## FAQ
 
 * Q. The compiled library and executable run on a compiled PC, but it does not work on another PC.
-  * Confirm that the Microsoft Visual C++ 2015 Redistributable is installed on target PC.
+  * Confirm that the Microsoft Visual C++ 2019 Redistributable is installed on target PC.

--- a/doc/build/quick_build_tools.md
+++ b/doc/build/quick_build_tools.md
@@ -53,13 +53,9 @@ Please see [Official site](https://chocolatey.org/install)
 After installing Chocolatey do following command on Administrator cmd.exe.
 ```
 choco feature enable -n allowGlobalConfirmation
-choco install cmake git miniconda3 vcbuildtools
-set PATH=C:\tools\Miniconda3\Scripts;%PATH%
-conda install -y pywin32 Cython=0.25 boto3 protobuf h5py ipython numpy=1.11 pip pytest scikit-image scipy wheel pyyaml mako
-pip install tqdm
+choco install cmake git vcbuildtools
+pip install pywin32 Cython boto3 protobuf h5py ipython numpy pip pytest scikit-image scipy wheel pyyaml mako tqdm
 ```
-And make sure that `C:\tools\Miniconda3\Scripts` in your PATH environment.
-
 
 ### Build cpplib
 ```
@@ -68,5 +64,6 @@ And make sure that `C:\tools\Miniconda3\Scripts` in your PATH environment.
 
 ### Build wheel
 ```
-> call build-tools\msvc\build_wheel.bat
+> call build-tools\msvc\build_wheel.bat PYTHON_VERSION
 ```
+The python version we tested is 3.7, 3.8 3.9 and 3.10.

--- a/doc/python/install_on_windows.rst
+++ b/doc/python/install_on_windows.rst
@@ -9,14 +9,13 @@ Installation on Windows
 Prerequisites
 ^^^^^^^^^^^^^
 
-We tested on Windows8.1 64bit and Windows10 64bit.
+We tested on Windows10 64bit, python3.10.
 
 The following software are required for installation:
 
 * Required software.
 
   * Python>=3.7: PIP
-  * Microsoft Visual C++ 2015 Redistributable
 
 * Recommended.
 
@@ -28,31 +27,16 @@ Setup environment
 
 Python
 """"""
+If you don't install python, you can refer to the link below.
 
-In this instruction, we use `Miniconda <https://conda.io/miniconda.html>`_.
-
-Get and install the windows binary from `here <https://repo.anaconda.com/miniconda/Miniconda3-latest-Windows-x86_64.exe>`_
-
-
-And then install required packages from command prompt.
-
-.. code-block:: doscon
-
-    > conda install scipy scikit-image ipython
-
+`python <https://www.python.org/downloads/windows/>`_
 
 If your network is using proxy and setup fails, configure proxy server with environment variable and try install again.
 
 .. code-block:: doscon
 
-    > SET HTTP_PROXY=http://(enter the address of the http proxy server here)
-    > SET HTTPS_PROXY=https://(enter the address of the https proxy server here)
-
-
-Microsoft Visual C++ 2015 Redistributable
-"""""""""""""""""""""""""""""""""""""""""
-
-Get and install from `here <https://www.microsoft.com/en-us/download/details.aspx?id=52685>`_
+    > set http_proxy=http://(enter the address of the http proxy server here)
+    > set https_proxy=http://(enter the address of the https proxy server here)
 
 
 CUDA and cuDNN library
@@ -60,13 +44,13 @@ CUDA and cuDNN library
 
 If you are using a NVIDIA GPU, execution speed will be drastically improved by installing the following software.
 
+For the versions of CUDA/cuDNN we support, see :ref:`the table <cuda-cudnn-compatibility>`.
+
 `CUDA Toolkit <https://developer.nvidia.com/cuda-downloads>`_
 
 `cuDNN <https://developer.nvidia.com/cudnn>`_
 
 To install cuDNN, copy bin, include and lib to C:\\Program Files\\NVIDIA GPU Computing Toolkit\\CUDA\\v{CUDA_VERSION}
-
-See :ref:`a list of compatible cuDNN versions of CUDA extension packages <cuda-cudnn-compatibility>`.
 
 
 Install
@@ -81,9 +65,4 @@ Q. Scikit-image installation takes a long time.
 """""""""""""""""""""""""""""""""""""""""""""""
 
 Depending on the environment, it will take a long time.  Please wait.
-
-Q. Failed to install Scipy during installation.
-"""""""""""""""""""""""""""""""""""""""""""""""
-
-Please install scipy using "conda install" before "pip install nnabla".
 

--- a/doc/python/pip_installation_cuda.rst
+++ b/doc/python/pip_installation_cuda.rst
@@ -22,8 +22,8 @@ CUDA vs cuDNN Compatibility
 Package name       CUDA version cuDNN version
 ================== ============ =====================
 nnabla-ext-cuda110 11.0.3       8.0(Linux & Win)
-nnabla-ext-cuda114 11.4.3       8.0(Linux & Win)
-nnabla-ext-cuda116 11.6.2       8.0(Linux & Win)
+nnabla-ext-cuda114 11.4.3       8.2(Linux & Win)
+nnabla-ext-cuda116 11.6.2       8.4(Linux & Win)
 ================== ============ =====================
 
 The latest CUDA version is always preferred if your GPU accepts.
@@ -83,7 +83,7 @@ Installation with Multi-GPU supported
 
 Multi-GPU wheel package is only available on python3.7+.
 
-.. _cuda-cudnn-compatibility:
+.. _cuda-cudnn-compatibility-multi-gpu:
 
 CUDA vs cuDNN Compatibility
 ---------------------------
@@ -92,8 +92,8 @@ CUDA vs cuDNN Compatibility
 Package name                        CUDA version cuDNN version
 =================================== ============ =============
 nnabla-ext-cuda110                  11.0.3       8.0
-nnabla-ext-cuda114                  11.4.3       8.0
-nnabla-ext-cuda116                  11.6.2       8.0
+nnabla-ext-cuda114                  11.4.3       8.2
+nnabla-ext-cuda116                  11.6.2       8.4
 =================================== ============ =============
 
 You can install as the following.


### PR DESCRIPTION
By [fixing vs2019 path issue](https://github.com/sony/nnabla/pull/1178), we update the build instruction on windows.
This PR updates the documents of installing and building nnabla on windows.