### PR TITLE
drop python3.8 and cuda11.0 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ pip install nnabla
 
 This installs the CPU version of Neural Network Libraries. GPU-acceleration can be added by installing the CUDA extension with following command.
 ```
-pip install nnabla-ext-cuda110
+pip install nnabla-ext-cuda116
 ```
-Above command is for version 11.0 CUDA Toolkit.
+Above command is for version 11.6 CUDA Toolkit.
 
 The other supported CUDA packages are listed [here](https://nnabla.readthedocs.io/en/latest/python/pip_installation_cuda.html#cuda-vs-cudnn-compatibility).
 

--- a/build-tools/msvc/build_cpplib.bat
+++ b/build-tools/msvc/build_cpplib.bat
@@ -17,7 +17,7 @@ REM
 REM 
 REM Usage:
 REM   build_cpplib.bat [PYTHON_VERSION] [VISUAL_STUDIO_EDITION]
-REM     (optional) PYTHON_VERSION: 3.8, 3.9 or 3.10
+REM     (optional) PYTHON_VERSION: 3.9 or 3.10
 REM     (optional) VISUAL_STUDIO_EDITION: 2015 or 2019(experimental)
 REM
 @ECHO ON
@@ -25,7 +25,7 @@ SETLOCAL
 
 REM Environment
 IF [%1] == [] (
-    CALL %~dp0tools\env.bat 3.8 %1 || GOTO :error
+    CALL %~dp0tools\env.bat 3.9 %1 || GOTO :error
 ) ELSE (
     CALL %~dp0tools\env.bat %1 %2 || GOTO :error
 )

--- a/build-tools/msvc/build_cpplib.bat
+++ b/build-tools/msvc/build_cpplib.bat
@@ -25,7 +25,7 @@ SETLOCAL
 
 REM Environment
 IF [%1] == [] (
-    CALL %~dp0tools\env.bat 3.9 %1 || GOTO :error
+    CALL %~dp0tools\env.bat 3.10 %1 || GOTO :error
 ) ELSE (
     CALL %~dp0tools\env.bat %1 %2 || GOTO :error
 )

--- a/build-tools/msvc/build_wheel.bat
+++ b/build-tools/msvc/build_wheel.bat
@@ -20,7 +20,7 @@ REM set build_type=Debug
 REM 
 REM Usage:
 REM   build_wheel.bat PYTHON_VERSION [VISUAL_STUDIO_ EDITION]
-REM                PYTHON_VERSION: 3.8, 3.9 or 3.10
+REM                PYTHON_VERSION: 3.9 or 3.10
 REM     (optional) VISUAL_STUDIO_ EDITION: 2015 or 2019(experimental)
 REM
 SETLOCAL

--- a/build-tools/msvc/test_nbla.bat
+++ b/build-tools/msvc/test_nbla.bat
@@ -18,7 +18,7 @@ REM limitations under the License.
 SETLOCAL
 
 REM Environment
-CALL %~dp0tools\env.bat 3.8 %1 || GOTO :error
+CALL %~dp0tools\env.bat 3.9 %1 || GOTO :error
 
 %nnabla_build_folder%\bin\Release\test_nbla_utils || GOTO :error
 

--- a/build-tools/msvc/test_nbla.bat
+++ b/build-tools/msvc/test_nbla.bat
@@ -18,7 +18,7 @@ REM limitations under the License.
 SETLOCAL
 
 REM Environment
-CALL %~dp0tools\env.bat 3.9 %1 || GOTO :error
+CALL %~dp0tools\env.bat 3.10 %1 || GOTO :error
 
 %nnabla_build_folder%\bin\Release\test_nbla_utils || GOTO :error
 

--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -16,7 +16,7 @@ REM limitations under the License.
 
 SET PYVER=%1
 IF [%PYVER%] == [] (
-   ECHO Please specify Python version 3.8, 3.9 or 3.10.
+   ECHO Please specify Python version 3.9 or 3.10.
    EXIT /b 255
 )
 FOR /F "TOKENS=1 DELIMS=." %%A IN ("%PYVER%") DO SET PYVER_MAJOR=%%A

--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -9,7 +9,7 @@ For build instructions for Windows and macOS, go to:
 
 ## Linux
 
-This document demonstrates how to build NNabla Python package from source on Ubuntu 20.04 LTS and Python 3.9. It also works for many other linux distributions by replacing the installation commands that use `apt` in this example by commands for a package manager on your system (e.g. `yum`).
+This document demonstrates how to build NNabla Python package from source on Ubuntu 20.04 LTS and Python 3.10. It also works for many other linux distributions by replacing the installation commands that use `apt` in this example by commands for a package manager on your system (e.g. `yum`).
 
 ### Setup
 
@@ -65,7 +65,7 @@ If you want to install nnabla for python 3.x, you may need to add `-DPYTHON_COMM
 So replace `cmake ../`. with
 
 ```shell
-cmake ../ -DPYTHON_COMMAND_NAME=python3.9  # if you use python 3.9
+cmake ../ -DPYTHON_COMMAND_NAME=python3.10  # if you use python 3.10
 ```
 
 Be careful if you have multiple python versions.

--- a/doc/build/build.md
+++ b/doc/build/build.md
@@ -9,7 +9,7 @@ For build instructions for Windows and macOS, go to:
 
 ## Linux
 
-This document demonstrates how to build NNabla Python package from source on Ubuntu 20.04 LTS and Python 3.8.10. It also works for many other linux distributions by replacing the installation commands that use `apt` in this example by commands for a package manager on your system (e.g. `yum`). 
+This document demonstrates how to build NNabla Python package from source on Ubuntu 20.04 LTS and Python 3.9. It also works for many other linux distributions by replacing the installation commands that use `apt` in this example by commands for a package manager on your system (e.g. `yum`).
 
 ### Setup
 
@@ -65,7 +65,7 @@ If you want to install nnabla for python 3.x, you may need to add `-DPYTHON_COMM
 So replace `cmake ../`. with
 
 ```shell
-cmake ../ -DPYTHON_COMMAND_NAME=python3.8  # if you use python 3.8
+cmake ../ -DPYTHON_COMMAND_NAME=python3.9  # if you use python 3.9
 ```
 
 Be careful if you have multiple python versions.

--- a/doc/build/build_cpp_utils.md
+++ b/doc/build/build_cpp_utils.md
@@ -3,7 +3,7 @@
 This document describes how to build and install C++ libraries,
 headers and executables that can be used for C++ standalone inference
 and training. The following instruction demonstrates the build
-procedure on Ubuntu 20.04 LTS and Python 3.9, but we successfully build C++ libraries on
+procedure on Ubuntu 20.04 LTS and Python 3.10, but we successfully build C++ libraries on
 macOS and Windows ([manual](./build_cpp_utils_windows.md)) too in a
 similar way (the differences lie in the installation of some
 dependencies). We may add build instructions on another platform in

--- a/doc/build/build_cpp_utils.md
+++ b/doc/build/build_cpp_utils.md
@@ -3,7 +3,7 @@
 This document describes how to build and install C++ libraries,
 headers and executables that can be used for C++ standalone inference
 and training. The following instruction demonstrates the build
-procedure on Ubuntu 20.04 LTS and Python 3.8.10, but we successfully build C++ libraries on
+procedure on Ubuntu 20.04 LTS and Python 3.9, but we successfully build C++ libraries on
 macOS and Windows ([manual](./build_cpp_utils_windows.md)) too in a
 similar way (the differences lie in the installation of some
 dependencies). We may add build instructions on another platform in

--- a/doc/build/build_windows.md
+++ b/doc/build/build_windows.md
@@ -13,9 +13,9 @@ Then, install required tools with following command.
 
 Note: Please make sure `Microsoft Visual Studio` is installed in the path of `C:\program files (x86)` and the path exists in `C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Auxiliary\Build\vcvars64.bat` and `C:\Program Files "("x86")"\Microsoft Visual Studio\2019\BuildTools\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`.
 
-Install python3.8.10 or 3.9.13 or 3.10.8. You can refer to the following command.
+Install python3.9.13 or 3.10.8. You can refer to the following command.
 ```bat
-    choco install -y python3 --version=3.8.10
+    choco install -y python3 --version=3.9.13
 ```
 
 We use chocolatey to make the configuration as easy as possible（recommended).
