### PR TITLE
auto format for onnx importer

### DIFF
--- a/include/nbla/function/bit_shift.hpp
+++ b/include/nbla/function/bit_shift.hpp
@@ -74,5 +74,5 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
 };
-}
+} // namespace nbla
 #endif

--- a/include/nbla/function/eye_like.hpp
+++ b/include/nbla/function/eye_like.hpp
@@ -71,5 +71,5 @@ protected:
     return false;
   }
 };
-}
+} // namespace nbla
 #endif

--- a/include/nbla/function/mod2.hpp
+++ b/include/nbla/function/mod2.hpp
@@ -75,5 +75,5 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
 };
-}
+} // namespace nbla
 #endif

--- a/include/nbla/function/unique.hpp
+++ b/include/nbla/function/unique.hpp
@@ -102,5 +102,5 @@ protected:
                                       const vector<bool> &propagate_down,
                                       const vector<bool> &accum);
 };
-}
+} // namespace nbla
 #endif

--- a/src/nbla/function/generic/bit_shift.cpp
+++ b/src/nbla/function/generic/bit_shift.cpp
@@ -138,4 +138,4 @@ void BitShift<T>::backward_impl(const Variables &inputs,
   NBLA_ERROR(error_code::not_implemented,
              "BitShift<T>::backward is currently not implemented.");
 }
-}
+} // namespace nbla

--- a/src/nbla/function/generic/eye_like.cpp
+++ b/src/nbla/function/generic/eye_like.cpp
@@ -57,4 +57,4 @@ void EyeLike<T>::backward_impl(const Variables &inputs,
                                const vector<bool> &accum) {
   // pass
 }
-}
+} // namespace nbla

--- a/src/nbla/function/generic/mod2.cpp
+++ b/src/nbla/function/generic/mod2.cpp
@@ -89,7 +89,7 @@ void integer_mod(const Variables &inputs, const Variables &outputs,
                                strides_x0, strides_x1, strides_y, shape_y);
   }
 }
-}
+} // namespace
 
 template <typename T>
 void Mod2<T>::forward_impl(const Variables &inputs, const Variables &outputs) {
@@ -182,4 +182,4 @@ void Mod2<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   NBLA_ERROR(error_code::not_implemented,
              "Mod2<T>::backward is currently not implemented.");
 }
-}
+} // namespace nbla

--- a/src/nbla/function/generic/unique.cpp
+++ b/src/nbla/function/generic/unique.cpp
@@ -268,4 +268,4 @@ void Unique<T>::backward_impl(const Variables &inputs, const Variables &outputs,
   NBLA_ERROR(error_code::not_implemented,
              "Unique<T>::backward is currently not implemented.");
 }
-}
+} // namespace nbla


### PR DESCRIPTION
Latest merged PR didn't match the auto-format after the ubuntu 20.04 update.
This PR is prepared to fix the auto-format error.