### PR TITLE
Skip test_graph_model recurrent test for Linux

### DIFF
--- a/python/test/test_forward_all.py
+++ b/python/test/test_forward_all.py
@@ -84,7 +84,10 @@ def test_graph_logreg(seed):
 
 
 @pytest.mark.parametrize("seed", [311])
-@pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
+# Skip model = 'recurrent'  temporarily since it cause
+# randomly crash when perform CI testing
+# @pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
+@pytest.mark.parametrize("model", ["mlp", "convolution"])
 def test_graph_model(model, seed):
     np.random.seed(313)
     rng = np.random.RandomState(seed)

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -62,7 +62,10 @@ def test_graph_logreg(seed):
 
 
 @pytest.mark.parametrize("seed", [311])
-@pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
+# Skip model = 'recurrent'  temporarily since it cause
+# randomly crash when perform CI testing
+# @pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
+@pytest.mark.parametrize("model", ["mlp", "convolution"])
 def test_graph_model(model, seed):
     np.random.seed(313)
     rng = np.random.RandomState(seed)


### PR DESCRIPTION
We found the recurrent tests are sometimes failed on Linux, and it seems to have depends on python version.
This PR excludes the test temporary.
