### PR TITLE
add necessary dll files in release package

### DIFF
--- a/build-tools/msvc/tools/get_liblz4.bat
+++ b/build-tools/msvc/tools/get_liblz4.bat
@@ -26,6 +26,11 @@ cmake -E tar xvzf ..\%LZ4_PACKAGE%.zip || GOTO :error
 MOVE dll\msys-lz4-1.dll %VENV%\Scripts\liblz4.dll
 CD ..
 
+SET REQDLLS_DIR=%nnabla_root%\third_party\required_dlls
+IF NOT EXIST %REQDLLS_DIR% MD %REQDLLS_DIR%
+ECHO  COPY %VENV%\Scripts\liblz4.dll %REQDLLS_DIR%\liblz4.dll
+COPY %VENV%\Scripts\liblz4.dll %REQDLLS_DIR%\liblz4.dll
+
 DEL %LZ4_PACKAGE%.zip
 RMDIR /s /q %LZ4_PACKAGE%
 

--- a/build-tools/msvc/tools/get_libzstd.bat
+++ b/build-tools/msvc/tools/get_libzstd.bat
@@ -26,6 +26,11 @@ cmake -E tar xvzf ..\%ZSTD_PACKAGE%.zip || GOTO :error
 MOVE dll\libzstd.dll %VENV%\Scripts\zstd.dll
 CD ..
 
+SET REQDLLS_DIR=%nnabla_root%\third_party\required_dlls
+IF NOT EXIST %REQDLLS_DIR% MD %REQDLLS_DIR%
+ECHO  COPY %VENV%\Scripts\zstd.dll %REQDLLS_DIR%\zstd.dll
+COPY %VENV%\Scripts\zstd.dll %REQDLLS_DIR%\zstd.dll
+
 DEL %ZSTD_PACKAGE%.zip
 RMDIR /s /q %ZSTD_PACKAGE%
 

--- a/src/nbla/CMakeLists.txt
+++ b/src/nbla/CMakeLists.txt
@@ -53,6 +53,23 @@ install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/nbla DESTINATION include)
 install(FILES ${PROJECT_SOURCE_DIR}/LICENSE ${PROJECT_SOURCE_DIR}/NOTICE.md
   DESTINATION doc)
 install(FILES ${PROJECT_SOURCE_DIR}/third_party/LICENSES.md DESTINATION doc/third_party)
+
+file(GLOB_RECURSE DLLFILES
+  "${PROJECT_SOURCE_DIR}/third_party/zlib*/*/*.dll"
+  "${PROJECT_SOURCE_DIR}/third_party/libarchive-*/build-folder/*/*/*.dll"
+  "${PROJECT_SOURCE_DIR}/third_party/required_dlls/*.dll"
+  )
+file(GLOB_RECURSE LIBFILES
+  "${PROJECT_SOURCE_DIR}/third_party/zlib*/*/*.lib"
+  "${PROJECT_SOURCE_DIR}/third_party/libarchive-*/build-folder/*/*/*.lib")
+file(GLOB_RECURSE ARCHIVE_HEADERS
+  "${PROJECT_SOURCE_DIR}/third_party/libarchive-*/archive.h"
+  "${PROJECT_SOURCE_DIR}/third_party/libarchive-*/archive_entry.h")
+file(GLOB_RECURSE ZLIB_HEADERS
+  "${PROJECT_SOURCE_DIR}/third_party/zlib*/*.h")
+install(FILES ${DLLFILES} DESTINATION bin)
+install(FILES ${LIBFILES} DESTINATION lib)
+install(FILES ${ARCHIVE_HEADERS} ${ZLIB_HEADERS} DESTINATION include)
 include(CPack)
 
 set(NBLA_LIBRARY_NAME ${LIB_NAME} PARENT_SCOPE)


### PR DESCRIPTION
In the previous release, there were not included some dlls and header files.
So, developer cannot run the software that is built by themselves.

This PR adds necessary dlls into release package.
So, the developers are able to compile and link their software with all necessary libraries.
The packages will be uploaded in https://nnabla.org/install/#cpplib_list
