### PR TITLE
Update nnabla cuda12.0 document

### DIFF
--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -32,8 +32,8 @@ You can also use another distribution (e.g. [Pyenv](https://github.com/pyenv/pye
 [Google Protocol Buffer](https://github.com/google/protobuf) compiler is also required to create NNabla's neural network format serializer/desrializer in Python or C++.
 
 ```shell
-curl -L https://github.com/google/protobuf/releases/download/v3.19.6/protoc-3.19.6-linux-x86_64.zip -o /tmp/protoc-3.19.6-linux-x86_64.zip
-sudo unzip -d /usr/local /tmp/protoc-3.19.6-linux-x86_64.zip && sudo chmod 755 /usr/local/bin/protoc
+curl -L https://github.com/google/protobuf/releases/download/v3.20.3/protoc-3.20.3-linux-x86_64.zip -o /tmp/protoc-3.20.3-linux-x86_64.zip
+sudo unzip -d /usr/local /tmp/protoc-3.20.3-linux-x86_64.zip && sudo chmod 755 /usr/local/bin/protoc
 ```
 
 ### Build and installation

--- a/doc/build/build_android.md
+++ b/doc/build/build_android.md
@@ -62,12 +62,12 @@ Following build dependencies needs to be installed by the user manually.
 Unlike [Python Package compilation](./build.md) which requires
 `protoc` compiler only, the NNabla C++ utility library requires
 protobuf C++ library too.  The following snippet running on your
-terminal will build and install protobuf-3.19.6 from source.
+terminal will build and install protobuf-3.20.3 from source.
 
 ```shell
-curl -L https://github.com/google/protobuf/archive/v3.19.6.tar.gz -o protobuf-v3.19.6.tar.gz
-tar xvf protobuf-v3.19.6.tar.gz
-cd protobuf-3.19.6
+curl -L https://github.com/google/protobuf/archive/v3.20.3.tar.gz -o protobuf-v3.20.3.tar.gz
+tar xvf protobuf-v3.20.3.tar.gz
+cd protobuf-3.20.3
 mkdir build build-android
 cd build
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF -DCMAKE_CXX_STANDARD=14 ../cmake

--- a/doc/build/build_cpp_utils.md
+++ b/doc/build/build_cpp_utils.md
@@ -34,12 +34,12 @@ Note: You can choose one of the following two installing methods.
 Unlike [Python Package compilation](./build.md) which requires
 `protoc` compiler only, the NNabla C++ utility library requires
 protobuf C++ library too.  The following snippet running on your
-terminal will build and install protobuf-3.1.0 from source.
+terminal will build and install protobuf-3.20.3 from source.
 
 ```shell
-curl -L https://github.com/google/protobuf/archive/v3.19.6.tar.gz -o protobuf-v3.19.6.tar.gz
-tar xvf protobuf-v3.19.6.tar.gz
-cd protobuf-3.19.6
+curl -L https://github.com/google/protobuf/archive/v3.20.3.tar.gz -o protobuf-v3.20.3.tar.gz
+tar xvf protobuf-v3.20.3.tar.gz
+cd protobuf-3.20.3
 mkdir build && cd build
 cmake -DCMAKE_POSITION_INDEPENDENT_CODE=ON -Dprotobuf_BUILD_TESTS=OFF ../cmake
 make

--- a/doc/python/pip_installation_cuda.rst
+++ b/doc/python/pip_installation_cuda.rst
@@ -23,6 +23,7 @@ Package name       CUDA version cuDNN version
 ================== ============ =====================
 nnabla-ext-cuda110 11.0.3       8.0(Linux & Win)
 nnabla-ext-cuda116 11.6.2       8.4(Linux & Win)
+nnabla-ext-cuda120 12.0.1       8.8(Linux & Win)
 ================== ============ =====================
 
 The latest CUDA version is always preferred if your GPU accepts.
@@ -92,6 +93,7 @@ Package name                        CUDA version cuDNN version
 =================================== ============ =============
 nnabla-ext-cuda110                  11.0.3       8.0
 nnabla-ext-cuda116                  11.6.2       8.4
+nnabla-ext-cuda120                  12.0.1       8.8
 =================================== ============ =============
 
 You can install as the following.
@@ -113,7 +115,7 @@ If you are using Ubuntu 20.04 and choose mpi4.0.3, you can install mpi with foll
 
   sudo apt install -y --no-install-recommends openmpi-bin libopenmpi-dev
 
-Otherwise, you must install a version openmpi by supported on ubuntu 20.04. (e.g. 3.1.6 or 4.1.3). In theory, all versions of openmpi are supported.
+Otherwise, you must install a version openmpi by supported on ubuntu 20.04. (e.g. 3.1.6 or 4.1.5). In theory, all versions of openmpi are supported.
 
 .. code-block:: bash
 


### PR DESCRIPTION
This PRs update the instruction document to reflect support for cuda 12.0 and the change in the version of protobuf to be used.
