### PR TITLE
save executors in graph_def

### DIFF
--- a/python/src/nnabla/core/graph_optimizer.py
+++ b/python/src/nnabla/core/graph_optimizer.py
@@ -76,6 +76,29 @@ def remove_function(pf, renamed):
     logger.info(f"proto_function:{pf.name} is deleted.")
 
 
+def rename_variable(proto_network, renames):
+    """
+    renames:
+        {'old_name': 'new_name', ...}
+
+    note:
+        caller must ensure there is no duplicated name in current network.
+    """
+    for old_name, new_name in renames:
+        if old_name not in proto_network.variables:
+            raise ValueError("{} is not found in networks!".format(
+                proto_network.variables[new_name]))
+        proto_network.variables[new_name] = proto_network.variables[old_name]
+        del proto_network.variables[old_name]
+        proto_network.variables[new_name].name = new_name
+        proto_network.variables[new_name].proto.name = new_name
+        output_index = proto_network.functions[proto_network.variables[new_name].parent].outputs.index(
+            old_name)
+        proto_network.functions[proto_network.variables[new_name].parent].outputs[output_index] = new_name
+
+    proto_network.outputs = [renames.get(n, n) for n in proto_network.outputs]
+
+
 class IdentityRemover:
     def __init__(self, renamed=None, is_required=None):
         self.renamed = renamed

