### PR TITLE
limit matplotlib version for windows

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -70,5 +70,5 @@ CALL pip install %PIP_INS_OPTS% ^
            virtualenv ^
            wheel ^
            mlflow ^
-           setuptools>60.0.0 ^
+           "setuptools>60.0.0" ^
            "matplotlib<3.9"

--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -70,4 +70,5 @@ CALL pip install %PIP_INS_OPTS% ^
            virtualenv ^
            wheel ^
            mlflow ^
-           setuptools>60.0.0
+           setuptools>60.0.0 ^
+           "matplotlib<3.9"


### PR DESCRIPTION
With matplotlib latest version, we met an error on Windows platform for python>3.8.

The error was caused here:
```log
>       plt.imshow(tile_images(digits.images[:64, None]), cmap='gray', interpolation='nearest')
(snip)
    @contextmanager
    def _restore_foreground_window_at_end():
>       foreground = _c_internal_utils.Win32_GetForegroundWindow()
E       ValueError: PyCapsule_New called with null pointer
```

This imshow is normal use, but the error was thrown by  `_c_internal_utils.Win32_GetForegroundWindow()` which is a Windows system function, so we think this might be a permission or system environment issue for matplotlib 3.9.
So currently, we decide to `limit matplotlib version to be lower than 3.9` for nnabla tests on Windows only.
The version on Linux will not be limited.