### PR TITLE
pycodestyle update auto format

### DIFF
--- a/build-tools/code_formatter/file_formatter.py
+++ b/build-tools/code_formatter/file_formatter.py
@@ -57,7 +57,7 @@ def which(name):
         f = os.path.join(p, name)
         if os.path.isfile(f):
             return f
-        if os.name is 'nt':
+        if os.name == 'nt':
             p = p.replace('"', '')
             f = os.path.join(p, name)
             if os.path.isfile(f):
@@ -70,8 +70,8 @@ def which(name):
 
 def search_clang_format():
     base = 'clang-format'
-    versions = ['12']  # Use clang-format-12
-    for c in [base] + [base + '-{}'.format(v) for v in versions]:
+    versions = ['10', '12']  # Use clang-format-10 or 12 for ubuntu 20.04
+    for c in [base + '-{}'.format(v) for v in versions]:
         clang = which(c)
         if clang is not None:
             return clang

--- a/python/src/nnabla/models/object_detection/base.py
+++ b/python/src/nnabla/models/object_detection/base.py
@@ -56,7 +56,7 @@ class ObjectDetection(object):
         '''
         if hasattr(self, '_category_names'):
             return self._category_names
-        assert hasattr(self, '_dataset_name'),\
+        assert hasattr(self, '_dataset_name'), \
             'A class attribute _dataset_name must be set.'
         with open(
                 os.path.join(

--- a/python/src/nnabla/models/object_detection/yolov2.py
+++ b/python/src/nnabla/models/object_detection/yolov2.py
@@ -47,7 +47,7 @@ class YoloV2(ObjectDetection):
     def __init__(self, dataset='voc'):
 
         # Check validity of num_layers
-        assert dataset in ['voc', 'coco'],\
+        assert dataset in ['voc', 'coco'], \
             'dataset must be chosen from ["voc", "coco"].'
         # Load nnp
         self._dataset_name = dataset

--- a/python/src/nnabla/models/semantic_segmentation/deeplabv3plus.py
+++ b/python/src/nnabla/models/semantic_segmentation/deeplabv3plus.py
@@ -51,9 +51,9 @@ class DeepLabV3plus(SemanticSegmentation):
     def __init__(self, dataset='voc', output_stride=16):
 
         # Check validity of num_layers
-        assert dataset in ['voc', 'voc-coco'],\
+        assert dataset in ['voc', 'voc-coco'], \
             'dataset must be chosen from ["voc", "voc-coco"].'
-        assert output_stride in [16, 8],\
+        assert output_stride in [16, 8], \
             'dataset must be chosen from [16, 8].'
         # Load nnp
         self._dataset_name = dataset

--- a/python/src/nnabla/normalization_functions.py
+++ b/python/src/nnabla/normalization_functions.py
@@ -771,7 +771,7 @@ def _instance_normalization_v1(x, beta, gamma, channel_axis=1, batch_axis=0, eps
     adapt_shape = tuple(adapt_shape)
 
     if beta is not None and beta.shape != adapt_shape:
-        assert beta.shape[channel_axis] == adapt_shape[channel_axis],\
+        assert beta.shape[channel_axis] == adapt_shape[channel_axis], \
             "channel size of beta: {} != channel size of x ({}).".format(beta.shape[channel_axis],
                                                                          adapt_shape[channel_axis])
         beta = broadcast(beta, shape=adapt_shape)


### PR DESCRIPTION
pycodestyle is a python library for autopep8's dependency. It has a new release on July 30th, which causes the auto-format update for nnabla.

Moreover, we found out that the [default clang-format](https://packages.ubuntu.com/focal/clang-format) used in ubuntu 20.04's repository is clang-format-10. So we modify the python script for searching clang-format in environment to let it could work correctly.