@@ -41,7 +41,7 @@ You can build windows binary with following command.
     build-tools\msvc\build_wheel.bat PYTHON_VERSION
 ```
 
-The PYTHON_VERSION we tested is 3.8 3.9 and 3.10.
+The PYTHON_VERSION we tested is 3.9 and 3.10.
 
 
 Then you can run test with following.

--- a/doc/build/build_windows.md
+++ b/doc/build/build_windows.md
@@ -15,7 +15,7 @@ Note: Please make sure `Microsoft Visual Studio` is installed in the path of `C:
 
 Install python3.9.13 or 3.10.8. You can refer to the following command.
 ```bat
-    choco install -y python3 --version=3.9.13
+    choco install -y python3 --version=3.10.8
 ```
 
 We use chocolatey to make the configuration as easy as possible（recommended).

--- a/doc/build/quick_build_tools.md
+++ b/doc/build/quick_build_tools.md
@@ -32,7 +32,7 @@ After this you can find executable file and shared library in `nnabla/build/lib/
 Prepare to specify python version.
 ```
 $ export PYTHON_VERSION_MAJOR=3
-$ export PYTHON_VERSION_MINOR=9
+$ export PYTHON_VERSION_MINOR=10
 ```
 
 Then you can get with,
@@ -42,7 +42,7 @@ $ make all
 
 Or you can specify every time.
 ```
