### PR TITLE
fix onnx range inputs

### DIFF
--- a/python/src/nnabla/utils/converter/onnx/importer.py
+++ b/python/src/nnabla/utils/converter/onnx/importer.py
@@ -4436,6 +4436,7 @@ class OnnxImporter:
             np.ceil((func_param.stop - func_param.start) / func_param.step), 0))
         self._shape_output[n.output[0]] = [number_of_elements]
         func_list.append(func)
+        del func.input[:]
 
     def Det(self, func_list, n):
         assert len(n.input) == 1


### PR DESCRIPTION
This PR tends to fix the problem when converting from onnx.range() to nnabla.arange(), the inputs of onnx.range() will be converted to arguments, from inputs(start, stop, step) to arguments(start, stop, step).