### PR TITLE
change default cuda version in the document and colab demos

### DIFF
--- a/doc/python/pip_installation_cuda.rst
+++ b/doc/python/pip_installation_cuda.rst
@@ -22,7 +22,6 @@ CUDA vs cuDNN Compatibility
 Package name       CUDA version cuDNN version
 ================== ============ =====================
 nnabla-ext-cuda110 11.0.3       8.0(Linux & Win)
-nnabla-ext-cuda114 11.4.3       8.2(Linux & Win)
 nnabla-ext-cuda116 11.6.2       8.4(Linux & Win)
 ================== ============ =====================
 
@@ -92,7 +91,6 @@ CUDA vs cuDNN Compatibility
 Package name                        CUDA version cuDNN version
 =================================== ============ =============
 nnabla-ext-cuda110                  11.0.3       8.0
-nnabla-ext-cuda114                  11.4.3       8.2
 nnabla-ext-cuda116                  11.6.2       8.4
 =================================== ============ =============
 

--- a/tutorial/by_examples.ipynb
+++ b/tutorial/by_examples.ipynb
@@ -36,7 +36,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda114\n",
+    "!pip install nnabla-ext-cuda116\n",
     "!git clone https://github.com/sony/nnabla.git\n",
     "%cd nnabla/tutorial"
    ]

--- a/tutorial/cifar10_classification.ipynb
+++ b/tutorial/cifar10_classification.ipynb
@@ -13,7 +13,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda114\n",
+        "!pip install nnabla-ext-cuda116\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples"
       ],

--- a/tutorial/dcgan_image_generation.ipynb
+++ b/tutorial/dcgan_image_generation.ipynb
@@ -12,7 +12,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda114\n",
+        "!pip install nnabla-ext-cuda116\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples"
       ],

--- a/tutorial/debugging.ipynb
+++ b/tutorial/debugging.ipynb
@@ -35,7 +35,7 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "!pip install nnabla-ext-cuda114\n",
+    "!pip install nnabla-ext-cuda116\n",
     "!git clone https://github.com/sony/nnabla.git\n",
     "%cd nnabla/tutorial"
    ],

--- a/tutorial/dynamic_and_static_nn.ipynb
+++ b/tutorial/dynamic_and_static_nn.ipynb
@@ -15,7 +15,7 @@
    "cell_type": "code",
    "execution_count": null,
    "source": [
-    "!pip install nnabla-ext-cuda114\n",
+    "!pip install nnabla-ext-cuda116\n",
     "!git clone https://github.com/sony/nnabla.git\n",
     "%cd nnabla/tutorial"
    ],

--- a/tutorial/model_finetuning.ipynb
+++ b/tutorial/model_finetuning.ipynb
@@ -17,7 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda114\n",
+    "!pip install nnabla-ext-cuda116\n",
     "!git clone https://github.com/sony/nnabla.git\n",
     "%cd nnabla/tutorial"
    ]

--- a/tutorial/python_api.ipynb
+++ b/tutorial/python_api.ipynb
@@ -17,7 +17,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install nnabla-ext-cuda114\n",
+    "!pip install nnabla-ext-cuda116\n",
     "!git clone https://github.com/sony/nnabla.git\n",
     "%cd nnabla/tutorial"
    ]

--- a/tutorial/siamese_feature_embedding.ipynb
+++ b/tutorial/siamese_feature_embedding.ipynb
@@ -16,7 +16,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda114\n",
+        "!pip install nnabla-ext-cuda116\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples"
       ],

--- a/tutorial/vae_unsupervised_learning.ipynb
+++ b/tutorial/vae_unsupervised_learning.ipynb
@@ -14,7 +14,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda114\n",
+        "!pip install nnabla-ext-cuda116\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples"
       ],

--- a/tutorial/vat_semi_supervised_learning.ipynb
+++ b/tutorial/vat_semi_supervised_learning.ipynb
@@ -13,7 +13,7 @@
       "cell_type": "code",
       "metadata": {},
       "source": [
-        "!pip install nnabla-ext-cuda114\n",
+        "!pip install nnabla-ext-cuda116\n",
         "!git clone https://github.com/sony/nnabla-examples.git\n",
         "%cd nnabla-examples"
       ],


### PR DESCRIPTION
The default cuda version has changed from cuda11.4 to cuda11.6 and some documents need update correspondingly.
The wheel used in colab demo should also be updated.