--- a/python/src/nnabla/core/graph_optimizer.py
+++ b/python/src/nnabla/core/graph_optimizer.py
@@ -84,7 +84,7 @@ def rename_variable(proto_network, renames):
     note:
         caller must ensure there is no duplicated name in current network.
     """
-    for old_name, new_name in renames:
+    for old_name, new_name in renames.items():
         if old_name not in proto_network.variables:
             raise ValueError("{} is not found in networks!".format(
                 proto_network.variables[new_name]))
@@ -94,7 +94,8 @@ def rename_variable(proto_network, renames):
         proto_network.variables[new_name].proto.name = new_name
         output_index = proto_network.functions[proto_network.variables[new_name].parent].outputs.index(
             old_name)
-        proto_network.functions[proto_network.variables[new_name].parent].outputs[output_index] = new_name
+        proto_network.functions[proto_network.variables[new_name]
+                                .parent].outputs[output_index] = new_name
 
     proto_network.outputs = [renames.get(n, n) for n in proto_network.outputs]
 

--- a/python/test/utils/test_save_load.py
+++ b/python/test/utils/test_save_load.py
@@ -289,12 +289,22 @@ def test_save_load_from_graph_with_file_object():
         y0, y1 = mlp_module(x0, x1)
 
     executors = [
-        {'name': 'runtime',
-         'network': network_name,
-         'data': ['x0', 'x1'],
-         'output': {"y0": y0, 'y1': y1}}]
+        {
+            'name': 'runtime',
+            'no_image_normalization': True,
+            'num_evaluations': 32,
+            'repeat_evaluation_type': 'Repeat',
+            'need_back_propagation': False,
+            'network': network_name,
+            'data': ['x0', 'x1'],
+            'output': {"y0": y0, "y1": y1}}]
 
     import io
     nnpdata = io.BytesIO()
     nn.graph_def.save(nnpdata, [g], executors=executors, extension='.nnp')
     nnabla.utils.load.load(nnpdata, extension='.nnp')
+    info = nnabla.utils.load.load(nnpdata, extension='.nnp')
+    assert info.executors['runtime'].no_image_normalization, "value error!"
+    assert info.executors['runtime'].num_evaluations == 32, "Value error!"
+    assert info.executors['runtime'].repeat_evaluation_type == 'Repeat', "Value error!"
+    assert not info.executors['runtime'].need_back_propagation, "Value error!"

--- a/python/test/utils/test_save_load.py
+++ b/python/test/utils/test_save_load.py
@@ -268,3 +268,33 @@ def test_save_load_executor_attributes(tmpdir):
     assert info.executors['runtime'].num_evaluations == 32, "Value error!"
     assert info.executors['runtime'].repeat_evaluation_type == 'Repeat', "Value error!"
     assert not info.executors['runtime'].need_back_propagation, "Value error!"
+
+
+def test_save_load_from_graph_with_file_object():
+    nn.clear_parameters()
+    network_name = 'my_model'
+
+    def mlp_module(x0, x1):
+        h1_0 = PF.affine(x0, 100, name='affine1_0')
+        h1_1 = PF.affine(x1, 100, name='affine1_0')
+        h1 = F.tanh(h1_0 + h1_1)
+        h2 = F.tanh(PF.affine(h1, 50, name='affine2'))
+        y0 = PF.affine(h2, 10, name='affiney_0')
+        y1 = PF.affine(h2, 10, name='affiney_1')
+        return y0, y1
+
+    with nn.graph_def.graph(name=network_name) as g:
+        x0 = nn.ProtoVariable((64, 100), name='x0')
+        x1 = nn.ProtoVariable((64, 100), name='x1')
+        y0, y1 = mlp_module(x0, x1)
+
+    executors = [
+        {'name': 'runtime',
+         'network': network_name,
+         'data': ['x0', 'x1'],
+         'output': {"y0": y0, 'y1': y1}}]
+
+    import io
+    nnpdata = io.BytesIO()
+    nn.graph_def.save(nnpdata, [g], executors=executors, extension='.nnp')
+    nnabla.utils.load.load(nnpdata, extension='.nnp')


### PR DESCRIPTION
This PR allows executors to be saved even when graph_def is used.

Here is an example that a graph is created from Variable:
```python
import nnabla as nn
import nnabla.functions as F
import nnabla.parametric_functions as PF

def my_model(x):
    x_conv1 = PF.convolution(x, 16, (3, 3), pad=(1, 1), name='conv1')
    x_relu1 = F.relu(x_conv1)
    x_conv2 = PF.convolution(x_relu1, 32, (3, 3), pad=(1, 1), name='conv2')
    x_pool = F.max_pooling(x_conv2, (2, 2))
    x_fc1 = PF.affine(x_pool, 64, name='fc1')
    y = PF.affine(x_fc1, 10, name='fc2')
    return y

x = nn.Variable((1, 3, 32, 32))
y = my_model(x)

contents = {
    'networks': [{
        'name': 'my_model',
        'batch_size': 2,
        'outputs': {'y': y},
        'names': {'x': x, }
    }],
    'executors': [{
        'name': 'runtime',
        'network': 'my_model',
        'data': ['x'],
        'output': ['y']
    }]
}

executors = [{
    'name': 'runtime',
    'network': 'my_model',
    'data': ['x'],
    'output': ['y']
}]

g = nn.graph_def.create_graph_from_variable("my_model", y, names={"x": x, "y'": y})
g.save("./model.nnp", executors=executors)
```

Here is another example that a graph is created in graph context:
```python
import nnabla as nn
import nnabla.functions as F
import nnabla.parametric_functions as PF

def mlp_module(x0, x1):
    h1_0 = PF.affine(x0, 100, name='affine1_0')
    h1_1 = PF.affine(x1, 100, name='affine1_0')
    h1 = F.tanh(h1_0 + h1_1)
    h2 = F.tanh(PF.affine(h1, 50, name='affine2'))
    y0 = PF.affine(h2, 10, name='affiney_0')
    y1 = PF.affine(h2, 10, name='affiney_1')
    return y0, y1

with nn.graph_def.graph(name='my_model') as g:
    x0 = nn.ProtoVariable((64, 100), name='x0')
    x1 = nn.ProtoVariable((64, 100), name='x1')
    y0, y1 = mlp_module(x0, x1)

executors = [{
    'name': 'runtime',
    'network': 'my_model',
    'data': ['x0', 'x1'],
    'output': {"y0": y0, 'y1': y1}
}]

nn.graph_def.save("mlp_net.nnp", [g], executors=executors)
```