-$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=9 all
+$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=10 all
 ```
 
 ## Windows

--- a/doc/build/quick_build_tools.md
+++ b/doc/build/quick_build_tools.md
@@ -32,7 +32,7 @@ After this you can find executable file and shared library in `nnabla/build/lib/
 Prepare to specify python version.
 ```
 $ export PYTHON_VERSION_MAJOR=3
-$ export PYTHON_VERSION_MINOR=8
+$ export PYTHON_VERSION_MINOR=9
 ```
 
 Then you can get with,
@@ -42,7 +42,7 @@ $ make all
 
 Or you can specify every time.
 ```
-$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=8 all
+$ make PYTHON_VERSION_MAJOR=3 PYTHON_VERSION_MINOR=9 all
 ```
 
 ## Windows
@@ -66,5 +66,5 @@ pip install pywin32 Cython boto3 protobuf h5py ipython numpy pip pytest scikit-i
 ```
 > call build-tools\msvc\build_wheel.bat PYTHON_VERSION
 ```
-The PYTHON_VERSION we tested is 3.8 3.9 and 3.10.
+The PYTHON_VERSION we tested is 3.9 and 3.10.
 

--- a/doc/contributing/add_function.md
+++ b/doc/contributing/add_function.md
@@ -263,7 +263,7 @@ After editing the above files with details of new function usage, compile the fi
 cd ${nnabla_root_directory}
 mkdir ${doc_dir_name}
 cd ${doc_dir_name}
-cmake -DPYTHON_VERSION=3.9 -DBUILD_CPP_LIB=ON -DBUILD_CPP_UTILS=OFF -DNNABLA_UTILS_STATIC_LINK_DEPS=ON -DBUILD_PYTHON_PACKAGE=ON ..
+cmake -DPYTHON_VERSION=3.10 -DBUILD_CPP_LIB=ON -DBUILD_CPP_UTILS=OFF -DNNABLA_UTILS_STATIC_LINK_DEPS=ON -DBUILD_PYTHON_PACKAGE=ON ..
 cd ..
 make -C ${doc_dir_name} all wheel doc
 ``` 

--- a/doc/contributing/add_function.md
+++ b/doc/contributing/add_function.md
@@ -263,7 +263,7 @@ After editing the above files with details of new function usage, compile the fi
 cd ${nnabla_root_directory}
 mkdir ${doc_dir_name}
 cd ${doc_dir_name}
-cmake -DPYTHON_VERSION=3.8 -DBUILD_CPP_LIB=ON -DBUILD_CPP_UTILS=OFF -DNNABLA_UTILS_STATIC_LINK_DEPS=ON -DBUILD_PYTHON_PACKAGE=ON ..
+cmake -DPYTHON_VERSION=3.9 -DBUILD_CPP_LIB=ON -DBUILD_CPP_UTILS=OFF -DNNABLA_UTILS_STATIC_LINK_DEPS=ON -DBUILD_PYTHON_PACKAGE=ON ..
 cd ..
 make -C ${doc_dir_name} all wheel doc
 ``` 

--- a/doc/python.rst
+++ b/doc/python.rst
@@ -1,7 +1,7 @@
 Python Package
 ==============
 
-The Python API built on top of our C++11 core maximizes the flexibility of the design of neural networks , and encourages fast prototyping and experimentation. NNabla works on Python>=3.8 (>=3.8 is recommended).
+The Python API built on top of our C++11 core maximizes the flexibility of the design of neural networks , and encourages fast prototyping and experimentation. NNabla works on Python>=3.9 (>=3.9 is recommended).
 
 .. toctree::
     :maxdepth: 1

--- a/doc/python/install_on_linux.rst
+++ b/doc/python/install_on_linux.rst
@@ -12,7 +12,7 @@ Prerequisites
 This installation instruction describes how to install NNabla using pip
 on almost any Linux 64-bit systems.
 
