### PR TITLE
Add dllexport/import to create_Callback

### DIFF
--- a/include/nbla/function/callback.hpp
+++ b/include/nbla/function/callback.hpp
@@ -95,7 +95,7 @@ public:
     return vector<dtypes>{get_dtype<float>()};
   }
   virtual string name() { return "Callback"; }
-  NBLA_API virtual vector<string> allowed_array_classes();
+  virtual vector<string> allowed_array_classes();
   virtual bool grad_depends_output_data(int i, int o) const {
     if (!grad_depends_output_data_callback_)
       return true;
@@ -117,5 +117,12 @@ protected:
     return grad_depends_input_data_callback_(obj_, i, j);
   }
 };
+
+NBLA_API shared_ptr<Function> create_Callback(
+    const Context &ctx, void *obj, int min_outputs,
+    Callback::setup_callback_type s, Callback::forward_callback_type f,
+    Callback::backward_callback_type b, Callback::cleanup_callback_type c,
+    Callback::grad_depends_output_data_callback_type go,
+    Callback::grad_depends_input_data_callback_type gi);
 }
 #endif

--- a/python/src/nnabla/function.pxd.tmpl
+++ b/python/src/nnabla/function.pxd.tmpl
@@ -79,8 +79,8 @@ cdef extern from "nbla/computation_graph/function.hpp" namespace "nbla":
         void set_info(const string &info)
     ctypedef shared_ptr[CgFunction] CgFunctionPtr
     
-cdef extern from "nbla/function/callback.hpp":
-    shared_ptr[CFunction] create_Callback "std::make_shared<nbla::Callback>" (
+cdef extern from "nbla/function/callback.hpp" namespace "nbla":
+    shared_ptr[CFunction] create_Callback(
         const CContext &, void *, int,
         void(void *, const Variables&, const Variables &) nogil except+,
         void(void *, const Variables&, const Variables &) nogil except+,

--- a/src/nbla/function/nontemplate/callback.cpp
+++ b/src/nbla/function/nontemplate/callback.cpp
@@ -33,4 +33,13 @@ void Callback::backward_impl(const Variables &inputs, const Variables &outputs,
 vector<string> Callback::allowed_array_classes() {
   return SingletonManager::get<Cpu>()->array_classes();
 }
+
+NBLA_API shared_ptr<Function> create_Callback(
+    const Context &ctx, void *obj, int min_outputs,
+    Callback::setup_callback_type s, Callback::forward_callback_type f,
+    Callback::backward_callback_type b, Callback::cleanup_callback_type c,
+    Callback::grad_depends_output_data_callback_type go,
+    Callback::grad_depends_input_data_callback_type gi) {
+  return make_shared<Callback>(ctx, obj, min_outputs, s, f, b, c, go, gi);
+}
 }


### PR DESCRIPTION
This PR adds NBLA_API (dllexport/import) to nbla::create_Callback.

In past, there was an issue that multiple instances were created even if it is singleton.
To overcome this, `create_Callback` is defined as Cython function, and `NBLA_API` is added to `allowed_array_classes` for dllexport/import.

This PR defines `create_Callback` function in c++ with dllexport/import, and bindings in Cython.
