### PR TITLE
fix numpy conflict by using tensorflow dependency

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -51,6 +51,7 @@ CALL %VENV%\Scripts\activate.bat
 CALL python -m pip install %PIP_INS_OPTS% --upgrade pip
 
 CALL pip install %PIP_INS_OPTS% ^
+           tensorflow~=2.12.0 ^
            Cython~=0.29 ^
            boto3 ^
            h5py ^

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,3 +1,4 @@
+tensorflow~=2.12.0
 Cython~=0.29
 boto3
 h5py


### PR DESCRIPTION
We updated the tensorflow to 2.12 to overcome the vulnerabilities on tensorflow, but it caused numpy dependency issue.

```log
nnabla latest depends on numpy~=1.26.0
onnx 1.13.0 depends on numpy>=1.16.6
tensorflow 2.12.1 depends on numpy<=1.24.3 and >=1.22
```

The numpy version dependency of nnabla is now set to be dynamically, which is determined by numpy version in the build environment. However, tensorflow was not installed in our build environment. This is the reason that causes the conflict.

So, in this PR, we add tensorflow into our build environment.