### PR TITLE
prune the constant branches

### DIFF
--- a/python/src/nnabla/core/graph_optimizer.py
+++ b/python/src/nnabla/core/graph_optimizer.py
@@ -19,6 +19,63 @@ This module implements a series of optimizer based on proto_graph object.
 from nnabla.logger import logger
 
 
+def remove_function(pf, renamed):
+    proto_network = pf.owner()
+    input_name = None
+    need_grad = False
+    for pv_name in pf.inputs:
+        pv = proto_network.variables[pv_name] \
+            if pv_name in proto_network.variables \
+            else proto_network.parameters[pv_name]
+        parent = pv.parent
+        required = filter(
+            lambda k: proto_network.functions[k] != pf, pv.required)
+        input_name = pv_name
+        need_grad = pv.need_grad
+        break
+
+    for pv_name in pf.outputs:
+        pv = proto_network.variables[pv_name]
+        pv.parent = parent
+        if len(pv.required) > 0:
+            for r in pv.required:
+                r_func = proto_network.functions[r]
+                index = r_func.inputs.index(pv.name)
+                r_func.inputs[index] = input_name
+
+            pv.required += required
+            if pv_name in proto_network.outputs:
+                index = proto_network.outputs.index(pv_name)
+                proto_network.outputs[index] = input_name
+            renamed[pv.name] = input_name
+            pv.name = input_name
+            pv.need_grad = need_grad
+            proto_network.variables[pv.name] = pv
+            logger.info(
+                f"[upper bound] proto_variable:{pv_name} is deleted, output name: {input_name} is kept.")
+            del proto_network.variables[pv_name]
+        else:
+            if parent is not None:
+                r_func = proto_network.functions[parent]
+                index = r_func.outputs.index(input_name)
+                r_func.outputs[index] = pv.name
+            # Re-check input variable
+            for f_name in required:
+                u_func = proto_network.functions[f_name]
+                index = u_func.inputs.index(input_name)
+                u_func.inputs[index] = pv.name
+            pv.need_grad = need_grad
+            pv.required += required
+            renamed[input_name] = pv.name
+            del proto_network.variables[input_name]
+            logger.info(
+                f"[lower bound] proto_variable:{input_name} is deleted, output name: {pv.name} is kept.")
+        break
+
+    del proto_network.functions[pf.name]
+    logger.info(f"proto_function:{pf.name} is deleted.")
+
+
 class IdentityRemover:
     def __init__(self, renamed=None, is_required=None):
         self.renamed = renamed
@@ -29,39 +86,4 @@ class IdentityRemover:
             if self.is_required:
                 if not self.is_required(pf):
                     return
-            proto_network = pf.owner()
-            input_name = None
-            need_grad = False
-            for pv_name in pf.inputs:
-                pv = proto_network.variables[pv_name] \
-                    if pv_name in proto_network.variables \
-                    else proto_network.parameters[pv_name]
-                parent = pv.parent
-                required = filter(
-                    lambda k: proto_network.functions[k] != pf, pv.required)
-                input_name = pv_name
-                need_grad = pv.need_grad
-                break
-
-            for pv_name in pf.outputs:
-                pv = proto_network.variables[pv_name]
-                pv.parent = parent
-                for r in pv.required:
-                    r_func = proto_network.functions[r]
-                    index = r_func.inputs.index(pv.name)
-                    r_func.inputs[index] = input_name
-
-                pv.required += required
-                if pv_name in proto_network.outputs:
-                    index = proto_network.outputs.index(pv_name)
-                    proto_network.outputs[index] = input_name
-                self.renamed[pv.name] = input_name
-                pv.name = input_name
-                pv.need_grad = need_grad
-                proto_network.variables[input_name] = pv
-                del proto_network.variables[pv_name]
-                break
-
-            del proto_network.functions[pf.name]
-            logger.debug("proto_variable:{} is deleted, proto_function:{} is deleted!"
-                         .format(pv.name, pf.name))
+            remove_function(pf, self.renamed)

--- a/python/src/nnabla/utils/converter/tensorflow/refine_graph.py
+++ b/python/src/nnabla/utils/converter/tensorflow/refine_graph.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import numpy as np
-import tensorflow as tf
+import tensorflow.compat.v1 as tf
 from tensorflow.core.framework.tensor_pb2 import TensorProto
 from tensorflow.core.framework.tensor_shape_pb2 import TensorShapeProto
 

