### PR TITLE
fix numpy error

### DIFF
--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -3,6 +3,7 @@ boto3
 h5py
 imageio
 numpy
+librosa
 pillow>=9.1.0
 protobuf<=3.19.6
 pyyaml

--- a/python/src/nnabla/functions.py
+++ b/python/src/nnabla/functions.py
@@ -1200,7 +1200,7 @@ def gather_nd(data, indices):
           tmp_index = index.reshape(index.shape[0], -1)
           tmp_index = (idx + (Ellipsis,) for idx in zip(*new_index))
           out_shape = index.shape[1:] + data.shape[index.shape[0]:]
-          return np.vstack(data[idx] for idx in tmp_index).reshape(*out_shape)
+          return np.vstack([data[idx] for idx in tmp_index]).reshape(*out_shape)
 
     Examples:
 

--- a/python/test/function/test_broadcast.py
+++ b/python/test/function/test_broadcast.py
@@ -29,8 +29,8 @@ def ref_broadcast(x, shape):
 def get_combination(n):
     if n == 0:
         return [(n, np.array([], dtype=bool))]
-    all_comb = np.vstack(map(lambda x: x.flatten(), np.meshgrid(
-        *[[0, 1] for _ in range(n)]))).T.astype(bool)
+    all_comb = np.vstack(list(map(lambda x: x.flatten(), np.meshgrid(
+        *[[0, 1] for _ in range(n)])))).T.astype(bool)
     return [(n, comb) for comb in all_comb]
 
 

--- a/python/test/function/test_gather_nd.py
+++ b/python/test/function/test_gather_nd.py
@@ -24,7 +24,7 @@ ctxs = list_context('GatherNd')
 def gather_nd(data, index):
     index_ = index.reshape(index.shape[0], -1)  # flatten inner dims
     index_ = (idx + (Ellipsis,) for idx in zip(*index_))
-    result = np.vstack(data[idx] for idx in index_)
+    result = np.vstack([data[idx] for idx in index_])
     result = result.reshape(*(index.shape[1:] + data.shape[index.shape[0]:]))
     return result
 


### PR DESCRIPTION
Updated numpy causes errors in builds.

The error log is shown as below:
```log
>           raise TypeError('arrays to stack must be passed as a "sequence" type '
                            'such as list or tuple.')
E           TypeError: arrays to stack must be passed as a "sequence" type such as list or tuple.
build-env-1296677-py39\Lib\site-packages\numpy\core\shape_base.py:209: TypeError
```

In addition, the incompatibility error occurs for numpy and numba version.
```log
        if numpy_version < (1, 21):
            msg = (f"Numba needs NumPy 1.21 or greater. Got NumPy "
                   f"{numpy_version[0]}.{numpy_version[1]}.")
            raise ImportError(msg)
        elif numpy_version > (1, 24):
>           raise ImportError("Numba needs NumPy 1.24 or less")
E           ImportError: Numba needs NumPy 1.24 or less
/usr/local/lib/python3.10/site-packages/numba/__init__.py:42: ImportError
```
Here is the document of numba support table of numpy: https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information
Numpy dependency of nnabla is now dynamically determined during build time, depending on the numpy version installed in build environment. However, currently numba will only be installed(with librosa dependency) in test environment of nnabla. This is the root cause of incompatibility. So now also add numba into the build environment.
