### PR TITLE
Bring back stft test, and remove version limit of librosa

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -55,7 +55,7 @@ CALL pip install %PIP_INS_OPTS% ^
            boto3 ^
            h5py ^
            ipython ^
-           librosa~=0.9.2 ^
+           librosa ^
            mako ^
            numpy ^
            pip ^

--- a/python/test/function/test_istft.py
+++ b/python/test/function/test_istft.py
@@ -112,7 +112,6 @@ def check_nola_violation(y_r, y_i, window_size, stride, fft_size, window_type, c
                     fft_size, window_type, center, pad_mode, as_stft_backward)
 
 
-'''
 @pytest.mark.parametrize("ctx", ctx_list)
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("window_size, stride, fft_size", [
@@ -154,7 +153,6 @@ def test_istft_forward_backward(ctx, seed, window_size, stride, fft_size, window
 
     function_tester(rng, F.istft, ref_istft, istft_inputs, func_args=[
                     window_size, stride, fft_size, window_type, center, pad_mode, as_stft_backward], ctx=ctx, func_name=func_name, atol_f=1e-5, atol_b=3e-2, dstep=1e-2)
-'''
 
 
 @pytest.mark.parametrize("ctx", ctx_list)

--- a/python/test/function/test_stft.py
+++ b/python/test/function/test_stft.py
@@ -17,7 +17,6 @@ import pytest
 import numpy as np
 import nnabla as nn
 import nnabla.functions as F
-import scipy.signal as sig
 import librosa
 from nbla_test_utils import list_context
 
@@ -77,6 +76,7 @@ def ref_stft(x, window_size, stride, fft_size, window_type, center, pad_mode, as
 
         # librosa.stft does not support batched input.
         window_type = 'hann' if window_type == 'hanning' else window_type
+        window_type = 'boxcar' if window_type == 'rectangular' else window_type
         b = x.shape[0]
         ys = []
         for i in range(b):
@@ -117,11 +117,10 @@ def create_stft_input_shape(window_size):
     return (2, window_size * 10)
 
 
-'''
 @pytest.mark.parametrize("ctx", ctx_list)
 @pytest.mark.parametrize("seed", [313])
 @pytest.mark.parametrize("window_size, stride, fft_size", [
-    (16, 8, 16), (16, 4, 16), (16, 8, 32),
+    (16, 2, 16), (16, 4, 16), (16, 8, 32),
 ])
 @pytest.mark.parametrize("window_type", ["hanning", "hamming", "rectangular"])
 @pytest.mark.parametrize("center", [True, False])
@@ -151,7 +150,6 @@ def test_stft_forward_backward(ctx, seed, window_size, stride, fft_size, window_
 
     function_tester(rng, F.stft, ref_stft, inputs, func_args=[
                     window_size, stride, fft_size, window_type, center, pad_mode, as_istft_backward], ctx=ctx, func_name=func_name, atol_f=2e-6, atol_b=2e-2, dstep=1e-2)
-'''
 
 
 @pytest.mark.parametrize("ctx", ctx_list)

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -2,5 +2,5 @@ ipython
 pytest
 pytest-xdist[psutil]
 scipy
-librosa~=0.9.2
+librosa
 backports.lzma


### PR DESCRIPTION
This PR is to resolve stft/istft test failures, skipped by https://github.com/sony/nnabla/pull/1193 .

Start from librosa 0.10.0, its stft implementation introduced some changes that may break existing testing cases of nnabla.
There seems to be an ongoing discussion on STFT inconsistencies regarding `tf.signal.stft`, `torch.stft`, `librosa.stft` and `scipy.signal.stft`.
But in this PR, we slightly changed one of our stft test parameter that could workaround the problem.

By the way, nnabla test case passes `window_type=rectangular` directly to `librosa.stft`, but according to [this document](https://librosa.org/doc/0.10.0/generated/librosa.stft.html#librosa.stft):

> _window: string, tuple, number, function, or np.ndarray [shape=(n_fft,)]
> Either:
> a window specification (string, tuple, or number); see [scipy.signal.get_window](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.get_window.html#scipy.signal.get_window)
> a window function, such as [scipy.signal.windows.hann](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.windows.hann.html#scipy.signal.windows.hann)
> a vector or array of length n_fft
> Defaults to a raised cosine window (‘hann’), which is adequate for most applications in audio signal processing._

And, refered to [scipy document](https://docs.scipy.org/doc/scipy/reference/generated/scipy.signal.get_window.html#scipy.signal.get_window), `rectangular` should be `boxcar`, so it's also changed in this PR.