### PR TITLE
use yaml to support cpp api for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,6 +4,20 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.10"
+  jobs:
+    post_checkout:
+      - git clone https://github.com/sony/nnabla-ext-cuda.git
+    pre_build:
+      - VERSION=$(cat VERSION.txt) && cd nnabla-ext-cuda && git checkout v${VERSION}
+      - mv nnabla-ext-cuda ../nnabla-ext-cuda
+      - mkdir -p build-doc/doc/doxygen
+      - cat build-tools/doxygen/config >Doxyfile && echo OUTPUT_DIRECTORY = build-doc/doc/doxygen >>Doxyfile && doxygen && rm -f Doxyfile
+      - mv build-doc/doc/doxygen/html build-doc/doc/html-Cpp && mv build-doc/doc/doxygen/xml build-doc/doc/xml-Cpp
+      - rm -rf build-doc/doc/doxygen && mkdir -p build-doc/doc/doxygen && cd ../nnabla-ext-cuda
+      - cd ../nnabla-ext-cuda && cat ../latest/build-tools/doxygen/config_ext_cuda >Doxyfile && echo OUTPUT_DIRECTORY = ../latest/build-doc/doc/doxygen >>Doxyfile && doxygen && rm -f Doxyfile
+      - mv build-doc/doc/doxygen/html build-doc/doc/html-Ext-Cuda-Cpp && mv build-doc/doc/doxygen/xml build-doc/doc/xml-Ext-Cuda-Cpp
+      - rm -rf build-doc/doc/doxygen && rm -rf doc/cpp/Cpp doc/cpp/Ext-Cuda-Cpp
+      - python doc/dox_to_rst.py 1
 
 python:
   install:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,18 +6,10 @@ build:
     python: "3.10"
   jobs:
     post_checkout:
-      - git clone https://github.com/sony/nnabla-ext-cuda.git
+      - git clone https://github.com/sony/nnabla-ext-cuda.git ../nnabla-ext-cuda
     pre_build:
-      - VERSION=$(cat VERSION.txt) && cd nnabla-ext-cuda && git checkout v${VERSION}
-      - mv nnabla-ext-cuda ../nnabla-ext-cuda
-      - mkdir -p build-doc/doc/doxygen
-      - cat build-tools/doxygen/config >Doxyfile && echo OUTPUT_DIRECTORY = build-doc/doc/doxygen >>Doxyfile && doxygen && rm -f Doxyfile
-      - mv build-doc/doc/doxygen/html build-doc/doc/html-Cpp && mv build-doc/doc/doxygen/xml build-doc/doc/xml-Cpp
-      - rm -rf build-doc/doc/doxygen && mkdir -p build-doc/doc/doxygen && cd ../nnabla-ext-cuda
-      - cd ../nnabla-ext-cuda && cat ../latest/build-tools/doxygen/config_ext_cuda >Doxyfile && echo OUTPUT_DIRECTORY = ../latest/build-doc/doc/doxygen >>Doxyfile && doxygen && rm -f Doxyfile
-      - mv build-doc/doc/doxygen/html build-doc/doc/html-Ext-Cuda-Cpp && mv build-doc/doc/doxygen/xml build-doc/doc/xml-Ext-Cuda-Cpp
-      - rm -rf build-doc/doc/doxygen && rm -rf doc/cpp/Cpp doc/cpp/Ext-Cuda-Cpp
-      - python doc/dox_to_rst.py 1
+      - VERSION=$(cat VERSION.txt) && cd ../nnabla-ext-cuda && git checkout v${VERSION}
+      - ./build-tools/make/rst_for_doc.sh $(pwd)/build-doc $(pwd) ../nnabla-ext-cuda
 
 python:
   install:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,73 +423,23 @@ if(BUILD_PYTHON_PACKAGE)
       if(NOT IS_ABSOLUTE ${NNABLA_EXT_CUDA_DIRECTORY})
         get_filename_component(NNABLA_EXT_CUDA_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${NNABLA_EXT_CUDA_DIRECTORY} ABSOLUTE)
       endif()