-The supported Python versions for provided binary packages are 3.8, 3.9, 3.10.
+The supported Python versions for provided binary packages are 3.9, 3.10.
 
 Python are installed by:
 

--- a/doc/python/install_on_windows.rst
+++ b/doc/python/install_on_windows.rst
@@ -15,7 +15,7 @@ The following software are required for installation:
 
 * Required software.
 
-  * Python>=3.8: PIP
+  * Python>=3.9: PIP
 
 * Recommended.
 

--- a/doc/python/pip_installation_cuda.rst
+++ b/doc/python/pip_installation_cuda.rst
@@ -21,7 +21,6 @@ CUDA vs cuDNN Compatibility
 ================== ============ =====================
 Package name       CUDA version cuDNN version
 ================== ============ =====================
-nnabla-ext-cuda110 11.0.3       8.0(Linux & Win)
 nnabla-ext-cuda116 11.6.2       8.4(Linux & Win)
 nnabla-ext-cuda120 12.0.1       8.8(Linux & Win)
 ================== ============ =====================
@@ -55,11 +54,11 @@ For example, if you think GeForce RTX 3070 and GeForce RTX 3090 are usable, you 
 Installation
 ------------
 
-The following is an example of installing the extension for CUDA 11.0.3
+The following is an example of installing the extension for CUDA 11.6.2
 
 .. code-block:: bash
 
-	pip install nnabla-ext-cuda110
+	pip install nnabla-ext-cuda116
 
 and check if all works.
 
@@ -81,7 +80,7 @@ and check if all works.
 Installation with Multi-GPU supported
 -------------------------------------
 
-Multi-GPU wheel package is only available on python3.8+.
+Multi-GPU wheel package is only available on python3.9+.
 
 .. _cuda-cudnn-compatibility-multi-gpu:
 
@@ -91,7 +90,6 @@ CUDA vs cuDNN Compatibility
 =================================== ============ =============
 Package name                        CUDA version cuDNN version
 =================================== ============ =============
-nnabla-ext-cuda110                  11.0.3       8.0
 nnabla-ext-cuda116                  11.6.2       8.4
 nnabla-ext-cuda120                  12.0.1       8.8
 =================================== ============ =============
@@ -101,7 +99,7 @@ You can install as the following.
 .. code-block:: bash
 
   pip install nnabla
-  pip install nnabla-ext-cuda110
+  pip install nnabla-ext-cuda116
 
 
 If you already installed NNabla, uninstall all of it, or start from a clean environment which you create using Anaconda, venv.
@@ -158,6 +156,6 @@ Following is a sample error message.
 .. code-block:: bash
 
   [nnabla][INFO]: Initializing CPU extension...
-  Please install CUDA version 11.0.3.
+  Please install CUDA version 11.6.2.
     and cuDNN version 8.0
     Or install correct nnabla-ext-cuda for installed version of CUDA/cuDNN.

--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -152,7 +152,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ARG PYTHON_VERSION_MAJOR=3
-ARG PYTHON_VERSION_MINOR=9
+ARG PYTHON_VERSION_MINOR=10
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 ADD python/setup_requirements.txt /tmp/deps/

--- a/docker/development/Dockerfile.build
+++ b/docker/development/Dockerfile.build
@@ -152,7 +152,7 @@ RUN mkdir /tmp/deps \
     && rm -rf /tmp/*
 
 ARG PYTHON_VERSION_MAJOR=3
-ARG PYTHON_VERSION_MINOR=8
+ARG PYTHON_VERSION_MINOR=9
 ENV PYVERNAME=${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}
 
 ADD python/setup_requirements.txt /tmp/deps/

--- a/python/setup.py
+++ b/python/setup.py
@@ -142,7 +142,6 @@ if __name__ == '__main__':
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: C++',
             'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: Implementation :: CPython',

--- a/python/src/nnabla/utils/converter/setup.py.tmpl
+++ b/python/src/nnabla/utils/converter/setup.py.tmpl
@@ -95,7 +95,6 @@ if __name__ == '__main__':
             'Topic :: Scientific/Engineering',
             'Topic :: Scientific/Engineering :: Artificial Intelligence',
             'License :: OSI Approved :: Apache Software License',
-            'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10'
         ],


### PR DESCRIPTION
Python3.8 would be EOL in this October, and many environments now supports real cuda11 and cuda12, so we have decided to end support for python 3.8 and cuda11.0.