### PR TITLE
Add .readthedocs.yaml v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,13 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: doc/requirements.txt
+
+sphinx:
+  configuration: doc/conf.py

--- a/build-tools/make/build-with-docker.mk
+++ b/build-tools/make/build-with-docker.mk
@@ -48,8 +48,8 @@ docker_image_auto_format:
 .PHONY: docker_image_doc
 docker_image_doc:
 	if ! docker image inspect $(DOCKER_IMAGE_DOC) >/dev/null 2>/dev/null; then \
-		docker pull ubuntu:18.04 && \
-		( cd $(NNABLA_DIRECTORY) && docker build $(DOCKER_BUILD_ARGS) -t $(DOCKER_IMAGE_DOC) -f docker/development/Dockerfile.document . ) \
+		docker pull $(shell cat $(NNABLA_DIRECTORY)/docker/development/Dockerfile.document |grep ^FROM |awk '{print $$2}') && \
+		(cd $(NNABLA_DIRECTORY) && docker build $(DOCKER_BUILD_ARGS) -t $(DOCKER_IMAGE_DOC) -f docker/development/Dockerfile.document .) \
 	fi
 
 .PHONY: docker_image_build

--- a/docker/development/Dockerfile.document
+++ b/docker/development/Dockerfile.document
@@ -79,7 +79,7 @@ ADD python/setup_requirements.txt /tmp/deps/
 ADD python/requirements.txt /tmp/deps/
 ADD doc/requirements.txt /tmp/deps_doc/
 
-ENV PYVERNAME=3.8
+ENV PYVERNAME=3.10
 RUN eval ${APT_OPTS} \
     && apt update \
     && apt install -y --no-install-recommends \

--- a/docker/development/Dockerfile.document
+++ b/docker/development/Dockerfile.document
@@ -31,7 +31,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN eval ${APT_OPTS} \
     && apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
-    clang-format-3.9 \
+    clang-format-14 \
     cmake \
     curl \
     g++ \

--- a/docker/development/Dockerfile.document
+++ b/docker/development/Dockerfile.document
@@ -15,7 +15,7 @@
 
 # for nnabla>=1.5.0
 
-FROM ubuntu:18.04
+FROM ubuntu:22.04
 
 ARG PIP_INS_OPTS
 ARG PYTHONWARNINGS


### PR DESCRIPTION
Configuration file v2 (.readthedoc.yaml) is going to be mandatory on ReadTheDocs, here is the source: https://blog.readthedocs.com/migrate-configuration-v2/

This PR is the corresponding change to create documents by nnabla/doc.
