### PR TITLE
fix output missing problem

### DIFF
--- a/python/src/nnabla/utils/converter/tflite/exporter.py
+++ b/python/src/nnabla/utils/converter/tflite/exporter.py
@@ -1927,7 +1927,8 @@ class TFLiteExporter:
             if inp not in self.parameters:
                 self.inputs.append(inp)
 
-        self.outputs.extend(self.network.outputs)
+        self.outputs.extend(
+            [output_variable.variable_name for output_variable in self.executor.output_variable])
 
     def set_network(self):
         '''


### PR DESCRIPTION
This PR tends to fix the problem missing an output in JSON file with a .tflite output when converting from .nnp to .tflite.