### PR TITLE
bugfix for optimizer state recovery

### DIFF
--- a/python/src/nnabla/utils/get_file_handle.py
+++ b/python/src/nnabla/utils/get_file_handle.py
@@ -262,7 +262,10 @@ def _opti_file_rough_loader(ctx, fileloaders, nnp, filename, ext):
     This loader loads solver state and allow user to decide when to restore it
     '''
     file_type = get_buf_type(filename)
-    optimizer_states = OrderedDict()
+    if hasattr(ctx, "optimizer_states_checkpoint"):
+        optimizer_states = ctx.optimizer_states_checkpoint
+    else:
+        optimizer_states = OrderedDict()
     if file_type == 'protobuf':
         opti_proto = nnabla_pb2.NNablaProtoBuf()
         with get_file_handle_load(nnp, filename, '.protobuf') as f:
@@ -275,7 +278,7 @@ def _opti_file_rough_loader(ctx, fileloaders, nnp, filename, ext):
         with nnp.open(filename, 'r') as f:
             h5fio.write(f.read())
             h5fio.seek(0)
-        optimizer_states[filename.split('_')[0]] = ('.h5', h5fio)
+        optimizer_states['_'.join(filename.split('_')[:-2])] = ('.h5', h5fio)
     ctx.optimizer_states_checkpoint = optimizer_states
 
 


### PR DESCRIPTION
When the nnp contains optimizer_states_checkpoint, there was an issue that fails to load nnp file.
This PR fixes this issue.

```log
File "nnabla\utils\load.py", line 636, in _link_optimizer
    restore_optimizer_state(optimizer)
File "nnabla\utils\load.py", line 496, in restore_optimizer_state
    optimizer.solver.set_states(
File "solver.pyx", line 198, in nnabla.solver.Solver.set_states
RuntimeError: value error in nbla::Solver::set_states
nnabla\src\nbla\solver.cpp:174
Failed `it != states_.end()`: Set weight parameter for Discriminator9/BatchNormalization/bn/gamma first.
```
