### PR TITLE
adjust certifi dependency

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -47,7 +47,8 @@ install_requires = setup_requires + [
     'tqdm',
     'imageio',
     'pillow>=9.1.0',
-    'ply'
+    'ply',
+    'certifi'
 ]
 
 if sys.platform == 'win32':

--- a/python/src/nnabla/utils/converter/setup.py.tmpl
+++ b/python/src/nnabla/utils/converter/setup.py.tmpl
@@ -53,7 +53,6 @@ if __name__ == '__main__':
         'tflite2onnx',
         'flatbuffers',
         'pyopenssl',
-        'certifi',
         nnabla_version
     ]
 


### PR DESCRIPTION
In environments where nnabla is installed and nnabla-converter is not, the following command causes error.
```bash
$ nnabla_cli convert XXX.nnp XXX.nnb 

2023-08-24 13:00:24,383 [nnabla][INFO]: Initializing CPU extension...
Traceback (most recent call last):
...
ModuleNotFoundError: No module named 'certifi'
```

certifi was in nnabla-converter's dependency, but when converting from NNP to NNB, the installation of nnabla-converter is unnecessary.
So, this PR updates the dependency in the nnabla package to include certifi.