--- a/python/src/nnabla/utils/converter/tensorflow/refine_parser.py
+++ b/python/src/nnabla/utils/converter/tensorflow/refine_parser.py
@@ -32,6 +32,10 @@ class RefineParser:
                                  tracking=False
                                  )
 
+    def p_empty(self, p):
+        """empty :"""
+        pass
+
     def p_rf_net(self, p):
         """ rf_net   :    rf_layers
         """
@@ -88,9 +92,17 @@ class RefineParser:
          """
         p[0] = p[1]
 
+    def p_rf_add(self, p):
+        """ rf_add : Add
+                   | AddV2
+                   | empty
+        """
+        p[0] = p[1]
+
     def p_rf_split_stmt(self, p):
         """ rf_split_stmt     :    Split
                              |    SplitV
+                             |    empty
         """
         p[0] = p[1]
 
@@ -101,11 +113,10 @@ class RefineParser:
         p[0] = p[1]
 
     def p_rf_conv_transpose(self, p):
-        """ rf_conv_transpose  :    Transpose rf_split_stmt Conv2DBackpropInput Slice Identity Add Transpose
-                               |    Transpose rf_split_stmt Conv2DBackpropInput Slice Identity Transpose
-                               |    Transpose rf_split_stmt Conv2DBackpropInput Pad Slice Identity Add Transpose
+        """ rf_conv_transpose  :    Transpose rf_split_stmt Conv2DBackpropInput Slice Identity rf_add Transpose
+                               |    Transpose rf_split_stmt Conv2DBackpropInput Pad Slice Identity rf_add Transpose
         """
-        p[0] = self.graph.conv_transpose(p[1:])
+        p[0] = self.graph.conv_transpose([v for v in p[1:] if v is not None])
 
     def p_rf_p_relu(self, p):
         """ rf_p_relu  :    Relu Abs Sub Mul Mul Add
@@ -120,15 +131,15 @@ class RefineParser:
         p[0] = self.graph.conv_bn(p[1:])
 
     def p_rf_conv_2d(self, p):
-        """ rf_conv_2d  :    Pad Transpose rf_split_stmt Conv2D Identity Add Transpose
+        """ rf_conv_2d  :    Pad Transpose rf_split_stmt Conv2D Identity rf_add Transpose
                         |   Pad Transpose rf_split_stmt Conv2D Identity Transpose
-                        |   Pad Transpose rf_split_stmt rf_conv2d_loop_stmt ConcatV2 Add Transpose
+                        |   Pad Transpose rf_split_stmt rf_conv2d_loop_stmt ConcatV2 rf_add Transpose
                         |   Pad Transpose rf_split_stmt rf_conv2d_loop_stmt ConcatV2 Transpose
-                        |   Transpose rf_split_stmt rf_conv2d_loop_stmt Identity Add Transpose
+                        |   Transpose rf_split_stmt rf_conv2d_loop_stmt Identity rf_add Transpose
                         |   Transpose rf_split_stmt rf_conv2d_loop_stmt Identity Transpose
                         |   Transpose rf_split_stmt rf_conv2d_loop_stmt ConcatV2 Transpose
         """
-        p[0] = self.graph.conv2d(p[1:])
+        p[0] = self.graph.conv2d([v for v in p[1:] if v is not None])
 
     def p_rf_pool_stmt(self, p):
         """ rf_pool_stmt     :    MaxPool
@@ -152,10 +163,9 @@ class RefineParser:
         p[0] = self.graph.bn(p[1:])
 
     def p_rf_affine(self, p):
-        """ rf_affine    :    Reshape Reshape MatMul Mul Add Reshape
-                         |    Reshape Reshape MatMul Mul Add
-                         |    Reshape Reshape MatMul Mul Add Reshape Reshape Mul Add
-                         |    Reshape Reshape MatMul Mul AddV2
+        """ rf_affine    :    Reshape Reshape MatMul Mul rf_add Reshape
+                         |    Reshape Reshape MatMul Mul rf_add
+                         |    Reshape Reshape MatMul Mul rf_add Reshape Reshape Mul rf_add
         """
         p[0] = self.graph.affine(p[1:])
 


### PR DESCRIPTION
This PR tends to optimize the tflite model converted from nnabla, which precompute the branches with completed constant inputs.
There are 6 changes in this PR:
* Precompute the constant branches
* Remove Split and slice operator if the shape of input and output are same
* Replace Split with slice if the model wants to be converted to quant model
* Replace PReLU with a combination of operators if the model wants to be converted to quant model
* Add the support of TRANSPOSE_CONV operator for quant model
* Update the support of pb to pb optimization to remove redundant transpose operators (version up to tf2.x)
