### PR TITLE
Limit cython version less than 3.0.11

### DIFF
--- a/build-tools/msvc/tools/python_env.bat
+++ b/build-tools/msvc/tools/python_env.bat
@@ -51,7 +51,7 @@ CALL %VENV%\Scripts\activate.bat
 CALL python -m pip install %PIP_INS_OPTS% --upgrade pip
 
 CALL pip install %PIP_INS_OPTS% ^
-           Cython ^
+           "Cython<3.0.11" ^
            boto3 ^
            h5py ^
            ipython ^

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
-Cython
+Cython<3.0.11
 boto3
 h5py
 imageio

--- a/python/setup.py
+++ b/python/setup.py
@@ -26,7 +26,7 @@ import pathlib
 
 setup_requires = [
     'setuptools',
-    'Cython',  # Requires python-dev.
+    'Cython<3.0.11',  # Requires python-dev.
 ]
 
 numpy_version = ""


### PR DESCRIPTION
Cython 3.0.11 causes build break, so we limit the cython version temporary.
