### PR TITLE
update trilu funciton id

### DIFF
--- a/build-tools/code_generator/api_levels.yaml
+++ b/build-tools/code_generator/api_levels.yaml
@@ -304,4 +304,4 @@
   BitShift_i: 356
   Einsum_i: 359
 45:
-  Trilu_iB: 359
+  Trilu_iB: 360

--- a/build-tools/code_generator/functions.yaml
+++ b/build-tools/code_generator/functions.yaml
@@ -4663,7 +4663,7 @@ Array Manipulation:
         doc: N-D array with shape (:math:`M_0 \times \ldots \times M_N`).
     c_runtime: support
     function_ids:
-      iB: 359
+      iB: 360
   Meshgrid:
     snake_name: meshgrid
     doc: |2


### PR DESCRIPTION
We introduced new function by https://github.com/sony/nnabla/pull/1231 (Einsum) and https://github.com/sony/nnabla/pull/1232 (Trilu), but I missed to increment function ID.
This PR fixes the duplicates.
