### PR TITLE
Limit pillow version<10 for doc build

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -2,7 +2,7 @@ nnabla==1.36.0.dev1
 Sphinx
 sphinx-rtd-theme
 mock
-pillow
+pillow<10.0
 alabaster
 commonmark
 recommonmark

--- a/doc/requirements.txt.tmpl
+++ b/doc/requirements.txt.tmpl
@@ -2,7 +2,7 @@ nnabla==${'.'.join(version.split('.')[:3])}
 Sphinx
 sphinx-rtd-theme
 mock
-pillow
+pillow<10.0
 alabaster
 commonmark
 recommonmark


### PR DESCRIPTION
Pillow v10.0.0 was released on this month, but it causes document build failure.
So, this PR limits to use Pillow<10.0.
