### PR TITLE
fix build errors to upgrade cython

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -51,7 +51,7 @@ CALL %VENV%\Scripts\activate.bat
 CALL python -m pip install %PIP_INS_OPTS% --upgrade pip
 
 CALL pip install %PIP_INS_OPTS% ^
-           Cython~=0.29 ^
+           Cython ^
            boto3 ^
            h5py ^
            ipython ^

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-Cython~=0.29
+Cython
 boto3
 h5py
 imageio

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ import pathlib
 
 setup_requires = [
     'setuptools',
-    'Cython~=0.29',  # Requires python-dev.
+    'Cython',  # Requires python-dev.
 ]
 
 numpy_version = ""

--- a/python/setup.py
+++ b/python/setup.py
@@ -207,7 +207,8 @@ if __name__ == '__main__':
                             "embedsignature": True,
                             "language_level": "2",
                             "c_string_type": 'str',
-                            "c_string_encoding": "ascii"})
+                            "c_string_encoding": "ascii",
+                            "legacy_implicit_noexcept": True})
 
     ############################################################################
     # Package data

--- a/python/src/nnabla/_nd_array.pyx
+++ b/python/src/nnabla/_nd_array.pyx
@@ -54,7 +54,7 @@ cdef c_get_numpy_array(CNdArray * arrp, vector[np.npy_intp] & shape,
         shape.size(), shape.data(), type_num, < void*>(arr.get().const_pointer()))
     ndarray.flags.writeable = False
     pyarr = Array.create(arr)
-    ndarray.base = <PyObject * > pyarr
+    np.PyArray_SetBaseObject(ndarray, pyarr)
     Py_INCREF(pyarr)
     return ndarray
 
@@ -68,7 +68,7 @@ cdef c_cast_numpy_array(CNdArray * arrp, vector[np.npy_intp] & shape,
         shape.size(), shape.data(), type_num, arr.get().pointer())
     cdef shared_ptr[const CArray] carr = < shared_ptr[const CArray] > const_pointer_cast[ConstArray, CArray](arr)
     pyarr = Array.create(carr)
-    ndarray.base = <PyObject * > pyarr
+    np.PyArray_SetBaseObject(ndarray, pyarr)
     Py_INCREF(pyarr)
     return ndarray
 
@@ -496,6 +496,24 @@ cdef class NdArray:
 
     def __matmul__(x, y):
         return AOP.matmul(x, y)
+
+    def __radd__(y, x):
+        return AOP.add(x, y)
+
+    def __rsub__(y, x):
+        return AOP.sub(x, y)
+
+    def __rmul__(y, x):
+        return AOP.mul(x, y)
+
+    def __rtruediv__(y, x):
+        return AOP.truediv(x, y)
+
+    def __rdiv__(y, x):
+        return AOP.div(x, y)
+
+    def __rpow__(y, x, z):
+        return AOP.pow(x, y, z)
 
     def __iadd__(self, x):
         import nnabla.functions as F

--- a/python/src/nnabla/_variable.pyx
+++ b/python/src/nnabla/_variable.pyx
@@ -1193,6 +1193,24 @@ cdef class Variable:
     def __matmul__(x, y):
         return AOP.matmul(x, y)
 
+    def __radd__(y, x):
+        return AOP.add(x, y)
+
+    def __rsub__(y, x):
+        return AOP.sub(x, y)
+
+    def __rmul__(y, x):
+        return AOP.mul(x, y)
+
+    def __rtruediv__(y, x):
+        return AOP.truediv(x, y)
+
+    def __rdiv__(y, x):
+        return AOP.div(x, y)
+
+    def __rpow__(y, x, z):
+        return AOP.pow(x, y, z)
+
     def __getitem__(self, key):
         return IDX.getitem(self, key)
 


### PR DESCRIPTION
Due to Cython 3.0 updates, the behavior of arithmetic special methods are changed.
This change will cause the generated wheel runtime error.
