### PR TITLE
change the default batch size for exporter

### DIFF
--- a/python/src/nnabla/utils/cli/convert.py
+++ b/python/src/nnabla/utils/cli/convert.py
@@ -194,7 +194,7 @@ def add_convert_command(subparsers):
                                 argument \'--export-format\' will have to be set!!!'.format(export_formats_string))
     subparser.add_argument('-f', '--force', action='store_true',
                            help='[export] overwrite output file.')
-    subparser.add_argument('-b', '--batch-size', type=int, default=-1,
+    subparser.add_argument('-b', '--batch-size', type=int, default=1,
                            help='[export] overwrite batch size.')
     subparser.add_argument('-S', '--split', type=str, default=None,
                            help='[export] This option need to set  "-E" option.' +


### PR DESCRIPTION
The default batch size was handled differently depending on the type of converter used.
For example, the default batch size was equivalent to network batch size when converting from nnp to onnx, but it was 1 when converting from nnp to nnb or csrc.

This PR changes the default batch size is 1 for any exporter.
