### PR TITLE
Allow to set the parameter file format

### DIFF
--- a/python/src/nnabla/utils/save.py
+++ b/python/src/nnabla/utils/save.py
@@ -360,7 +360,8 @@ def create_proto(contents, include_params=False, variable_batch_size=True, save_
     return proto
 
 
-def save(filename, contents, include_params=False, variable_batch_size=True, extension=".nnp", parameters=None, include_solver_state=False, solver_state_format='.h5'):
+def save(filename, contents, include_params=False, variable_batch_size=True, extension=".nnp", parameters=None,
+         parameter_format=".h5", include_solver_state=False, solver_state_format='.h5'):
     '''Save network definition, inference/training execution
     configurations etc.
 
@@ -381,6 +382,7 @@ def save(filename, contents, include_params=False, variable_batch_size=True, ext
             (more specifically ``-1``). The placeholder dimension will be
             filled during/after loading.
         extension: if files is file-like object, extension is one of ".nntxt", ".prototxt", ".protobuf", ".h5", ".nnp".
+        parameter_format: ".h5" or ".protobuf". Allow to choose which parameter file type.
         include_solver_state (bool): Indicate whether to save solver state or not. 
         solver_state_format (str):
             '.h5' or '.protobuf', default '.h5', indicate in which format will solver state be saved,
@@ -494,8 +496,10 @@ def save(filename, contents, include_params=False, variable_batch_size=True, ext
                 contents when include_solver_state is True')
         _format_opti_config_for_states_checkpoint(ctx, contents)
         file_savers = get_default_file_savers(
+            parameter_format=parameter_format,
             solver_state_format=solver_state_format)
     else:
-        file_savers = get_default_file_savers()
+        file_savers = get_default_file_savers(
+            parameter_format=parameter_format)
     save_files(ctx, file_savers, filename, ext)
     logger.info("Model file is saved as ({}): {}".format(ext, filename))

--- a/python/test/core/test_load.py
+++ b/python/test/core/test_load.py
@@ -615,7 +615,7 @@ def compare_info(ref_info, info):
 
 
 @pytest.mark.parametrize("nntxt_idx", CASE_INDEX)
-@pytest.mark.parametrize("parameter_format", ['.protobuf'])
+@pytest.mark.parametrize("parameter_format", ['.h5', '.protobuf'])
 @pytest.mark.parametrize("dataset_sample_num", [64])
 @pytest.mark.parametrize("batch_size", [16])
 @pytest.mark.parametrize("include_params", [False])
@@ -708,7 +708,7 @@ def test_load_and_save_equivalence(nntxt_idx, parameter_format, dataset_sample_n
                     }
 
                     save.save(saved_nnp_file, contents,
-                              include_params, variable_batch_size, include_solver_state=True)
+                              include_params, variable_batch_size, include_solver_state=True, parameter_format=parameter_format)
 
             new_config = TrainConfig()
             new_config.start_iteration = 0


### PR DESCRIPTION
The parameters in the nnp file are stored in h5 format by default.
This PR tends to add an option to allow include a .protobuf file in nnp file.

Here is the example:
```python
# These are stored by h5 format:
save('model.nnp', contents=contents)
save('model.nnp', contents=contents, parameter_format='.h5')

# This is stored by protobuf format:
save('model.nnp', contents=contents, parameter_format='.protobuf')
```
