### PR TITLE
Skip test_grad_grad_resnet test when auto_foward is True

### DIFF
--- a/python/test/test_forward_all.py
+++ b/python/test/test_forward_all.py
@@ -84,10 +84,7 @@ def test_graph_logreg(seed):
 
 
 @pytest.mark.parametrize("seed", [311])
-# Skip model = 'recurrent'  temporarily since it cause
-# randomly crash when perform CI testing
-# @pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
-@pytest.mark.parametrize("model", ["mlp", "convolution"])
+@pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
 def test_graph_model(model, seed):
     np.random.seed(313)
     rng = np.random.RandomState(seed)

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -107,7 +107,10 @@ def test_grad_resnet(seed, ctx, auto_forward, flag_grad_outputs, act, inplace, s
 
 @pytest.mark.parametrize("seed", [311])
 @pytest.mark.parametrize("ctx", ctx_list)
-@pytest.mark.parametrize("auto_forward", [True, False])
+# Skip auto_forward = 'True' temporarily since it influences test_graph_model case
+# and causes randomly crash when perform CI testing
+# @pytest.mark.parametrize("auto_forward", [True, False])
+@pytest.mark.parametrize("auto_forward", [False])
 @pytest.mark.parametrize("inplace", [False, True])
 @pytest.mark.parametrize("shared", [False, True])
 def test_grad_grad_resnet(seed, ctx, auto_forward, inplace, shared):
@@ -115,9 +118,9 @@ def test_grad_grad_resnet(seed, ctx, auto_forward, inplace, shared):
     if backend == 'cuda':
         pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
 
-    if sys.version_info[1] >= 9 and auto_forward == True and shared == False:
-        pytest.skip(
-            "Skip to avoid random KeyError with _ModuleLock. Referred to nnabla-ext-cuda issue #481.")
+    #if sys.version_info[1] >= 9 and auto_forward == True and shared == False:
+    #    pytest.skip(
+    #        "Skip to avoid random KeyError with _ModuleLock. Referred to nnabla-ext-cuda issue #481.")
 
     nn.clear_parameters()
 

--- a/python/test/test_grad.py
+++ b/python/test/test_grad.py
@@ -118,9 +118,9 @@ def test_grad_grad_resnet(seed, ctx, auto_forward, inplace, shared):
     if backend == 'cuda':
         pytest.skip('CUDA Convolution N-D is only supported in CUDNN extension')
 
-    #if sys.version_info[1] >= 9 and auto_forward == True and shared == False:
-    #    pytest.skip(
-    #        "Skip to avoid random KeyError with _ModuleLock. Referred to nnabla-ext-cuda issue #481.")
+    if sys.version_info[1] >= 9 and auto_forward == True and shared == False:
+        pytest.skip(
+            "Skip to avoid random KeyError with _ModuleLock. Referred to nnabla-ext-cuda issue #481.")
 
     nn.clear_parameters()
 

--- a/python/test/test_graph.py
+++ b/python/test/test_graph.py
@@ -62,10 +62,7 @@ def test_graph_logreg(seed):
 
 
 @pytest.mark.parametrize("seed", [311])
-# Skip model = 'recurrent'  temporarily since it cause
-# randomly crash when perform CI testing
-# @pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
-@pytest.mark.parametrize("model", ["mlp", "convolution"])
+@pytest.mark.parametrize("model", ["mlp", "recurrent", "convolution"])
 def test_graph_model(model, seed):
     np.random.seed(313)
     rng = np.random.RandomState(seed)

--- a/python/test_requirements.txt
+++ b/python/test_requirements.txt
@@ -1,6 +1,6 @@
 ipython
 pytest
-pytest-xdist[psutil]
+pytest-xdist[psutil]~=3.3.1
 scipy
 librosa
 backports.lzma


### PR DESCRIPTION
[Previous temporal PR](https://github.com/sony/nnabla/pull/1237) still left some random errors.
According to the root cause investigated in the issue, we exclude the test case instead that auto_forward equals True.
Moreover, in this PR we also limit the version of pytest-xdist on Linux either, as we still found the previous random save_and_load test error in our Linux CI.