### PR TITLE
fix tensor shape propagate error

### DIFF
--- a/python/src/nnabla/utils/converter/tflite/exporter.py
+++ b/python/src/nnabla/utils/converter/tflite/exporter.py
@@ -1621,8 +1621,8 @@ class TFLiteExporter:
             inputs = [scalar_name, pf.inputs[0]]
         else:
             inputs = [pf.inputs[0], scalar_name]
-        self.convert_generic_tflite_op(inputs, pf.outputs, tflite_operator)
         self.propagate_variable_semantic(pf)
+        self.convert_generic_tflite_op(inputs, pf.outputs, tflite_operator)
 
     def BatchNormalization(self, pf):
         inputs = pf.inputs[:]


### PR DESCRIPTION
TFLite exporter has a issue that the shape information (NCHW / NHWC) is not propagated correctly.
This PR fix this.

Here is a example of this issue:
```text
Before [-1,64,64,21] -> [-1,44,64,64] -> [-1,40,64,64]
After  [-1,64,64,21] -> [-1,64,64,44] -> [-1,64,64,40]
```