### PR TITLE
add -x parameter for nnabla_cli function_info

### DIFF
--- a/build-tools/msvc/test.bat
+++ b/build-tools/msvc/test.bat
@@ -24,7 +24,7 @@ REM Execute test
 
 FOR /f %%i IN ('dir /b /s %nnabla_build_wheel_folder%\dist\nnabla-*.whl') DO set WHL=%%~fi
 pip install %PIP_INS_OPTS% %WHL% || GOTO :error
-pip install %PIP_INS_OPTS% pytest pytest-xdist[psutil]
+pip install %PIP_INS_OPTS% pytest pytest-xdist[psutil]~=3.3.1
 python -m pytest %PYTEST_OPTS% %~dp0..\..\python\test || GOTO :error
 
 CALL deactivate.bat  || GOTO :error

--- a/python/src/nnabla/utils/cli/func_info.py
+++ b/python/src/nnabla/utils/cli/func_info.py
@@ -32,6 +32,8 @@ class NnablaHandler:
                     f, expand_network=not FuncInfo.params.nnp_no_expand_network).execute()
                 self._nnp_set |= cvt.func_set_import_nnp(nnp)
             self._func_set &= self._nnp_set
+        if FuncInfo.params.exclude:
+            self._func_set -= set([f for f in FuncInfo.params.exclude])
         if FuncInfo.params.config:
             self._config_set = cvt.func_set_import_config(
                 FuncInfo.params.config)
@@ -202,6 +204,8 @@ def add_function_info_command(subparsers):
                            help='*.nnp files that the function sets want to be shown')
     subparser.add_argument('-c', '--config', default=None,
                            help='user config file for target constraint')
+    subparser.add_argument('-x', '--exclude', action='append', default=[],
+                           help='exclude specified functions')
     subparser.add_argument('-t', '--target', action='store_true',
                            help='specify function set is output for target format/device')
     subparser.add_argument('-q', '--query', default=None,


### PR DESCRIPTION
This PR tends to add a -x parameter for nnabla_cli function_info subcommand.

Please refer: https://github.com/sony/nnabla-c-runtime/pull/87
