### PR TITLE
replace numpy deprecated api calls

### DIFF
--- a/python/test/function/test_transpose.py
+++ b/python/test/function/test_transpose.py
@@ -42,7 +42,7 @@ def ref_transpose(x, axes):
 def test_transpose_forward_backward(seed, inshape, axes, ctx, func_name):
     from nbla_test_utils import function_tester
     rng = np.random.RandomState(seed)
-    if np.product(inshape) > 1000000:
+    if np.prod(inshape) > 1000000:
         with nn.context_scope(ctx):
             x = nn.Variable(inshape)
             y = F.transpose(x, axes)

--- a/python/test/function/test_unique.py
+++ b/python/test/function/test_unique.py
@@ -32,6 +32,8 @@ def ref_unique(x, flatten, axis, sorted, with_index, with_inverse, with_counts):
     if flatten:
         axis = None
     y, indices, inverse_indices, counts = np.unique(x, True, True, True, axis)
+    inverse_indices = inverse_indices.flatten() \
+        if isinstance(inverse_indices, np.ndarray) else inverse_indices
 
     if not sorted:
         argsort_indices = np.argsort(indices)


### PR DESCRIPTION
nnabla has some code that is still calling numpy deprecated APIs. And some of these APIs are removed in numpy v2.1.x which released in Sep 3.

- numpy.product(...) -> numpy.prod(...)
- make sure input parameter of numpy.asarray(...) is hashable
