### PR TITLE
fix mlflow test random failure

### DIFF
--- a/python/test/test_autolog.py
+++ b/python/test/test_autolog.py
@@ -45,6 +45,7 @@ def prepare_dir():
 @pytest.mark.parametrize("interval_0, interval_1", [(1, 5), (2, 4), (4, 2), (3, 5)])
 def test_autolog(experiment, with_save_parameters, interval_0, interval_1, prepare_dir):
     path = tempfile.mkdtemp()
+    mlflow.set_tracking_uri(prefix_scheme + prepare_dir)
 
     # Create experiment
     assert mlflow.set_experiment(experiment)
@@ -66,7 +67,6 @@ def test_autolog(experiment, with_save_parameters, interval_0, interval_1, prepa
     assert mit
 
     # Main training loop
-    mlflow.set_tracking_uri(prefix_scheme + prepare_dir)
     with mlflow.start_run(experiment_id=experiment_id):
         for i in range(10):
             ms.add(i, i * 2)

--- a/python/test/test_mlflow_save_load_model.py
+++ b/python/test/test_mlflow_save_load_model.py
@@ -175,6 +175,7 @@ def model(data):
     test_work_path = tempfile.mkdtemp(prefix='tmp_save_load', dir=cwd)
     mlflow_workdir = os.path.join(test_work_path, "mlruns")
     os.chdir(test_work_path)
+    mlflow.set_tracking_uri(prefix_scheme + mlflow_workdir)
     assert mlflow.set_experiment("save_load_model")
 
     if not os.path.isdir(model_save_path):


### PR DESCRIPTION
This PR is aim to fix the random error(with high frequency) in test phase.

This error message shows that `mlflow.exceptions.MlflowException: Could not find experiment with ID xxxxxxxx`.
This is caused by another test case which also runs mlflow.
Thus in parallel test, the mlflow experiment id may change between different test cases.
This solution is to explicitly pass the experiment id each time when we run mlflow.
We also optimize the generation of temp directory for mlflow working path.