-      add_custom_target(doc
-        COMMAND pip3 install ${PIP_INSTALL_OPTS} ${CMAKE_BINARY_DIR}/dist/nnabla-*.whl
-        COMMAND rm -rf ${CMAKE_BINARY_DIR}/doc
-        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/doxygen
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                cat build-tools/doxygen/config >Doxyfile &&
-                echo OUTPUT_DIRECTORY  = ${CMAKE_BINARY_DIR}/doc/doxygen >>Doxyfile &&
-                doxygen && rm -f Doxyfile
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/doxygen/html ${CMAKE_BINARY_DIR}/doc/html-Cpp
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/doxygen/xml ${CMAKE_BINARY_DIR}/doc/xml-Cpp
-        COMMAND rm -rf ${CMAKE_BINARY_DIR}/doc/doxygen
-        #ext-cuda
-        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/doxygen
-        COMMAND cd ${NNABLA_EXT_CUDA_DIRECTORY} &&
-                cat ${CMAKE_SOURCE_DIR}/build-tools/doxygen/config_ext_cuda >Doxyfile &&
-                echo OUTPUT_DIRECTORY  = ${CMAKE_BINARY_DIR}/doc/doxygen >>Doxyfile &&
-                doxygen && rm -f Doxyfile
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/doxygen/html ${CMAKE_BINARY_DIR}/doc/html-Ext-Cuda-Cpp
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/doxygen/xml ${CMAKE_BINARY_DIR}/doc/xml-Ext-Cuda-Cpp
-        COMMAND rm -rf ${CMAKE_BINARY_DIR}/doc/doxygen
-        # Generate rst
-        COMMAND rm -rf ${CMAKE_SOURCE_DIR}/doc/cpp/Cpp ${CMAKE_SOURCE_DIR}/doc/cpp/Ext-Cuda-Cpp
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                python doc/dox_to_rst.py 1
-        # English
-        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/sphinx
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                PYTHONPATH=${CMAKE_BINARY_DIR}/build/${NBLA_SETUP_LIB_DIR}:$ENV{PYTHONPATH}
-                sphinx-build -b html doc ${CMAKE_BINARY_DIR}/doc/sphinx -c doc
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/sphinx ${CMAKE_BINARY_DIR}/doc/html
-        # Japanese
-        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/sphinx
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                PYTHONPATH=${CMAKE_BINARY_DIR}/build/${NBLA_SETUP_LIB_DIR}:$ENV{PYTHONPATH}
-                sphinx-build -b html -D language=ja doc ${CMAKE_BINARY_DIR}/doc/sphinx -c doc
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/sphinx ${CMAKE_BINARY_DIR}/doc/html-ja
-        )
-    else()
-      add_custom_target(doc
-        COMMAND pip3 install ${PIP_INSTALL_OPTS} ${CMAKE_BINARY_DIR}/dist/nnabla-*.whl
-        COMMAND rm -rf ${CMAKE_BINARY_DIR}/doc
-        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/doxygen
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                cat build-tools/doxygen/config >Doxyfile &&
-                echo OUTPUT_DIRECTORY  = ${CMAKE_BINARY_DIR}/doc/doxygen >>Doxyfile &&
-                doxygen && rm -f Doxyfile
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/doxygen/html ${CMAKE_BINARY_DIR}/doc/html-Cpp
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/doxygen/xml ${CMAKE_BINARY_DIR}/doc/xml-Cpp
-        COMMAND rm -rf ${CMAKE_BINARY_DIR}/doc/doxygen
-        # Generate rst
-        COMMAND rm -rf ${CMAKE_SOURCE_DIR}/doc/cpp/Cpp ${CMAKE_SOURCE_DIR}/doc/cpp/Ext-Cuda-Cpp
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                python doc/dox_to_rst.py 0
-        # English
-        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/sphinx
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                PYTHONPATH=${CMAKE_BINARY_DIR}/build/${NBLA_SETUP_LIB_DIR}:$ENV{PYTHONPATH}
-                sphinx-build -b html doc ${CMAKE_BINARY_DIR}/doc/sphinx -c doc
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/sphinx ${CMAKE_BINARY_DIR}/doc/html
-        # Japanese
-        COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/sphinx
-        COMMAND cd ${CMAKE_SOURCE_DIR} &&
-                PYTHONPATH=${CMAKE_BINARY_DIR}/build/${NBLA_SETUP_LIB_DIR}:$ENV{PYTHONPATH}
-                sphinx-build -b html -D language=ja doc ${CMAKE_BINARY_DIR}/doc/sphinx -c doc
-        COMMAND mv ${CMAKE_BINARY_DIR}/doc/sphinx ${CMAKE_BINARY_DIR}/doc/html-ja
-        )
     endif()
