### PR TITLE
Selectable onnx IR version

### DIFF
--- a/python/src/nnabla/utils/cli/convert.py
+++ b/python/src/nnabla/utils/cli/convert.py
@@ -214,6 +214,9 @@ def add_convert_command(subparsers):
                            help='[export][TFLite] export to INT8 quantized tflite model.')
     subparser.add_argument('--dataset', type=str, default=None,
                            help='[export][TFLite] Specify the path of represent dataset which will be passed to INT8 quantized tflite converter.')
+    subparser.add_argument('--ir_version', type=int, default=-1,
+                           help='[export] Set ONNX IR version to convert to, \
+                           default is the latest supported IR version corresponding to the current ONNX version.')
 
     # For config function list
     subparser.add_argument('-c', '--config', type=str, default=None,

--- a/python/src/nnabla/utils/converter/commands.py
+++ b/python/src/nnabla/utils/converter/commands.py
@@ -177,9 +177,10 @@ def _export_from_nnp(args, nnp, output):
             args.batch_size = nnp.protobuf.network[0].batch_size
         if args.define_version and args.define_version.startswith('opset_'):
             opset = args.define_version.split("_")[1]
-            OnnxExporter(nnp, args.batch_size, opset=opset).execute(output)
+            OnnxExporter(nnp, args.batch_size, args.ir_version,
+                         opset=opset).execute(output)
         else:
-            OnnxExporter(nnp, args.batch_size).execute(output)
+            OnnxExporter(nnp, args.batch_size, args.ir_version).execute(output)
     elif args.export_format == 'SAVED_MODEL' or args.export_format == 'TF_PB':
         from .tensorflow import TensorflowExporter
         if args.batch_size < 0:
@@ -187,7 +188,7 @@ def _export_from_nnp(args, nnp, output):
             print(
                 f'{args.export_format}: If you want to use with other size use `-b` option and provide a positive value.')
             args.batch_size = nnp.protobuf.network[0].batch_size
-        TensorflowExporter(nnp, args.batch_size,
+        TensorflowExporter(nnp, args.batch_size, args.ir_version,
                            model_format=args.export_format).execute(output)
     elif args.export_format == 'TFLITE':
         if args.batch_size < 0:

--- a/python/src/nnabla/utils/converter/onnx/utils.py
+++ b/python/src/nnabla/utils/converter/onnx/utils.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 NNABLA_DOMAIN = "org.nnabla"
 NNABLA_OPSET_VERSION = 1
-ONNX_IR_VERSION = 7
+ONNX_IR_VERSION = 8
 ONNX_OPSET_VERSION = 6
 PRODUCER_NAME = "nnabla-onnx"
 PRODUCER_VERSION = "0.1"

--- a/python/src/nnabla/utils/converter/onnx/utils.py
+++ b/python/src/nnabla/utils/converter/onnx/utils.py
@@ -12,9 +12,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import onnx
+
 NNABLA_DOMAIN = "org.nnabla"
 NNABLA_OPSET_VERSION = 1
-ONNX_IR_VERSION = 8
+# Loop up to ONNX version table to find the supported IR version
+ONNX_VERSION = onnx.__version__
+ONNX_IR_VERSION = next(
+    (version_info[1] for version_info in onnx.helper.VERSION_TABLE if version_info[0] == ONNX_VERSION), None)
 ONNX_OPSET_VERSION = 6
 PRODUCER_NAME = "nnabla-onnx"
 PRODUCER_VERSION = "0.1"

--- a/python/src/nnabla/utils/converter/tensorflow/exporter.py
+++ b/python/src/nnabla/utils/converter/tensorflow/exporter.py
@@ -23,9 +23,10 @@ from ..onnx import OnnxExporter
 
 
 class TensorflowExporter:
-    def __init__(self, nnp, batch_size, model_format='TF_PB'):
+    def __init__(self, nnp, batch_size, ir_version, model_format='TF_PB'):
         self._nnp = nnp
         self._batch_size = batch_size
+        self._ir_version = ir_version
         self._model_format = model_format
         self.check_nnp_variable_name()
 
@@ -67,7 +68,7 @@ class TensorflowExporter:
 
     def execute(self, output):
         onnx_model = OnnxExporter(
-            self._nnp, self._batch_size, opset="11").export_model_proto()
+            self._nnp, self._batch_size, self._ir_version, opset="11").export_model_proto()
         tf_rep = prepare(onnx_model)
         if self._model_format == 'TF_PB':
             output_path = os.path.dirname(output)


### PR DESCRIPTION
nnabla-converter has ONNX_IR_VERSION definition and use it when import from / export to onnx format.
This doesn't necessarily require the latest IR version, but depends on the model to be converted.

So, this PR supports the latest IR version by default, and allow users to specify a IR version by argument.