### PR TITLE
fix readthedocs and cython dependency

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -51,7 +51,7 @@ CALL %VENV%\Scripts\activate.bat
 CALL python -m pip install %PIP_INS_OPTS% --upgrade pip
 
 CALL pip install %PIP_INS_OPTS% ^
-           Cython ^
+           Cython~=0.29 ^
            boto3 ^
            h5py ^
            ipython ^

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,6 +1,6 @@
 nnabla==1.37.0.dev1
 Sphinx<7
-sphinx-rtd-theme
+sphinx-rtd-theme>=1.2
 mock
 pillow<10.0
 alabaster

--- a/doc/requirements.txt.tmpl
+++ b/doc/requirements.txt.tmpl
@@ -1,6 +1,6 @@
 nnabla==${'.'.join(version.split('.')[:3])}
 Sphinx<7
-sphinx-rtd-theme
+sphinx-rtd-theme>=1.2
 mock
 pillow<10.0
 alabaster
@@ -19,4 +19,3 @@ pygments
 funcparserlib
 tensorflow
 tensorboardX
-

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-Cython
+Cython~=0.29
 boto3
 h5py
 imageio

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ import pathlib
 
 setup_requires = [
     'setuptools',
-    'Cython',  # Requires python-dev.
+    'Cython~=0.29',  # Requires python-dev.
 ]
 
 numpy_version = ""


### PR DESCRIPTION
During the release process of nnabla v1.36.0, we found the python package conflict for Readthedocs build environment, referred as https://github.com/sony/nnabla/pull/1207. This PR do fix the conflict and the documents are generated correctly. But after the release finished, the document is found that fail in switching between different version by the click button. User could only switch by manually modifying the URL.

The reason for this issue is also caused by python build environment. As the Sphinx is upgraded(though limited to be lower than 7), the sphinx-rtd-theme is still kept to be 0.4.3. This won't cause build error, however, would still cause such incompatibility. So in this PR, sphinx-rtd-theme is also upgraded. 

For version <= 1.0.0, sphinx-rtd-theme shows no dependency requirement. For version <=1.1.1, >1.0, it requires sphinx >=1.6, <6. For version >=1.2.0, it requires sphinx >=1.6, <7. So we choose to limit sphinx-rtd-theme>=1.2.


In addition, the current CIs are blocked by the cython v3.0.0 which was released at 17th July.
This cause several Cython compile error during nnabla build, so we temporally limit the Cython version.