+    add_custom_target(doc
+      COMMAND pip3 install ${PIP_INSTALL_OPTS} ${CMAKE_BINARY_DIR}/dist/nnabla-*.whl
+      COMMAND bash ${CMAKE_SOURCE_DIR}/build-tools/make/rst_for_doc.sh ${CMAKE_BINARY_DIR} ${CMAKE_SOURCE_DIR} ${NNABLA_EXT_CUDA_DIRECTORY}
+      # English
+      COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/sphinx
+      COMMAND cd ${CMAKE_SOURCE_DIR} &&
+              PYTHONPATH=${CMAKE_BINARY_DIR}/build/${NBLA_SETUP_LIB_DIR}:$ENV{PYTHONPATH}
+              sphinx-build -b html doc ${CMAKE_BINARY_DIR}/doc/sphinx -c doc
+      COMMAND mv ${CMAKE_BINARY_DIR}/doc/sphinx ${CMAKE_BINARY_DIR}/doc/html
+      # Japanese
+      COMMAND mkdir -p ${CMAKE_BINARY_DIR}/doc/sphinx
+      COMMAND cd ${CMAKE_SOURCE_DIR} &&
+              PYTHONPATH=${CMAKE_BINARY_DIR}/build/${NBLA_SETUP_LIB_DIR}:$ENV{PYTHONPATH}
+              sphinx-build -b html -D language=ja doc ${CMAKE_BINARY_DIR}/doc/sphinx -c doc
+      COMMAND mv ${CMAKE_BINARY_DIR}/doc/sphinx ${CMAKE_BINARY_DIR}/doc/html-ja
+      )
     add_dependencies(doc wheel)
     nbla_exclude_from_all(doc)
   endif()

--- a/build-tools/make/build.mk
+++ b/build-tools/make/build.mk
@@ -68,10 +68,10 @@ nnabla-doc:
 	&& cmake -DBUILD_CPP_LIB=ON \
 		-DBUILD_CPP_UTILS=OFF \
 		-DBUILD_PYTHON_PACKAGE=ON \
-		-DNNABLA_EXT_CUDA_DIRECTORY=$(NNABLA_EXT_CUDA_DIRECTORY)\
+		-DNNABLA_EXT_CUDA_DIRECTORY=$(NNABLA_EXT_CUDA_DIRECTORY) \
 		$(CMAKE_OPTS) \
 		$(NNABLA_DIRECTORY)
-	make -C $(DOC_DIRECTORY) -j$(PARALLEL_BUILD_NUM) all wheel doc
+	make -C $(DOC_DIRECTORY) -j$(PARALLEL_BUILD_NUM) wheel doc
 
 
 ########################################################################################################################

--- a/build-tools/make/rst_for_doc.sh
+++ b/build-tools/make/rst_for_doc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+rm -rf $1/doc && mkdir -p $1/doc/doxygen
+cd $2 && \
+	cat build-tools/doxygen/config >Doxyfile && \
+	echo OUTPUT_DIRECTORY  = $1/doc/doxygen >>Doxyfile && \
+	doxygen && rm -f Doxyfile
+mv $1/doc/doxygen/html $1/doc/html-Cpp && mv $1/doc/doxygen/xml $1/doc/xml-Cpp
+rm -rf $1/doc/doxygen
+if [ -d $3 ]; then \
+	mkdir -p $1/doc/doxygen; \
+	cd $3 && \
+	cat $2/build-tools/doxygen/config_ext_cuda >Doxyfile && \
+	echo OUTPUT_DIRECTORY  = $1/doc/doxygen >>Doxyfile && \
+	doxygen && rm -f Doxyfile; \
+	mv $1/doc/doxygen/html $1/doc/html-Ext-Cuda-Cpp && mv $1/doc/doxygen/xml $1/doc/xml-Ext-Cuda-Cpp; \
+	rm -rf $1/doc/doxygen; \
+fi
+cd $2 && rm -rf $2/doc/cpp/Cpp $2/doc/cpp/Ext-Cuda-Cpp
+if [ -d $3 ]; then \
+	python $2/doc/dox_to_rst.py 1; else \
+	python $2/doc/dox_to_rst.py 0; \
+fi

--- a/doc/python/api/callback.rst
+++ b/doc/python/api/callback.rst
@@ -1,0 +1,28 @@
+Callbacks
+=========
+
+APIs to setup global hooks for functions and solvers.
+
+.. automodule:: nnabla.callback
+
+Function callback
+-----------------
+
+.. autofunction:: nnabla.callback.set_function_pre_hook
+
+.. autofunction:: nnabla.callback.set_function_post_hook
+
+.. autofunction:: nnabla.callback.unset_function_pre_hook
+
+.. autofunction:: nnabla.callback.unset_function_post_hook
+
+Solver callback
+---------------
+
+.. autofunction:: nnabla.callback.set_solver_pre_hook
+
+.. autofunction:: nnabla.callback.set_solver_post_hook
+
+.. autofunction:: nnabla.callback.unset_solver_pre_hook
+
+.. autofunction:: nnabla.callback.unset_solver_post_hook


### PR DESCRIPTION
We had a plan to update rst files for readthedocs to support NNabla C++ API documents.
However, after testing on readthedocs, only updating rst files are not enough to display the documents correctly.
Xml and html files that generated by doxygen are also needed.

So, this PR tries to generate all these files during readthedocs build, instead of updating them in advance.
We utilize .readthedocs.yaml and follow the similar build steps in cmake command for building document.
